### PR TITLE
Switch to PyPi lightkube-models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ kubernetes
 pyaml
 requests
 lightkube >= 0.8.1
-git+git://github.com/balbirthomas/lightkube-models@pip-installer
+lightkube-models >= 1.22.0.4


### PR DESCRIPTION
A previous commit used a fork of the lightkube-models git repository
because lightkube-models did not provide a PyPi source distribution
required by charmcraft and upstream lightkube-models git repository
setup.py did not correctly build or install it (upstream uses
a release.sh script to do so). Upstream has now released a PyPi
source distribution so this commit ensures that the official
PyPi package is used henceforth.