### PR TITLE
add support for injecting label-matchers at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ __pycache__
 build
 venv
 .idea
+.vscode
 tests/integration/prometheus-tester/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+promql-transform
+promql-transform*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,29 @@ $ charmcraft pack
 
 ### Deploy
 
+There are two ways of deploying the prometheus-k8s operator, with and without 
+promql-transform.  Deploying the charm without PromQL Transform means you won't 
+get any Juju topology labels  injected into your alert rule expressions.
+
+#### Without PromQL Transform
+
 ```bash
-$ juju deploy ./prometheus-k8s_ubuntu-20.04-amd64.charm --resource prometheus-image=ubuntu/prometheus:latest
+$ juju deploy \
+    ./prometheus-k8s_ubuntu-20.04-amd64.charm \
+    --resource prometheus-image=ubuntu/prometheus:latest
+```
+
+#### With PromQL Transform
+
+Place the binary of your selected promql-transform version in the root of the prometheus-k8s
+charm directory. Official binaries are available from the 
+[promql-transform repository](https://github.com/canonical/promql-transform).
+
+```bash
+$ juju deploy \
+    ./prometheus-k8s_ubuntu-20.04-amd64.charm \
+    --resource prometheus-image=ubuntu/prometheus:latest
+    --resource promql-transform-amd64=./promql-transform
 ```
 
 ## Linting

--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -14,13 +14,15 @@ import json
 import logging
 import os
 from collections import OrderedDict
+import platform
+import subprocess
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 import yaml
 from ops.charm import CharmBase, HookEvent, RelationEvent, RelationMeta, RelationRole
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
-from ops.model import Relation
+from ops.model import ModelError, Relation
 
 # The unique Charmhub library identifier, never change it
 LIBID = "f783823fa75f4b7880eb70f2077ec259"
@@ -900,6 +902,7 @@ class PrometheusRemoteWriteProvider(Object):
 
         super().__init__(charm, relation_name)
         self._charm = charm
+        self._transformer = PromqlTransformer(self._charm)
         self._relation_name = relation_name
         self._endpoint_schema = endpoint_schema
         self._endpoint_address = endpoint_address
@@ -1010,7 +1013,7 @@ class PrometheusRemoteWriteProvider(Object):
             try:
                 scrape_metadata = json.loads(relation.data[relation.app]["scrape_metadata"])
                 identifier = ProviderTopology.from_relation_data(scrape_metadata).identifier
-                alerts[identifier] = alert_rules
+                alerts[identifier] = self._transformer.apply_label_matchers(alert_rules)
             except KeyError as e:
                 logger.warning(
                     "Relation %s has no 'scrape_metadata': %s",
@@ -1035,3 +1038,88 @@ class PrometheusRemoteWriteProvider(Object):
                         logger.error("Alert rules were found but no usable labels were present")
 
         return alerts
+
+
+# Copy/pasted from prometheus_scrape.py
+class PromqlTransformer:
+    """Uses promql-transform to inject label matchers into alert rule expressions."""
+
+    _path = None
+    _disabled = False
+
+    @property
+    def path(self):
+        """Lazy lookup of the path of promql-transform."""
+        if self._disabled:
+            return None
+        if not self._path:
+            self._path = self._get_transformer_path()
+            if not self._path:
+                logger.debug("Skipping injection of juju topology as label matchers")
+                self._disabled = True
+        return self._path
+
+    def __init__(self, charm):
+        self._charm = charm
+
+    def apply_label_matchers(self, rules):
+        """Will apply label matchers to the expression of all alerts in all supplied groups."""
+        if not self.path:
+            return rules
+        for group in rules["groups"]:
+            rules_in_group = group.get("rules", [])
+            for rule in rules_in_group:
+                topology = {}
+                # if the user for some reason has provided juju_unit, we'll need to honor it
+                # in most cases, however, this will be empty
+                for label in [
+                    "juju_model",
+                    "juju_model_uuid",
+                    "juju_application",
+                    "juju_charm",
+                    "juju_unit",
+                ]:
+                    if label in rule["labels"]:
+                        topology[label] = rule["labels"][label]
+                rule["expr"] = self._apply_label_matcher(rule["expr"], topology)
+        return rules
+
+    def _apply_label_matcher(self, expression, topology):
+        if not topology:
+            return expression
+        if not self.path:
+            logger.debug(
+                "`promql-transform` unavailable. leaving expression unchanged: %s", expression
+            )
+            return expression
+        args = [str(self.path)]
+        args.extend(
+            ['--label-matcher={}="{}"'.format(key, value) for key, value in topology.items()]
+        )
+
+        args.extend(["{}".format(expression)])
+        # noinspection PyBroadException
+        try:
+            return self._exec(args)
+        except Exception as e:
+            logger.debug('Applying the expression failed: "{}", falling back to the original', e)
+            return expression
+
+    def _get_transformer_path(self) -> Optional[Path]:
+        arch = platform.processor()
+        arch = "amd64" if arch == "x86_64" else arch
+        res = "promql-transform-{}".format(arch)
+        try:
+            path = self._charm.model.resources.fetch(res)
+            os.chmod(path, 0o777)
+            return path
+        except NotImplementedError:
+            logger.debug("System lacks support for chmod")
+        except (NameError, ModelError):
+            logger.debug('No resource available for the platform "{}"'.format(arch))
+        return None
+
+    def _exec(self, cmd):
+        result = subprocess.run(cmd, check=False, stdout=subprocess.PIPE)
+        output = result.stdout.decode("utf-8").strip()
+        return output

--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -13,9 +13,9 @@ should use the `PrometheusRemoteWriteProducer`.
 import json
 import logging
 import os
-from collections import OrderedDict
 import platform
 import subprocess
+from collections import OrderedDict
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -1011,19 +1011,9 @@ class PrometheusRemoteWriteProvider(Object):
                 continue
 
             try:
-<<<<<<< HEAD
                 scrape_metadata = json.loads(relation.data[relation.app]["scrape_metadata"])
                 identifier = ProviderTopology.from_relation_data(scrape_metadata).identifier
                 alerts[identifier] = self._transformer.apply_label_matchers(alert_rules)
-=======
-                # as this might very well contain multiple groups from different origins,
-                # and as such, with different topologies, we need to flatten the groups
-                # structure to be able to distinguish between what came from where.
-                for group in alert_rules["groups"]:
-                    alerts[group["name"]] = self._transformer.apply_label_matchers(
-                        {"groups": [group]}
-                    )
->>>>>>> da885dd (fix spurious quoting and update contributing.md)
             except KeyError as e:
                 logger.warning(
                     "Relation %s has no 'scrape_metadata': %s",

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -2112,6 +2112,7 @@ class PromqlTransformer:
                 ]:
                     if label in rule["labels"]:
                         topology[label] = rule["labels"][label]
+
                 rule["expr"] = self._apply_label_matcher(rule["expr"], topology)
         return rules
 
@@ -2125,7 +2126,7 @@ class PromqlTransformer:
             return expression
         args = [str(self.path)]
         args.extend(
-            ['--label-matcher={}="{}"'.format(key, value) for key, value in topology.items()]
+            ['--label-matcher {}="{}"'.format(key, value) for key, value in topology.items()]
         )
 
         args.extend(["{}".format(expression)])
@@ -2134,6 +2135,8 @@ class PromqlTransformer:
             return self._exec(args)
         except Exception as e:
             logger.debug('Applying the expression failed: "{}", falling back to the original', e)
+            raise e
+
             return expression
 
     def _get_transformer_path(self) -> Optional[Path]:
@@ -2151,6 +2154,6 @@ class PromqlTransformer:
         return None
 
     def _exec(self, cmd):
-        result = subprocess.run(cmd, check=False, stdout=subprocess.PIPE)
+        result = subprocess.run(" ".join(cmd), check=False, stdout=subprocess.PIPE, shell=True)
         output = result.stdout.decode("utf-8").strip()
         return output

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -47,12 +47,18 @@ resources:
     description: Container image for Prometheus
     upstream-source: docker.io/ubuntu/prometheus@sha256:03936a740851b8786c328e08803a70feaa97731714a8dbe4b709c44366699b0c
   promql-transform-amd64:
+    # When picking which version to use with the charm, use the latest one from
+    # https://github.com/canonical/promql-transform that has the same version number
+    # as the Prometheus shipped within the `prometheus-image` resource.
     type: file
     description: |
       Promql-transform binary for adding label selectors on amd64. Promql-transform is available
       as a stand-alone tool on https://github.com/canonical/promql-transform
     filename: promql-transform-amd64
   promql-transform-arm64:
+    # When picking which version to use with the charm, use the latest one from
+    # https://github.com/canonical/promql-transform that has the same version number
+    # as the Prometheus shipped within the `prometheus-image` resource.
     type: file
     description: |
       Promql-transform binary for adding label selectors on arm64. Promql-transform is available

--- a/tests/unit/prometheus_alert_rules/cpu_overuse.rule
+++ b/tests/unit/prometheus_alert_rules/cpu_overuse.rule
@@ -1,5 +1,5 @@
 alert: CPUOverUse
-expr: process_cpu_seconds_total{%%juju_topology%%} > 0.12
+expr: process_cpu_seconds_total > 0.12
 for: 0m
 labels:
   severity: Low

--- a/tests/unit/prometheus_alert_rules/cpu_overuse_no_labels.rule
+++ b/tests/unit/prometheus_alert_rules/cpu_overuse_no_labels.rule
@@ -1,5 +1,5 @@
 alert: CPUOverUse_no_labels
-expr: process_cpu_seconds_total{%%juju_topology%%} > 0.12
+expr: process_cpu_seconds_total > 0.12
 for: 0m
 annotations:
   summary: "Instance {{ $labels.instance }} CPU over use"

--- a/tests/unit/prometheus_alert_rules/target_missing.rule
+++ b/tests/unit/prometheus_alert_rules/target_missing.rule
@@ -1,5 +1,5 @@
 alert: PrometheusTargetMissing
-expr: up{%%juju_topology%%} == 0
+expr: up == 0
 for: 0m
 labels:
   severity: critical

--- a/tests/unit/prometheus_alert_rules/with_template_string.rule
+++ b/tests/unit/prometheus_alert_rules/with_template_string.rule
@@ -1,0 +1,8 @@
+alert: PrometheusTargetMissing
+expr: up{%%juju_topology%%} == 0
+for: 0m
+labels:
+  severity: critical
+annotations:
+  summary: Prometheus target missing (instance {{ $labels.instance }})
+  description: "A Prometheus target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -57,6 +57,8 @@ SCRAPE_JOBS = [
         ],
     },
 ]
+
+
 ALERT_RULES = {
     "groups": [
         {
@@ -64,9 +66,7 @@ ALERT_RULES = {
             "rules": [
                 {
                     "alert": "CPUOverUse",
-                    "expr": 'process_cpu_seconds_total{juju_model="None",'
-                    'juju_model_uuid="f2c1b2a6-e006-11eb-ba80-0242ac130004",'
-                    'juju_application="consumer-tester"} > 0.12',
+                    "expr": "process_cpu_seconds_total > 0.12",
                     "for": "0m",
                     "labels": {
                         "severity": "Low",
@@ -82,9 +82,7 @@ ALERT_RULES = {
                 },
                 {
                     "alert": "PrometheusTargetMissing",
-                    "expr": 'up{juju_model="None",'
-                    'juju_model_uuid="f2c1b2a6-e006-11eb-ba80-0242ac130004",'
-                    'juju_application="consumer-tester"} == 0',
+                    "expr": "up == 0",
                     "for": "0m",
                     "labels": {
                         "severity": "critical",
@@ -138,6 +136,11 @@ class TestEndpointConsumer(unittest.TestCase):
     def setUp(self):
         metadata_file = open("metadata.yaml")
         self.harness = Harness(EndpointConsumerCharm, meta=metadata_file)
+
+        self.harness.add_resource(
+            "promql-transform-amd64",
+            open("./promql-transform", "rb").read(),
+        )
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
@@ -386,7 +389,10 @@ class TestEndpointConsumer(unittest.TestCase):
 
         rules_file = self.harness.charm.prometheus_consumer.alerts()
         alerts = list(rules_file.values())[0]
-        self.assertEqual(ALERT_RULES, alerts)
+
+        alert_names = [x["alert"] for x in alerts["groups"][0]["rules"]]
+
+        self.assertEqual(alert_names, ["CPUOverUse", "PrometheusTargetMissing"])
 
     def test_consumer_logs_an_error_on_missing_alerting_data(self):
         self.assertEqual(self.harness.charm._stored.num_events, 0)

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -212,7 +212,7 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertIn("alert_rules", data)
         alerts = json.loads(data["alert_rules"])
         self.assertIn("groups", alerts)
-        self.assertEqual(len(alerts["groups"]), 4)
+        self.assertEqual(len(alerts["groups"]), 5)
         group = alerts["groups"][0]
         for rule in group["rules"]:
             self.assertIn("labels", rule)
@@ -230,7 +230,7 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertIn("alert_rules", data)
         alerts = json.loads(data["alert_rules"])
         self.assertIn("groups", alerts)
-        self.assertEqual(len(alerts["groups"]), 4)
+        self.assertEqual(len(alerts["groups"]), 5)
         group = alerts["groups"][0]
         for rule in group["rules"]:
             self.assertIn("expr", rule)

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -26,6 +26,10 @@ name: consumer-tester
 requires:
   {RELATION_NAME}:
     interface: {RELATION_INTERFACE}
+resources:
+    promql-transform-amd64:
+        type: file
+        filename: promql-transform-amd64
 """
 
 
@@ -97,6 +101,10 @@ class RemoteWriteConsumerCharm(CharmBase):
 class TestRemoteWriteConsumer(unittest.TestCase):
     def setUp(self):
         self.harness = Harness(RemoteWriteConsumerCharm, meta=METADATA)
+        self.harness.add_resource(
+            "promql-transform-amd64",
+            open("./promql-transform", "rb").read(),
+        )
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(True)
         self.harness.begin_with_initial_hooks()

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -1,0 +1,121 @@
+# Copyright 2020 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import subprocess
+import unittest
+from pathlib import PosixPath
+
+from charms.prometheus_k8s.v0.prometheus_scrape import PromqlTransformer
+from ops.charm import CharmBase
+from ops.testing import Harness
+
+META = """
+resources:
+  promql-transform-amd64:
+    type: file
+    description: test
+"""
+
+
+# noqa: E302
+# pylint: disable=too-few-public-methods
+class TransformProviderCharm(CharmBase):
+    """Container charm for running the integration test."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.transformer = PromqlTransformer(self)
+
+
+class TestTransform(unittest.TestCase):
+    """Test that the promql-transform implementation works."""
+
+    def setUp(self):
+        self.harness = Harness(TransformProviderCharm, meta=META)
+        self.harness.set_model_name("transform")
+        self.addCleanup(self.harness.cleanup)
+        self.harness.add_resource("promql-transform-amd64", "dummy resource")
+        self.harness.begin()
+
+    # pylint: disable=protected-access
+    @unittest.mock.patch("platform.processor", lambda: "teakettle")
+    def test_disable_on_invalid_arch(self):
+        transform = self.harness.charm.transformer
+        self.assertIsNone(transform.path)
+        self.assertTrue(transform._disabled)
+
+    # pylint: disable=protected-access
+    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    def test_gives_path_on_valid_arch(self):
+        """When given a valid arch, it should return the resource path."""
+        transformer = self.harness.charm.transformer
+        self.assertIsInstance(transformer.path, PosixPath)
+
+    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    def test_setup_transformer(self):
+        """When setup it should know the path to the binary."""
+        transform = self.harness.charm.transformer
+
+        self.assertIsInstance(transform.path, PosixPath)
+
+        p = str(transform.path)
+        self.assertTrue(p.startswith("/") and p.endswith("promql-transform-amd64"))
+
+    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    @unittest.mock.patch("subprocess.run")
+    def test_returns_original_expression_when_subprocess_call_errors(self, mocked_run):
+        mocked_run.side_effect = subprocess.CalledProcessError(
+            returncode=10, cmd="promql-transform", stderr=""
+        )
+
+        transform = self.harness.charm.transformer
+        output = transform.apply_label_matchers(
+            {
+                "groups": [
+                    {
+                        "alert": "CPUOverUse",
+                        "expr": "process_cpu_seconds_total > 0.12",
+                        "for": "0m",
+                        "labels": {
+                            "severity": "Low",
+                            "juju_model": "None",
+                            "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                            "juju_application": "consumer-tester",
+                        },
+                        "annotations": {
+                            "summary": "Instance {{ $labels.instance }} CPU over use",
+                            "description": "{{ $labels.instance }} of job "
+                            "{{ $labels.job }} has used too much CPU.",
+                        },
+                    }
+                ]
+            }
+        )
+        self.assertEqual(output["groups"][0]["expr"], "process_cpu_seconds_total > 0.12")
+
+    @unittest.mock.patch("platform.processor", lambda: "invalid")
+    def test_uses_original_expression_when_resource_missing(self):
+        transform = self.harness.charm.transformer
+        output = transform.apply_label_matchers(
+            {
+                "groups": [
+                    {
+                        "alert": "CPUOverUse",
+                        "expr": "process_cpu_seconds_total > 0.12",
+                        "for": "0m",
+                        "labels": {
+                            "severity": "Low",
+                            "juju_model": "None",
+                            "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                            "juju_application": "consumer-tester",
+                        },
+                        "annotations": {
+                            "summary": "Instance {{ $labels.instance }} CPU over use",
+                            "description": "{{ $labels.instance }} of job "
+                            "{{ $labels.job }} has used too much CPU.",
+                        },
+                    }
+                ]
+            }
+        )
+        self.assertEqual(output["groups"][0]["expr"], "process_cpu_seconds_total > 0.12")

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -119,3 +119,12 @@ class TestTransform(unittest.TestCase):
             }
         )
         self.assertEqual(output["groups"][0]["expr"], "process_cpu_seconds_total > 0.12")
+
+    def test_fetches_the_correct_expression(self):
+        self.harness.add_resource(
+            "promql-transform-amd64",
+            open("./promql-transform", "rb").read(),
+        )
+        transform = self.harness.charm.transformer
+        output = transform._apply_label_matcher("up", {"juju_model": "some_juju_model"})
+        assert output == 'up{juju_model="some_juju_model"}'

--- a/tox.ini
+++ b/tox.ini
@@ -85,23 +85,28 @@ deps =
     -r{toxinidir}/requirements.txt
     deepdiff
 commands =
+    sh -c 'stat promql-transform > /dev/null 2>&1 || curl "https://github.com/canonical/promql-transform/releases/download/2.25.2-1rc1/promql-transform_2.25.2-1rc1_linux_amd64.tar.gz" -L -s | tar zxv promql-transform'
     coverage run \
       --source={[vars]src_path},{[vars]lib_path} \
       -m pytest -v --tb native -s {posargs} {[vars]tst_path}/unit
     coverage report
+allowlist_externals =
+    sh
 
 [testenv:integration]
 description = Run integration tests
 deps =
     aiohttp
     git+https://github.com/juju/python-libjuju.git
-    #juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     prometheus-api-client
     tenacity
 commands =
+    sh -c 'stat promql-transform > /dev/null 2>&1 || curl "https://github.com/canonical/promql-transform/releases/download/2.25.2-1rc1/promql-transform_2.25.2-1rc1_linux_amd64.tar.gz" -L -s | tar zxv promql-transform'
     pytest -v --tb native --log-cli-level=INFO --color=yes -s {posargs} {toxinidir}/tests/integration
+allowlist_externals =
+    sh
 
 [testenv:integration-lma]
 description = Run lma bundle integration tests but with prometheus built from source
@@ -110,7 +115,6 @@ deps =
     # deps from lma-bundle - these are needed here because will be running pytest on lma-bundle
     jinja2
     git+https://github.com/juju/python-libjuju.git
-    #juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 allowlist_externals =


### PR DESCRIPTION
This PR adds support for injecting label-matchers to promql expressions at runtime. Currently, this is implemented for alert rules, which are injected with the juju topology, replacing the previous relabeling mechanics of jinja with actual promql parsing and validation.

There are a couple of issues with the current promql-transform binary which are tracked in that repo:

- https://github.com/canonical/promql-transform/issues/1
- https://github.com/canonical/promql-transform/issues/2

Still left todo:
- [x] https://github.com/canonical/prometheus-k8s-operator/pull/166#pullrequestreview-866903808