### PR TITLE
Refactor JujuTopology and fix `scrape_metadata`

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -665,7 +665,7 @@ class ProviderTopology(JujuTopology):
         # This is used only by Metrics[Consumer|Provider] and does not need a
         # unit name, so only check for the charm name
         return "juju_{}_prometheus_scrape".format(
-            "_".join([self.model, self.model_uuid[:7], self.application, self.charm_name])
+                "_".join([self.model, self.model_uuid[:7], self.application, self.charm_name]) # type: ignore
         )
 
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1062,11 +1062,20 @@ class MetricsEndpointConsumer(Object):
                 identifier = ProviderTopology.from_relation_data(scrape_metadata).identifier
                 alerts[identifier] = alert_rules
             except KeyError as e:
-                logger.error(
+                logger.warning(
                     "Relation %s has no 'scrape_metadata': %s",
                     relation.id,
                     e,
                 )
+
+                # Construct an ID based on what's in the alert rules
+                labels = next(alert_rules["groups"])["labels"]
+                identifier = "{}_{}_{}".format(
+                    labels["juju_model"],
+                    labels["juju_model_uuid"],
+                    labels["juju_application"]
+                )
+                alerts[identifier] = alert_rules
 
         return alerts
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -574,10 +574,13 @@ class JujuTopology:
     def promql_labels(self) -> str:
         """Format the topology information into a verbose string."""
         return ", ".join(
-            ['juju_{}="{}"'.format(key, value) for key, value in self.as_dict().items()]
+            [
+                'juju_{}="{}"'.format(key, value)
+                for key, value in self.as_dict(replace={"charm_name": "charm"}).items()
+            ]
         )
 
-    def as_dict(self) -> dict:
+    def as_dict(self, replace: Dict[str, str] = dict()) -> dict:
         """Format the topology information into a dict."""
         ret = {
             "model": self.model,
@@ -589,14 +592,18 @@ class JujuTopology:
 
         ret["unit"] or ret.pop("unit")
         ret["charm_name"] or ret.pop("charm_name")
+
+        for drop, to in replace.items():
+            if drop in ret:
+                ret[to] = ret.pop(drop)
         return ret
 
     def as_promql_label_dict(self):
         """Format the topology information into a dict with keys having 'juju_' as prefix."""
-        vals = {"juju_{}".format(key): val for key, val in self.as_dict().items()}
-
-        if "juju_charm_name" in vals:
-            vals["juju_charm"] = vals.pop("juju_charm_name")
+        vals = {
+            "juju_{}".format(key): val
+            for key, val in self.as_dict(replace={"charm_name": "charm"}).items()
+        }
 
         return vals
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -627,7 +627,7 @@ class AggregatorTopology(JujuTopology):
     """Class for initializing topology information for MetricsEndpointAggregator."""
 
     @classmethod
-    def from_arguments(cls, model: str, model_uuid: str, application: str, unit: str):
+    def create(cls, model: str, model_uuid: str, application: str, unit: str):
         """Factory method for creating the `AggregatorTopology` dataclass from a given charm.
 
         Args:
@@ -1988,7 +1988,7 @@ class MetricsEndpointAggregator(Object):
         for unit_name, rules in unit_rules.items():
             for rule in rules:
                 rule["labels"].update(
-                    AggregatorTopology.from_arguments(
+                    AggregatorTopology.create(
                         self.model.name, self.model.uuid, appname, unit_name
                     ).as_promql_label_dict()
                 )

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -860,7 +860,7 @@ class AlertRules:
 
         return alert_groups
 
-    def add_path(self, path: str, *, recursive: bool = False) -> bool:
+    def add_path(self, path: str, *, recursive: bool = False) -> None:
         """Add rules from a dir path.
 
         All rules from files are aggregated into a data structure representing a single rule file.
@@ -1052,7 +1052,6 @@ class MetricsEndpointConsumer(Object):
             if not alert_rules:
                 continue
 
-            identifier = None
             try:
                 scrape_metadata = json.loads(relation.data[relation.app]["scrape_metadata"])
                 identifier = ProviderTopology.from_relation_data(scrape_metadata).identifier
@@ -1512,14 +1511,14 @@ class MetricsEndpointProvider(Object):
             return
 
         alert_rules = AlertRules(topology=self.topology)
-        path_added = alert_rules.add_path(self._alert_rules_path, recursive=True)
+        alert_rules.add_path(self._alert_rules_path, recursive=True)
         alert_rules_as_dict = alert_rules.as_dict()
 
         for relation in self._charm.model.relations[self._relation_name]:
             relation.data[self._charm.app]["scrape_metadata"] = json.dumps(self._scrape_metadata)
             relation.data[self._charm.app]["scrape_jobs"] = json.dumps(self._scrape_jobs)
 
-            if path_added and alert_rules_as_dict:
+            if alert_rules_as_dict:
                 # Update relation data with the string representation of the rule file.
                 # Juju topology is already included in the "scrape_metadata" field above.
                 # The consumer side of the relation uses this information to name the rules file
@@ -1627,7 +1626,7 @@ class PrometheusRulesProvider(Object):
             return
 
         alert_rules = AlertRules()
-        path_added = alert_rules.add_path(self.dir_path, recursive=self._recursive)
+        alert_rules.add_path(self.dir_path, recursive=self._recursive)
         alert_rules_as_dict = alert_rules.as_dict()
 
         logger.info("Updating relation data with rule files from disk")

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1068,14 +1068,21 @@ class MetricsEndpointConsumer(Object):
                     e,
                 )
 
+                if "groups" not in alert_rules:
+                    logger.warning("No alert groups were found in relation data")
+                    continue
                 # Construct an ID based on what's in the alert rules
-                labels = next(alert_rules["groups"])["labels"]
-                identifier = "{}_{}_{}".format(
-                    labels["juju_model"],
-                    labels["juju_model_uuid"],
-                    labels["juju_application"]
-                )
-                alerts[identifier] = alert_rules
+                for group in alert_rules["groups"]:
+                    try:
+                        labels = group["rules"][0]["labels"]
+                        identifier = "{}_{}_{}".format(
+                            labels["juju_model"],
+                            labels["juju_model_uuid"],
+                            labels["juju_application"],
+                        )
+                        alerts[identifier] = alert_rules
+                    except KeyError:
+                        logger.error("Alert rules were found but no usable labels were present")
 
         return alerts
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -582,7 +582,12 @@ class JujuTopology:
         )
 
     def as_dict(self, rename_keys: Optional[Dict[str, str]] = None) -> dict:
-        """Format the topology information into a dict."""
+        """Format the topology information into a dict.
+
+        Args:
+            rename_keys: A dictionary mapping old key names to new key names, which will
+                be substituted when invoked.
+        """
         ret = {
             "model": self.model,
             "model_uuid": self.model_uuid,
@@ -638,7 +643,6 @@ class AggregatorTopology(JujuTopology):
         vals = {"juju_{}".format(key): val for key, val in self.as_dict().items()}
 
         # FIXME: Why is this different? I have no idea. The uuid length should be the same
-        vals["juju_model_uuid"] = vals.pop("juju_model_uuid")
         vals["juju_model_uuid"] = vals["juju_model_uuid"][:7]
 
         return vals
@@ -1076,6 +1080,12 @@ class MetricsEndpointConsumer(Object):
                 if "groups" in alert_rules["groups"][0].keys():
                     # Strip off the first parts of the rule name, set by topology, to give back
                     # an identifier which can be used to write the file
+                    #
+                    # Topology will look like:
+                    # juju_modelname_modeluuid_appname_alert.rules
+                    # The regular expression takes off:
+                    # juju_modelname_modeluuid_appname
+                    # And uses it as the dict key
                     flattened = {
                         re.sub(
                             r"^(?P<id>(.*?_){2}(.*?))_", r"\g<id>", alert["groups"][0]["name"]

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1507,7 +1507,7 @@ class MetricsEndpointProvider(Object):
 
         alert_rules = AlertRules()
         alert_rules.set_topology(self.topology)
-        path_added = alert_rules.add_path(self._alert_rules_path, recursive=False)
+        path_added = alert_rules.add_path(self._alert_rules_path, recursive=True)
         alert_rules_as_dict = alert_rules.as_dict()
 
         for relation in self._charm.model.relations[self._relation_name]:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -558,9 +558,9 @@ class JujuTopology:
             a `JujuTopology` object.
         """
         return cls(
-            model=data["model"],
-            model_uuid=data["model_uuid"],
-            application=data["application"],
+            model=data.get("model", ""),
+            model_uuid=data.get("model_uuid", ""),
+            application=data.get("application", ""),
             unit=data.get("unit", ""),
             charm_name=data.get("charm_name", ""),
         )

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -665,7 +665,7 @@ class ProviderTopology(JujuTopology):
         # This is used only by Metrics[Consumer|Provider] and does not need a
         # unit name, so only check for the charm name
         return "juju_{}_prometheus_scrape".format(
-                "_".join([self.model, self.model_uuid[:7], self.application, self.charm_name]) # type: ignore
+            "_".join([self.model, self.model_uuid[:7], self.application, self.charm_name])  # type: ignore
         )
 
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1072,8 +1072,22 @@ class MetricsEndpointConsumer(Object):
                 continue
 
             try:
-                scrape_metadata = json.loads(relation.data[relation.app]["scrape_metadata"])
-                topology = ProviderTopology.from_relation_data(scrape_metadata)
+                metadata = relation.data[relation.app].get("scrape_metadata", "")
+                if metadata:
+                    scrape_metadata = json.loads(metadata)
+                    topology = ProviderTopology.from_relation_data(scrape_metadata)
+                else:
+                    # FIXME: older versions of MetricsEndpointAggregator do not give
+                    # us nearly enough information about model data or other, so stub
+                    # out the topology with the only information we can
+                    topology = ProviderTopology.from_relation_data(
+                        {
+                            "model": self._charm.model,
+                            "model_uuid": self._charm.model.uuid,
+                            "applicaiton": relation.app.name,
+                            "unit": alert_rules["groups"].keys()[0],
+                        }
+                    )
 
                 alerts[topology.identifier] = alert_rules
 

--- a/tests/unit/prometheus_alert_rules/nested/target_missing.rule
+++ b/tests/unit/prometheus_alert_rules/nested/target_missing.rule
@@ -1,0 +1,10 @@
+groups:
+- name: NestedHighRequestLatency
+  rules:
+  - alert: NestedHighRequestLatency
+    expr: job:request_latency_seconds:mean5m{%%juju_topology%%} > 0.5
+    for: 10m
+    labels:
+      severity: page
+    annotations:
+      summary: Nested high request latency

--- a/tests/unit/test_endpoint_aggregator.py
+++ b/tests/unit/test_endpoint_aggregator.py
@@ -635,5 +635,4 @@ class TestEndpointAggregator(unittest.TestCase):
                 ],
             },
         ]
-        self.maxDiff = None
         self.assertListEqual(groups, expected_groups)

--- a/tests/unit/test_endpoint_aggregator.py
+++ b/tests/unit/test_endpoint_aggregator.py
@@ -635,5 +635,5 @@ class TestEndpointAggregator(unittest.TestCase):
                 ],
             },
         ]
-
+        self.maxDiff = None
         self.assertListEqual(groups, expected_groups)

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -218,6 +218,7 @@ class TestEndpointConsumer(unittest.TestCase):
                 self.assertIn("juju_model", labels)
                 self.assertIn("juju_model_uuid", labels)
                 self.assertIn("juju_application", labels)
+                self.assertIn("juju_charm", labels)
 
             relabel_configs = job["relabel_configs"]
             self.assertEqual(len(relabel_configs), 1)

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -436,10 +436,11 @@ def job_name_suffix(job_name, labels, rel_id):
     Returns:
         string name of job as set by provider (if any)
     """
-    name_prefix = "juju_{}_{}_{}_prometheus_{}_scrape_".format(
+    name_prefix = "juju_{}_{}_{}_{}_prometheus_{}_scrape_".format(
         labels["juju_model"],
         labels["juju_model_uuid"][:7],
         labels["juju_application"],
+        labels["juju_charm"],
         rel_id,
     )
     return job_name[len(name_prefix) :]

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -6,7 +6,6 @@ import unittest
 
 from charms.prometheus_k8s.v0.prometheus_scrape import (
     ALLOWED_KEYS,
-    InvalidTopologyError,
     MetricsEndpointConsumer,
 )
 from ops.charm import CharmBase
@@ -389,7 +388,7 @@ class TestEndpointConsumer(unittest.TestCase):
         alerts = list(rules_file.values())[0]
         self.assertEqual(ALERT_RULES, alerts)
 
-    def test_consumer_raises_an_exception_on_bad_metadata(self):
+    def test_consumer_logs_an_error_on_missing_alerting_data(self):
         self.assertEqual(self.harness.charm._stored.num_events, 0)
 
         bad_metadata = {"bad": "metadata"}
@@ -405,7 +404,12 @@ class TestEndpointConsumer(unittest.TestCase):
             },
         )
         self.harness.add_relation_unit(rel_id, "consumer/0")
-        self.assertRaises(InvalidTopologyError, self.harness.charm.prometheus_consumer.alerts)
+        self.assertEqual(self.harness.charm._stored.num_events, 1)
+        with self.assertLogs(level="ERROR") as logger:
+            _ = self.harness.charm.prometheus_consumer.alerts()
+            messages = sorted(logger.output)
+            self.assertEqual(len(messages), 1)
+            self.assertIn(f"Relation {rel_id} has no 'scrape_metadata'", messages[0])
 
 
 def juju_job_labels(job, num=0):

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -405,11 +405,11 @@ class TestEndpointConsumer(unittest.TestCase):
         )
         self.harness.add_relation_unit(rel_id, "consumer/0")
         self.assertEqual(self.harness.charm._stored.num_events, 1)
-        with self.assertLogs(level="ERROR") as logger:
+        with self.assertLogs(level="WARNING") as logger:
             _ = self.harness.charm.prometheus_consumer.alerts()
             messages = sorted(logger.output)
             self.assertEqual(len(messages), 1)
-            self.assertIn(f"Relation {rel_id} has invalid data", messages[0])
+            self.assertIn(f"Relation {rel_id} has no 'scrape_metadata'", messages[0])
 
 
 def juju_job_labels(job, num=0):

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -405,11 +405,12 @@ class TestEndpointConsumer(unittest.TestCase):
         )
         self.harness.add_relation_unit(rel_id, "consumer/0")
         self.assertEqual(self.harness.charm._stored.num_events, 1)
-        with self.assertLogs(level="ERROR") as logger:
+        with self.assertLogs(level="WARNING") as logger:
             _ = self.harness.charm.prometheus_consumer.alerts()
-            messages = sorted(logger.output)
-            self.assertEqual(len(messages), 1)
+            messages = logger.output
+            self.assertEqual(len(messages), 2)
             self.assertIn(f"Relation {rel_id} has no 'scrape_metadata'", messages[0])
+            self.assertIn("No alert groups were found", messages[1])
 
 
 def juju_job_labels(job, num=0):

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -13,8 +13,8 @@ import yaml
 from charms.prometheus_k8s.v0.prometheus_scrape import (
     ALLOWED_KEYS,
     AlertRules,
-    JujuTopology,
     MetricsEndpointProvider,
+    ProviderTopology,
     RelationInterfaceMismatchError,
     RelationNotFoundError,
     RelationRoleMismatchError,
@@ -212,7 +212,7 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertIn("alert_rules", data)
         alerts = json.loads(data["alert_rules"])
         self.assertIn("groups", alerts)
-        self.assertEqual(len(alerts["groups"]), 3)
+        self.assertEqual(len(alerts["groups"]), 4)
         group = alerts["groups"][0]
         for rule in group["rules"]:
             self.assertIn("labels", rule)
@@ -220,6 +220,7 @@ class TestEndpointProvider(unittest.TestCase):
             self.assertIn("juju_model", labels)
             self.assertIn("juju_application", labels)
             self.assertIn("juju_model_uuid", labels)
+            self.assertIn("juju_charm", labels)
 
     @patch("ops.testing._TestingModelBackend.network_get")
     def test_each_alert_expression_is_topology_labeled(self, _):
@@ -229,7 +230,7 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertIn("alert_rules", data)
         alerts = json.loads(data["alert_rules"])
         self.assertIn("groups", alerts)
-        self.assertEqual(len(alerts["groups"]), 3)
+        self.assertEqual(len(alerts["groups"]), 4)
         group = alerts["groups"][0]
         for rule in group["rules"]:
             self.assertIn("expr", rule)
@@ -237,6 +238,7 @@ class TestEndpointProvider(unittest.TestCase):
                 self.assertIn("juju_model", labels)
                 self.assertIn("juju_model_uuid", labels)
                 self.assertIn("juju_application", labels)
+                self.assertIn("juju_charm", labels)
 
 
 class CustomizableEndpointProviderCharm(CharmBase):
@@ -331,7 +333,7 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
             ("rules/prom/prom_format/standard_rule.rule", yaml.safe_dump(rules_file_dict)),
         )
 
-        self.topology = JujuTopology("MyModel", "MyUUID", "MyApp", "MyCharm")
+        self.topology = ProviderTopology("MyModel", "MyUUID", "MyApp", "MyCharm")
 
     def test_non_recursive_is_default(self):
         rules = AlertRules()
@@ -436,7 +438,7 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
 
 class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
     def setUp(self) -> None:
-        self.topology = JujuTopology("MyModel", "MyUUID", "MyApp", "MyCharm")
+        self.topology = ProviderTopology("MyModel", "MyUUID", "MyApp", "MyCharm")
 
     def gen_rule(self, name, **extra):
         return {

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -349,7 +349,7 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
         expected_freestanding_rule = {
             "alert": "free_standing",
             "expr": "avg(some_vector[5m]) > 5",
-            "labels": self.topology.as_dict_with_promql_labels(),
+            "labels": self.topology.as_promql_label_dict(),
         }
 
         expected_rules_file = {
@@ -372,7 +372,7 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
         expected_alert_rule = {
             "alert": "CPUOverUse",
             "expr": f"process_cpu_seconds_total{{{self.topology.promql_labels}}} > 0.12",
-            "labels": self.topology.as_dict_with_promql_labels(),
+            "labels": self.topology.as_promql_label_dict(),
         }
 
         expected_rules_file = {
@@ -401,13 +401,13 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
         expected_alert_rule = {
             "alert": "CPUOverUse",
             "expr": f"process_cpu_seconds_total{{{self.topology.promql_labels}}} > 0.12",
-            "labels": self.topology.as_dict_with_promql_labels(),
+            "labels": self.topology.as_promql_label_dict(),
         }
 
         expected_freestanding_rule = {
             "alert": "free_standing",
             "expr": "avg(some_vector[5m]) > 5",
-            "labels": self.topology.as_dict_with_promql_labels(),
+            "labels": self.topology.as_promql_label_dict(),
         }
 
         expected_rules_file = {
@@ -464,15 +464,15 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
                 {
                     "name": f"{self.topology.identifier}_group_1_alerts",
                     "rules": [
-                        self.gen_rule(1, labels=self.topology.as_dict_with_promql_labels()),
-                        self.gen_rule(2, labels=self.topology.as_dict_with_promql_labels()),
+                        self.gen_rule(1, labels=self.topology.as_promql_label_dict()),
+                        self.gen_rule(2, labels=self.topology.as_promql_label_dict()),
                     ],
                 },
                 {
                     "name": f"{self.topology.identifier}_group_2_alerts",
                     "rules": [
-                        self.gen_rule(1, labels=self.topology.as_dict_with_promql_labels()),
-                        self.gen_rule(2, labels=self.topology.as_dict_with_promql_labels()),
+                        self.gen_rule(1, labels=self.topology.as_promql_label_dict()),
+                        self.gen_rule(2, labels=self.topology.as_promql_label_dict()),
                     ],
                 },
             ]
@@ -502,8 +502,8 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
                 {
                     "name": f"{self.topology.identifier}_my_group_alerts",
                     "rules": [
-                        self.gen_rule("same", labels=self.topology.as_dict_with_promql_labels()),
-                        self.gen_rule("same", labels=self.topology.as_dict_with_promql_labels()),
+                        self.gen_rule("same", labels=self.topology.as_promql_label_dict()),
+                        self.gen_rule("same", labels=self.topology.as_promql_label_dict()),
                     ],
                 },
             ]
@@ -526,15 +526,15 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
                 {
                     "name": f"{self.topology.identifier}_group_same_alerts",
                     "rules": [
-                        self.gen_rule(1, labels=self.topology.as_dict_with_promql_labels()),
-                        self.gen_rule(2, labels=self.topology.as_dict_with_promql_labels()),
+                        self.gen_rule(1, labels=self.topology.as_promql_label_dict()),
+                        self.gen_rule(2, labels=self.topology.as_promql_label_dict()),
                     ],
                 },
                 {
                     "name": f"{self.topology.identifier}_group_same_alerts",
                     "rules": [
-                        self.gen_rule(1, labels=self.topology.as_dict_with_promql_labels()),
-                        self.gen_rule(2, labels=self.topology.as_dict_with_promql_labels()),
+                        self.gen_rule(1, labels=self.topology.as_promql_label_dict()),
+                        self.gen_rule(2, labels=self.topology.as_promql_label_dict()),
                     ],
                 },
             ]
@@ -559,15 +559,15 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
             "groups": [
                 {
                     "name": f"{self.topology.identifier}_file_alerts",
-                    "rules": [self.gen_rule(0, labels=self.topology.as_dict_with_promql_labels())],
+                    "rules": [self.gen_rule(0, labels=self.topology.as_promql_label_dict())],
                 },
                 {
                     "name": f"{self.topology.identifier}_a_file_alerts",
-                    "rules": [self.gen_rule(1, labels=self.topology.as_dict_with_promql_labels())],
+                    "rules": [self.gen_rule(1, labels=self.topology.as_promql_label_dict())],
                 },
                 {
                     "name": f"{self.topology.identifier}_a_b_file_alerts",
-                    "rules": [self.gen_rule(2, labels=self.topology.as_dict_with_promql_labels())],
+                    "rules": [self.gen_rule(2, labels=self.topology.as_promql_label_dict())],
                 },
             ]
         }

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -336,15 +336,13 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
         self.topology = ProviderTopology("MyModel", "MyUUID", "MyApp", "MyCharm")
 
     def test_non_recursive_is_default(self):
-        rules = AlertRules()
-        rules.set_topology(self.topology)
+        rules = AlertRules(topology=self.topology)
         rules.add_path(os.path.join(self.sandbox.root, "rules", "prom"))
         rules_file_dict = rules.as_dict()
         self.assertEqual({}, rules_file_dict)
 
     def test_non_recursive_lma_format_loading_from_root_dir(self):
-        rules = AlertRules()
-        rules.set_topology(self.topology)
+        rules = AlertRules(topology=self.topology)
         rules.add_path(os.path.join(self.sandbox.root, "rules", "prom", "lma_format"))
         rules_file_dict = rules.as_dict()
 
@@ -366,8 +364,7 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
         self.assertEqual(expected_rules_file, rules_file_dict)
 
     def test_non_recursive_official_format_loading_from_root_dir(self):
-        rules = AlertRules()
-        rules.set_topology(self.topology)
+        rules = AlertRules(topology=self.topology)
         rules.add_path(os.path.join(self.sandbox.root, "rules", "prom", "prom_format"))
         rules_file_dict = rules.as_dict()
 
@@ -395,8 +392,7 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
           - For rules in lma format, core group name is the filename
           - For rules in official format, core group name is the group name in the file
         """
-        rules = AlertRules()
-        rules.set_topology(self.topology)
+        rules = AlertRules(topology=self.topology)
         rules.add_path(os.path.join(self.sandbox.root, "rules", "prom"), recursive=True)
         rules_file_dict = rules.as_dict()
 
@@ -456,8 +452,7 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
         sandbox = TempFolderSandbox()
         sandbox.put_file("rules/file.rule", yaml.safe_dump(rules_file_dict))
 
-        rules = AlertRules()
-        rules.set_topology(self.topology)
+        rules = AlertRules(topology=self.topology)
         rules.add_path(os.path.join(sandbox.root, "rules"), recursive=False)
         rules_file_dict_read = rules.as_dict()
 
@@ -494,8 +489,7 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
         sandbox = TempFolderSandbox()
         sandbox.put_file("rules/file.rule", yaml.safe_dump(rules_file_dict))
 
-        rules = AlertRules()
-        rules.set_topology(self.topology)
+        rules = AlertRules(topology=self.topology)
         rules.add_path(os.path.join(sandbox.root, "rules"), recursive=False)
         rules_file_dict_read = rules.as_dict()
 
@@ -510,7 +504,6 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
                 },
             ]
         }
-        self.maxDiff = None
         self.assertDictEqual(expected_rules_file, rules_file_dict_read)
 
     def test_duplicated_group_names_within_a_file_are_silently_accepted(self):
@@ -518,8 +511,7 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
         sandbox = TempFolderSandbox()
         sandbox.put_file("rules/file.rule", yaml.safe_dump(rules_file_dict))
 
-        rules = AlertRules()
-        rules.set_topology(self.topology)
+        rules = AlertRules(topology=self.topology)
         rules.add_path(os.path.join(sandbox.root, "rules"), recursive=False)
         rules_file_dict_read = rules.as_dict()
 
@@ -541,7 +533,6 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
                 },
             ]
         }
-        self.maxDiff = None
         self.assertDictEqual(expected_rules_file, rules_file_dict_read)
 
     def test_deeply_nested(self):
@@ -552,8 +543,7 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
             ("rules/a/b/file.rule", yaml.safe_dump(self.gen_rule(2))),
         )
 
-        rules = AlertRules()
-        rules.set_topology(self.topology)
+        rules = AlertRules(topology=self.topology)
         rules.add_path(os.path.join(sandbox.root, "rules"), recursive=True)
         rules_file_dict_read = rules.as_dict()
 

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -334,13 +334,15 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
         self.topology = JujuTopology("MyModel", "MyUUID", "MyApp", "MyCharm")
 
     def test_non_recursive_is_default(self):
-        rules = AlertRules(self.topology)
+        rules = AlertRules()
+        rules.set_topology(self.topology)
         rules.add_path(os.path.join(self.sandbox.root, "rules", "prom"))
         rules_file_dict = rules.as_dict()
         self.assertEqual({}, rules_file_dict)
 
     def test_non_recursive_lma_format_loading_from_root_dir(self):
-        rules = AlertRules(self.topology)
+        rules = AlertRules()
+        rules.set_topology(self.topology)
         rules.add_path(os.path.join(self.sandbox.root, "rules", "prom", "lma_format"))
         rules_file_dict = rules.as_dict()
 
@@ -362,7 +364,8 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
         self.assertEqual(expected_rules_file, rules_file_dict)
 
     def test_non_recursive_official_format_loading_from_root_dir(self):
-        rules = AlertRules(self.topology)
+        rules = AlertRules()
+        rules.set_topology(self.topology)
         rules.add_path(os.path.join(self.sandbox.root, "rules", "prom", "prom_format"))
         rules_file_dict = rules.as_dict()
 
@@ -390,7 +393,8 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
           - For rules in lma format, core group name is the filename
           - For rules in official format, core group name is the group name in the file
         """
-        rules = AlertRules(self.topology)
+        rules = AlertRules()
+        rules.set_topology(self.topology)
         rules.add_path(os.path.join(self.sandbox.root, "rules", "prom"), recursive=True)
         rules_file_dict = rules.as_dict()
 
@@ -450,7 +454,8 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
         sandbox = TempFolderSandbox()
         sandbox.put_file("rules/file.rule", yaml.safe_dump(rules_file_dict))
 
-        rules = AlertRules(self.topology)
+        rules = AlertRules()
+        rules.set_topology(self.topology)
         rules.add_path(os.path.join(sandbox.root, "rules"), recursive=False)
         rules_file_dict_read = rules.as_dict()
 
@@ -487,7 +492,8 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
         sandbox = TempFolderSandbox()
         sandbox.put_file("rules/file.rule", yaml.safe_dump(rules_file_dict))
 
-        rules = AlertRules(self.topology)
+        rules = AlertRules()
+        rules.set_topology(self.topology)
         rules.add_path(os.path.join(sandbox.root, "rules"), recursive=False)
         rules_file_dict_read = rules.as_dict()
 
@@ -510,7 +516,8 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
         sandbox = TempFolderSandbox()
         sandbox.put_file("rules/file.rule", yaml.safe_dump(rules_file_dict))
 
-        rules = AlertRules(self.topology)
+        rules = AlertRules()
+        rules.set_topology(self.topology)
         rules.add_path(os.path.join(sandbox.root, "rules"), recursive=False)
         rules_file_dict_read = rules.as_dict()
 
@@ -543,7 +550,8 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
             ("rules/a/b/file.rule", yaml.safe_dump(self.gen_rule(2))),
         )
 
-        rules = AlertRules(self.topology)
+        rules = AlertRules()
+        rules.set_topology(self.topology)
         rules.add_path(os.path.join(sandbox.root, "rules"), recursive=True)
         rules_file_dict_read = rules.as_dict()
 


### PR DESCRIPTION
Ensure that missing scrape labels do not raise exceptions.

Significantly rework `JujuTopology` so the generation of labels (whether as a dict or as a string) dynamically cull from `as_dict`, and add an optional argument to `as_dict` to replace values. Realistically, the entire variable should just be renamed so this isn't necessary, but keep the API the same for now in case.

Branch out and add additional Providers for `Aggregator` and `Provider` which implementing only trivial methods needed for differing functionality.

Ensure that missing `scrape_metadata` does not blow up the relations.

For now, keep the API and labels the same, but this will have a followup which *properly* sets `scrape_metadata`, even as a partial key with a validator, so the Juju `model` and `model.uuid` are appropriately set from the side of the Aggregator.

 Closes #185.
 Closes #186 