### PR TITLE
add to CI a check for latest libs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,5 +51,7 @@ jobs:
       uses: charmed-kubernetes/actions-operator@main
       with:
         provider: microk8s
+    - name: Check charm is using latest libs
+      run: bash -c '[[ $(find lib/charms -mindepth 1 -maxdepth 1 -type d | wc -l) -eq $(charmcraft fetch-lib 2>&1 | grep "was already up to date" | wc -l) ]]'
     - name: Run Prometheus integration tests
       run: tox -vve integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
       uses: charmed-kubernetes/actions-operator@main
       with:
         provider: microk8s
-    - name: Check charm is using latest libs
-      run: bash -c '[[ $(find lib/charms -mindepth 1 -maxdepth 1 -type d | wc -l) -eq $(charmcraft fetch-lib 2>&1 | grep "was already up to date" | wc -l) ]]'
     - name: Run Prometheus integration tests
       run: tox -vve integration
+    - name: Check charm is using latest libs
+      run: bash -c '[[ $(find lib/charms -mindepth 1 -maxdepth 1 -type d | wc -l) -eq $(charmcraft fetch-lib 2>&1 | grep "was already up to date" | wc -l) ]]'


### PR DESCRIPTION
Add a step to the integration test to verify the charm is using the latest libs.
This is done under integration because that is where we already have charmcraft pre-installed for us.

Currently [the test fails](https://github.com/canonical/prometheus-k8s-operator/pull/189/checks#step:4:6) because:
1. `prometheus_scrape has local changes, can not be updated`
2. `alertmanager_dispatch` is out of date
3. `grafana_source` is out of date
4. `kubernetes_service_patch` is out of date

```
> charmcraft fetch-lib
Library charms.nginx_ingress_integrator.v0.ingress was already up to date in version 0.9.
Library charms.prometheus_k8s.v0.prometheus_scrape has local changes, can not be updated.
Library charms.alertmanager_k8s.v0.alertmanager_dispatch updated to version 0.2.
Library charms.grafana_k8s.v0.grafana_source updated to version 0.5.
Library charms.observability_libs.v0.kubernetes_service_patch updated to version 0.5.
```
In its current form, having this CI check would result in the following workflow:
- a change to a charm's own lib(s) will fail the test,
- which means the author needs to publish the lib before merging, so integration tests on the ghwf pass