### PR TITLE
add charm upgrade itest

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -155,7 +155,10 @@ class IPAddressWorkaround:
     Due to a juju bug, occasionally some charms finish a startup sequence without
     having an ip address returned by `bind_address`.
     https://bugs.launchpad.net/juju/+bug/1929364
-    Issuing dummy update_status just to trigger an event, and then restore it.
+
+    On entry, the context manager changes the update status interval to the minimum 10s, so that
+    the update_status hook is trigger shortly.
+    On exit, the context manager restores the interval to its previous value.
     """
 
     def __init__(self, ops_test: OpsTest):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-from typing import Dict
 
 import yaml
 from pytest_operator.plugin import OpsTest
@@ -148,46 +147,6 @@ def oci_image(metadata_file: str, image_name: str) -> str:
         raise ValueError("Upstream source not found")
 
     return upstream_source
-
-
-def interleave(l1: list, l2: list) -> list:
-    """Interleave two lists.
-
-    >>> interleave([1,2,3], ['a', 'b', 'c'])
-    [1, 'a', 2, 'b', 3, 'c']
-
-    Reference: https://stackoverflow.com/a/11125298/3516684
-    """
-    return [x for t in zip(l1, l2) for x in t]
-
-
-async def cli_upgrade_from_path_and_wait(
-    ops_test: OpsTest,
-    path: str,
-    alias: str,
-    resources: Dict[str, str] = None,
-    wait_for_status: str = None,
-):
-    if resources is None:
-        resources = {}
-
-    resource_pairs = [f"{k}={v}" for k, v in resources.items()]
-    resource_arg_prefixes = ["--resource"] * len(resource_pairs)
-    resource_args = interleave(resource_arg_prefixes, resource_pairs)
-
-    cmd = [
-        "juju",
-        "refresh",
-        "--path",
-        path,
-        alias,
-        *resource_args,
-    ]
-
-    retcode, stdout, stderr = await ops_test._run(*cmd)
-    assert retcode == 0, f"Upgrade failed: {(stderr or stdout).strip()}"
-    log.info(stdout)
-    await ops_test.model.wait_for_idle(apps=[alias], status=wait_for_status, timeout=120)
 
 
 class IPAddressWorkaround:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,8 +1,12 @@
+import logging
 from pathlib import Path
+from typing import Dict
 
 import yaml
 from pytest_operator.plugin import OpsTest
 from workload import Prometheus
+
+log = logging.getLogger(__name__)
 
 
 async def unit_address(ops_test: OpsTest, app_name: str, unit_num: int) -> str:
@@ -144,3 +148,67 @@ def oci_image(metadata_file: str, image_name: str) -> str:
         raise ValueError("Upstream source not found")
 
     return upstream_source
+
+
+def interleave(l1: list, l2: list) -> list:
+    """Interleave two lists.
+
+    >>> interleave([1,2,3], ['a', 'b', 'c'])
+    [1, 'a', 2, 'b', 3, 'c']
+
+    Reference: https://stackoverflow.com/a/11125298/3516684
+    """
+    return [x for t in zip(l1, l2) for x in t]
+
+
+async def cli_upgrade_from_path_and_wait(
+    ops_test: OpsTest,
+    path: str,
+    alias: str,
+    resources: Dict[str, str] = None,
+    wait_for_status: str = None,
+):
+    if resources is None:
+        resources = {}
+
+    resource_pairs = [f"{k}={v}" for k, v in resources.items()]
+    resource_arg_prefixes = ["--resource"] * len(resource_pairs)
+    resource_args = interleave(resource_arg_prefixes, resource_pairs)
+
+    cmd = [
+        "juju",
+        "refresh",
+        "--path",
+        path,
+        alias,
+        *resource_args,
+    ]
+
+    retcode, stdout, stderr = await ops_test._run(*cmd)
+    assert retcode == 0, f"Upgrade failed: {(stderr or stdout).strip()}"
+    log.info(stdout)
+    await ops_test.model.wait_for_idle(apps=[alias], status=wait_for_status, timeout=120)
+
+
+class IPAddressWorkaround:
+    """Context manager for deploying a charm that needs to have its IP address.
+
+    Due to a juju bug, occasionally some charms finish a startup sequence without
+    having an ip address returned by `bind_address`.
+    https://bugs.launchpad.net/juju/+bug/1929364
+    Issuing dummy update_status just to trigger an event, and then restore it.
+    """
+
+    def __init__(self, ops_test: OpsTest):
+        self.ops_test = ops_test
+
+    async def __aenter__(self):
+        """On entry, the update status interval is set to the minimum 10s."""
+        config = await self.ops_test.model.get_config()
+        self.revert_to = config["update-status-hook-interval"]
+        await self.ops_test.model.set_config({"update-status-hook-interval": "10s"})
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, exc_traceback):
+        """On exit, the update status interval is reverted to its original value."""
+        await self.ops_test.model.set_config({"update-status-hook-interval": self.revert_to})

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 from helpers import (  # type: ignore[attr-defined]
     IPAddressWorkaround,
+    check_prometheus_is_ready,
     cli_upgrade_from_path_and_wait,
 )
 
@@ -47,3 +48,5 @@ async def test_build_and_deploy(ops_test, prometheus_charm):
             resources=resources,
             wait_for_status="active",
         )
+
+        await check_prometheus_is_ready(ops_test, app_name, 0)

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -26,9 +26,7 @@ async def test_build_and_deploy(ops_test, prometheus_charm):
     Assert on the unit status before any relations/configurations take place.
     """
     log.info("build charm from local source folder")
-    resources = {
-        "prometheus-image": METADATA["resources"]["prometheus-image"]["upstream-source"]
-    }
+    resources = {"prometheus-image": METADATA["resources"]["prometheus-image"]["upstream-source"]}
 
     async with IPAddressWorkaround(ops_test):
         log.info("deploy charm from charmhub")

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -20,7 +20,7 @@ app_name = METADATA["name"]
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test, prometheus_charm):
+async def test_deploy_from_edge_and_upgrade_from_local_path(ops_test, prometheus_charm):
     """Build the charm-under-test and deploy it together with related charms.
 
     Assert on the unit status before any relations/configurations take place.

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -27,7 +27,7 @@ async def test_build_and_deploy(ops_test, prometheus_charm):
     """
     log.info("build charm from local source folder")
     resources = {
-        "alertmanager-image": METADATA["resources"]["alertmanager-image"]["upstream-source"]
+        "prometheus-image": METADATA["resources"]["prometheus-image"]["upstream-source"]
     }
 
     async with IPAddressWorkaround(ops_test):

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -11,7 +11,6 @@ import yaml
 from helpers import (  # type: ignore[attr-defined]
     IPAddressWorkaround,
     check_prometheus_is_ready,
-    cli_upgrade_from_path_and_wait,
 )
 
 log = logging.getLogger(__name__)
@@ -37,16 +36,8 @@ async def test_build_and_deploy(ops_test, prometheus_charm):
         await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
         log.info("upgrade deployed charm with local charm %s", prometheus_charm)
-        # await ops_test.model.applications[app_name].refresh(
-        #     path=local_charm, resources=resources
-        # )
-
-        await cli_upgrade_from_path_and_wait(
-            ops_test,
-            path=prometheus_charm,
-            alias=app_name,
-            resources=resources,
-            wait_for_status="active",
+        await ops_test.model.applications[app_name].refresh(
+            path=prometheus_charm, resources=resources
         )
-
+        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
         await check_prometheus_is_ready(ops_test, app_name, 0)

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from helpers import (  # type: ignore[attr-defined]
+    IPAddressWorkaround,
+    cli_upgrade_from_path_and_wait,
+)
+
+log = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+app_name = METADATA["name"]
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test, prometheus_charm):
+    """Build the charm-under-test and deploy it together with related charms.
+
+    Assert on the unit status before any relations/configurations take place.
+    """
+    log.info("build charm from local source folder")
+    resources = {
+        "alertmanager-image": METADATA["resources"]["alertmanager-image"]["upstream-source"]
+    }
+
+    async with IPAddressWorkaround(ops_test):
+        log.info("deploy charm from charmhub")
+        await ops_test.model.deploy(f"ch:{app_name}", application_name=app_name, channel="edge")
+        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+
+        log.info("upgrade deployed charm with local charm %s", prometheus_charm)
+        # await ops_test.model.applications[app_name].refresh(
+        #     path=local_charm, resources=resources
+        # )
+
+        await cli_upgrade_from_path_and_wait(
+            ops_test,
+            path=prometheus_charm,
+            alias=app_name,
+            resources=resources,
+            wait_for_status="active",
+        )


### PR DESCRIPTION
This PR adds an integration test for upgrading from an edge release to the current source release.

TODO:
- [x] replace cli upgrade with refresh after https://github.com/juju/python-libjuju/issues/606