### PR TITLE
Split the single itest file into multiple files

### DIFF
--- a/tests/integration/test_alternative_images.py
+++ b/tests/integration/test_alternative_images.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+from helpers import check_prometheus_is_ready, oci_image
+
+tester_resources = {
+    "prometheus-tester-image": oci_image(
+        "./tests/integration/prometheus-tester/metadata.yaml", "prometheus-tester-image"
+    )
+}
+prometheus_resources = {"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")}
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy_with_alternative_images(ops_test, prometheus_charm):
+    """Test that the Prometheus charm can be deployed successfully."""
+    app_name = "prometheus-ubuntu"
+
+    await ops_test.model.deploy(
+        prometheus_charm, resources=prometheus_resources, application_name=app_name
+    )
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active")
+    await ops_test.model.block_until(lambda: len(ops_test.model.applications[app_name].units) > 0)
+
+    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
+
+    await check_prometheus_is_ready(ops_test, app_name, 0)
+
+    await ops_test.model.applications[app_name].remove()
+    await ops_test.model.block_until(lambda: app_name not in ops_test.model.applications)
+    await ops_test.model.reset()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -25,44 +25,6 @@ prometheus_resources = {"prometheus-image": oci_image("./metadata.yaml", "promet
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy_with_alternative_images(ops_test, prometheus_charm):
-    """Test that the Prometheus charm can be deployed successfully."""
-    app_name = "prometheus-ubuntu"
-
-    await ops_test.model.deploy(
-        prometheus_charm, resources=prometheus_resources, application_name=app_name
-    )
-    await ops_test.model.wait_for_idle(apps=[app_name], status="active")
-    await ops_test.model.block_until(lambda: len(ops_test.model.applications[app_name].units) > 0)
-
-    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
-
-    await check_prometheus_is_ready(ops_test, app_name, 0)
-
-    await ops_test.model.applications[app_name].remove()
-    await ops_test.model.block_until(lambda: app_name not in ops_test.model.applications)
-    await ops_test.model.reset()
-
-
-@pytest.mark.abort_on_fail
-async def test_build_and_deploy_prometheus_tester(ops_test, prometheus_tester_charm):
-    """Test that Prometheus tester charm can be deployed successfully."""
-    app_name = "prometheus-tester"
-
-    await ops_test.model.deploy(
-        prometheus_tester_charm, resources=tester_resources, application_name=app_name
-    )
-    await ops_test.model.wait_for_idle(apps=[app_name], status="active")
-    await ops_test.model.block_until(lambda: len(ops_test.model.applications[app_name].units) > 0)
-
-    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
-
-    await ops_test.model.applications[app_name].remove()
-    await ops_test.model.block_until(lambda: app_name not in ops_test.model.applications)
-    await ops_test.model.reset()
-
-
-@pytest.mark.abort_on_fail
 async def test_prometheus_scrape_relation_with_prometheus_tester(
     ops_test, prometheus_charm, prometheus_tester_charm
 ):

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,14 +16,22 @@ from helpers import (
 
 logger = logging.getLogger(__name__)
 
+tester_resources = {
+    "prometheus-tester-image": oci_image(
+        "./tests/integration/prometheus-tester/metadata.yaml", "prometheus-tester-image"
+    )
+}
+prometheus_resources = {"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")}
+
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy_with_alternative_images(ops_test, prometheus_charm):
     """Test that the Prometheus charm can be deployed successfully."""
-    resources = {"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")}
     app_name = "prometheus-ubuntu"
 
-    await ops_test.model.deploy(prometheus_charm, resources=resources, application_name=app_name)
+    await ops_test.model.deploy(
+        prometheus_charm, resources=prometheus_resources, application_name=app_name
+    )
     await ops_test.model.wait_for_idle(apps=[app_name], status="active")
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[app_name].units) > 0)
 
@@ -32,21 +40,17 @@ async def test_build_and_deploy_with_alternative_images(ops_test, prometheus_cha
     await check_prometheus_is_ready(ops_test, app_name, 0)
 
     await ops_test.model.applications[app_name].remove()
+    await ops_test.model.block_until(lambda: app_name not in ops_test.model.applications)
     await ops_test.model.reset()
 
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy_prometheus_tester(ops_test, prometheus_tester_charm):
     """Test that Prometheus tester charm can be deployed successfully."""
-    resources = {
-        "prometheus-tester-image": oci_image(
-            "./tests/integration/prometheus-tester/metadata.yaml", "prometheus-tester-image"
-        )
-    }
     app_name = "prometheus-tester"
 
     await ops_test.model.deploy(
-        prometheus_tester_charm, resources=resources, application_name=app_name
+        prometheus_tester_charm, resources=tester_resources, application_name=app_name
     )
     await ops_test.model.wait_for_idle(apps=[app_name], status="active")
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[app_name].units) > 0)
@@ -54,6 +58,7 @@ async def test_build_and_deploy_prometheus_tester(ops_test, prometheus_tester_ch
     assert ops_test.model.applications[app_name].units[0].workload_status == "active"
 
     await ops_test.model.applications[app_name].remove()
+    await ops_test.model.block_until(lambda: app_name not in ops_test.model.applications)
     await ops_test.model.reset()
 
 
@@ -62,12 +67,6 @@ async def test_prometheus_scrape_relation_with_prometheus_tester(
     ops_test, prometheus_charm, prometheus_tester_charm
 ):
     """Test basic functionality of prometheus_scrape relation interface."""
-    tester_resources = {
-        "prometheus-tester-image": oci_image(
-            "./tests/integration/prometheus-tester/metadata.yaml", "prometheus-tester-image"
-        )
-    }
-    prometheus_resources = {"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")}
     prometheus_app_name = "prometheus"
     tester_app_name = "prometheus-tester"
 
@@ -113,4 +112,9 @@ async def test_prometheus_scrape_relation_with_prometheus_tester(
     assert initial_rules == relation_removed_rules
 
     await ops_test.model.applications[prometheus_app_name].remove()
+
+    await ops_test.model.block_until(
+        lambda: prometheus_app_name not in ops_test.model.applications
+    )
+    await ops_test.model.block_until(lambda: tester_app_name not in ops_test.model.applications)
     await ops_test.model.reset()

--- a/tests/integration/test_prometheus_tester.py
+++ b/tests/integration/test_prometheus_tester.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+from helpers import oci_image
+
+tester_resources = {
+    "prometheus-tester-image": oci_image(
+        "./tests/integration/prometheus-tester/metadata.yaml", "prometheus-tester-image"
+    )
+}
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy_prometheus_tester(ops_test, prometheus_tester_charm):
+    """Test that Prometheus tester charm can be deployed successfully."""
+    app_name = "prometheus-tester"
+
+    await ops_test.model.deploy(
+        prometheus_tester_charm, resources=tester_resources, application_name=app_name
+    )
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active")
+    await ops_test.model.block_until(lambda: len(ops_test.model.applications[app_name].units) > 0)
+
+    assert ops_test.model.applications[app_name].units[0].workload_status == "active"
+
+    await ops_test.model.applications[app_name].remove()
+    await ops_test.model.block_until(lambda: app_name not in ops_test.model.applications)
+    await ops_test.model.reset()


### PR DESCRIPTION
This PR splits the single itest file into multiple files.

Possibly coincidentally, but with this fix all itests passed 4 times in a row
https://github.com/canonical/prometheus-k8s-operator/actions/runs/1664209651

Fixes #193