### PR TITLE
update tests

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -550,7 +550,7 @@ class PrometheusRemoteWriteConsumer(Object):
 
     ```
     requires:
-        prometheus-remote-write:  # Relation name
+        receive-remote-write:  # Relation name
             interface: prometheus_remote_write  # Relation interface
     ```
 
@@ -564,7 +564,7 @@ class PrometheusRemoteWriteConsumer(Object):
 
         self.framework.observe(
             self.remote_write_consumer.on.endpoints_changed,
-            _handle_endpoints_changed,
+            self._handle_endpoints_changed,
         )
     ```
     The `endpoints_changed` event will fire in situations such as provider ip change (e.g.
@@ -581,7 +581,7 @@ class PrometheusRemoteWriteConsumer(Object):
     which returns a dictionary structured like the Prometheus configuration object (see
     https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write).
 
-    Regarding the default relation name, `prometheus-remote-write`: if you choose to change it,
+    Regarding the default relation name, `receive-remote-write`: if you choose to change it,
     you would need to explicitly provide it to the `PrometheusRemoteWriteConsumer` via the
     `relation_name` constructor argument. (The relation interface, on the other hand, is
     fixed and, if you were to change it, your charm would not be able to relate with other
@@ -709,6 +709,9 @@ class PrometheusRemoteWriteConsumer(Object):
     @property
     def endpoints(self) -> List[Dict[str, str]]:
         """A config object ready to be dropped into a prometheus config file.
+
+        The format of the dict is specified in the official prometheus docs:
+        https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
 
         Returns:
             A list of dictionaries where each dictionary provides information about

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["W503", "E501", "D107", "E203"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 per-file-ignores = ["tests/*:D100,D101,D102,D103"]
 docstring-convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,5 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-[project]
-name = "prometheus-operator"
-description = "Kubernetes charm for Prometheus"
-license = "Apache 2.0"
-python = "^3.8"
-readme = "README.md"
-homepage = "https://charmhub.io/prometheus-k8s"
-repository = "https://github.com/canonical/prometheus-operator"
-documentation = "https://charmhub.io/prometheus-k8s/docs"
 
 # Testing tools configuration
 [tool.coverage.run]
@@ -34,9 +25,9 @@ exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107", "E203"]
+ignore = ["W503", "E501", "D107"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104,C801"]
+per-file-ignores = ["tests/*:D100,D101,D102,D103"]
 docstring-convention = "google"
 # Check for properly formatted copyright header in each file
 copyright-check = "True"

--- a/src/charm.py
+++ b/src/charm.py
@@ -116,7 +116,7 @@ class PrometheusCharm(CharmBase):
 
         # push Prometheus config file to workload
         prometheus_config = self._prometheus_config()
-        container.push(PROMETHEUS_CONFIG, prometheus_config)
+        container.push(PROMETHEUS_CONFIG, prometheus_config, make_dirs=True)
         logger.info("Pushed new configuration")
 
         # push alert rules if any

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import shutil
 
 import pytest

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import logging
 from pathlib import Path
 

--- a/tests/integration/prometheus-tester/src/metrics.py
+++ b/tests/integration/prometheus-tester/src/metrics.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import random
 import time
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -6,6 +6,8 @@ import asyncio
 import logging
 
 import pytest
+from pytest_operator.plugin import OpsTest
+
 from helpers import (
     check_prometheus_is_ready,
     get_job_config_for,
@@ -21,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.abort_on_fail
 async def test_prometheus_scrape_relation_with_prometheus_tester(
-    ops_test, prometheus_charm, prometheus_tester_charm
+    ops_test: OpsTest, prometheus_charm, prometheus_tester_charm
 ):
     """Test basic functionality of prometheus_scrape relation interface."""
     prometheus_app_name = "prometheus"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -6,8 +6,6 @@ import asyncio
 import logging
 
 import pytest
-from pytest_operator.plugin import OpsTest
-
 from helpers import (
     check_prometheus_is_ready,
     get_job_config_for,
@@ -17,6 +15,7 @@ from helpers import (
     initial_workload_is_ready,
     oci_image,
 )
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/workload.py
+++ b/tests/integration/workload.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import logging
 
 import aiohttp

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import yaml
 from ops.testing import Harness
 
-from charm import PrometheusCharm, PROMETHEUS_CONFIG
+from charm import PROMETHEUS_CONFIG, PrometheusCharm
 
 MINIMAL_CONFIG = {}
 

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -19,11 +19,10 @@ from charms.prometheus_k8s.v0.prometheus_scrape import (
     RelationRoleMismatchError,
 )
 from deepdiff import DeepDiff
+from helpers import TempFolderSandbox
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.testing import Harness
-
-from .helpers import TempFolderSandbox
 
 RELATION_NAME = "metrics-endpoint"
 PROVIDER_META = f"""

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -28,7 +28,6 @@ requires:
     interface: {RELATION_INTERFACE}
 """
 
-FILES = {}
 
 ALERT_RULES = {
     "groups": [
@@ -76,11 +75,6 @@ ALERT_RULES = {
         }
     ]
 }
-
-
-def fake_push(self, path, content, **kwargs):
-    global FILES
-    FILES[path] = content
 
 
 class RemoteWriteConsumerCharm(CharmBase):
@@ -157,8 +151,6 @@ class TestRemoteWriteProvider(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
 
     @patch.object(KubernetesServicePatch, "_service_object", new=lambda *args: None)
-    @patch("ops.testing._TestingPebbleClient.remove_path")
-    @patch("ops.testing._TestingPebbleClient.push", new=fake_push)
     @patch("ops.testing._TestingModelBackend.network_get")
     def test_port_is_set(self, mock_net_get, *_):
         ip = "1.1.1.1"
@@ -177,8 +169,6 @@ class TestRemoteWriteProvider(unittest.TestCase):
 
     @patch.object(KubernetesServicePatch, "_service_object", new=lambda *args: None)
     @patch.object(Prometheus, "reload_configuration", new=lambda _: True)
-    @patch("ops.testing._TestingPebbleClient.remove_path")
-    @patch("ops.testing._TestingPebbleClient.push", new=fake_push)
     @patch("ops.testing._TestingModelBackend.network_get")
     def test_endpoint_url_with_ingress_and_external_url(self, mock_net_get, *_):
         ip = "1.1.1.1"
@@ -203,8 +193,6 @@ class TestRemoteWriteProvider(unittest.TestCase):
 
     @patch.object(KubernetesServicePatch, "_service_object", new=lambda *args: None)
     @patch.object(Prometheus, "reload_configuration", new=lambda _: True)
-    @patch("ops.testing._TestingPebbleClient.remove_path")
-    @patch("ops.testing._TestingPebbleClient.push", new=fake_push)
     @patch("ops.testing._TestingModelBackend.network_get")
     def test_multiple_units_with_ingress(self, mock_net_get, *_):
         ip = "1.1.1.1"
@@ -238,10 +226,8 @@ class TestRemoteWriteProvider(unittest.TestCase):
 
     @patch.object(KubernetesServicePatch, "_service_object", new=lambda *args: None)
     @patch.object(Prometheus, "reload_configuration", new=lambda _: True)
-    @patch("ops.testing._TestingPebbleClient.remove_path")
-    @patch("ops.testing._TestingPebbleClient.push")
     @patch("ops.testing._TestingModelBackend.network_get")
-    def test_alert_rules(self, mock_net_get, mock_push, *_):
+    def test_alert_rules(self, mock_net_get, *_):
         ip = "1.1.1.1"
         net_info = {"bind-addresses": [{"interface-name": "ens1", "addresses": [{"value": ip}]}]}
         mock_net_get.return_value = net_info
@@ -262,5 +248,3 @@ class TestRemoteWriteProvider(unittest.TestCase):
         for name, alert_group in alerts.items():
             group = next((group for group in ALERT_RULES["groups"] if group["name"] == name), None)
             self.assertDictEqual(alert_group, group)
-
-        mock_push.has_been_called()


### PR DESCRIPTION
This change makes use of OF test harness for push/pull.
Currently tests fail because of https://github.com/canonical/operator/issues/676
Confirmed by adding the following before remove_path.
```python
        container.make_dir(RULES_DIR, make_parents=True)
```