### PR TITLE
Fix the prometheus_remote_write docstrings

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -29,7 +29,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 logger = logging.getLogger(__name__)
@@ -756,12 +756,12 @@ class PrometheusRemoteWriteProvider(Object):
 
     ```
     provides:
-        prometheus-remote-write:  # Relation name
+        receive-remote-write:  # Relation name
             interface: prometheus_remote_write  # Relation interface
     ```
 
     About the name of the relation managed by this library: technically, you *could* change
-    the relation name, `prometheus-remote-write`, but that requires you to provide the new
+    the relation name, `receive-remote-write`, but that requires you to provide the new
     relation name to the `PrometheusRemoteWriteProducer` via the `relation_name` constructor
     argument. (The relation interface, on the other hand, is immutable and, if you were to change
     it, your charm would not be able to relate with other charms using the right relation


### PR DESCRIPTION
It still had `prometheus-remote-write`, not `receive-remote-write`,
which is the correct name for the relation.