### PR TITLE
Change return type of _remote_write_address to strictly string

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -14,7 +14,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Union
 
 import yaml
 from ops.charm import CharmBase, RelationEvent, RelationMeta, RelationRole
@@ -779,7 +779,7 @@ class PrometheusRemoteWriteProvider(Object):
         charm: CharmBase,
         relation_name: str = DEFAULT_RELATION_NAME,
         endpoint_schema: str = "http",
-        endpoint_address: Optional[str] = None,
+        endpoint_address: str = "",
         endpoint_port: Union[str, int] = 9090,
         endpoint_path: str = "/api/v1/write",
     ):

--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -29,7 +29,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -311,7 +311,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 
 logger = logging.getLogger(__name__)

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,7 @@
 import logging
 import os
 import re
-from typing import Dict, Optional
+from typing import Dict
 
 import yaml
 from charms.alertmanager_k8s.v0.alertmanager_dispatch import AlertmanagerConsumer
@@ -370,8 +370,8 @@ class PrometheusCharm(CharmBase):
         return self.config["web_external_url"] or f"{self.app.name}"
 
     @property
-    def _remote_write_address(self) -> Optional[str]:
-        return self._external_hostname if self.model.get_relation("ingress") else None
+    def _remote_write_address(self) -> str:
+        return self._external_hostname if self.model.get_relation("ingress") else ""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Discussion takes place in #206. Discussion is a continuation of [these comments](https://github.com/canonical/prometheus-k8s-operator/pull/205#discussion_r787556937) from a previous pull request.

(At the moment I think this should not be merged and the None kept.)

Fixes #206 