### PR TITLE
Add the changes NRPE exporter needs to prometheus_scrape

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1765,7 +1765,7 @@ class MetricsEndpointAggregator(Object):
         event.relation.data[self._charm.app]["scrape_jobs"] = json.dumps(jobs)
         event.relation.data[self._charm.app]["alert_rules"] = json.dumps({"groups": groups})
 
-    def set_target_job_data(self, targets: dict, app_name: str, **kwargs) -> None:
+    def _set_target_job_data(self, targets: dict, app_name: str, **kwargs) -> None:
         """Update scrape jobs in response to scrape target changes.
 
         When there is any change in relation data with any scrape
@@ -1775,7 +1775,7 @@ class MetricsEndpointAggregator(Object):
 
         Args:
             targets: a `dict` containing target information
-            app_name: a `str` identifying the applications
+            app_name: a `str` identifying the application
         """
         # new scrape job for the relation that has changed
         updated_job = self._static_scrape_job(targets, app_name, **kwargs)
@@ -2022,8 +2022,7 @@ class MetricsEndpointAggregator(Object):
         """Construct a static scrape job for an application.
 
         Args:
-            targets:
-                a dictionary providing hostname and port for all
+            targets: a dictionary providing hostname and port for all
                 scrape target. The keys of this dictionary are unit
                 names. Values corresponding to these keys are
                 themselves a dictionary with keys "hostname" and

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1765,9 +1765,7 @@ class MetricsEndpointAggregator(Object):
         event.relation.data[self._charm.app]["scrape_jobs"] = json.dumps(jobs)
         event.relation.data[self._charm.app]["alert_rules"] = json.dumps({"groups": groups})
 
-    def set_target_job_data(
-        self, targets: dict, app_name: str, additional_fields: Optional[dict] = None
-    ) -> None:
+    def set_target_job_data(self, targets: dict, app_name: str, **kwargs) -> None:
         """Update scrape jobs in response to scrape target changes.
 
         When there is any change in relation data with any scrape
@@ -1776,13 +1774,11 @@ class MetricsEndpointAggregator(Object):
         sameself.
 
         Args:
-            target: a `dict` containing target information
+            targets: a `dict` containing target information
             app_name: a `str` identifying the applications
-            additional_fields: an optional `dict` containing extra annotations
-                to be added to the job configuration
         """
         # new scrape job for the relation that has changed
-        updated_job = self._static_scrape_job(targets, app_name, additional_fields)
+        updated_job = self._static_scrape_job(targets, app_name, **kwargs)
 
         for relation in self.model.relations[self._prometheus_relation]:
             jobs = json.loads(relation.data[self._charm.app].get("scrape_jobs", "[]"))
@@ -2022,9 +2018,7 @@ class MetricsEndpointAggregator(Object):
 
         return labeled_rules
 
-    def _static_scrape_job(
-        self, targets, application_name, additional_fields: Optional[dict] = None
-    ) -> dict:
+    def _static_scrape_job(self, targets, application_name, **kwargs) -> dict:
         """Construct a static scrape job for an application.
 
         Args:
@@ -2036,8 +2030,6 @@ class MetricsEndpointAggregator(Object):
                 "port".
             application_name: a string name of the application for
                 which this static scrape job is being constructed.
-            additional_fields: an optional dict containing extra fields
-                to add to the job, used primarily by NRPE
 
         Returns:
             A dictionary corresponding to a Prometheus static scrape
@@ -2045,7 +2037,6 @@ class MetricsEndpointAggregator(Object):
             dictionary may be transformed into YAML and appended to
             the list of any existing list of Prometheus static configs.
         """
-        additional_fields = additional_fields or {}
         juju_model = self.model.name
         juju_model_uuid = self.model.uuid
         job = {
@@ -2063,10 +2054,9 @@ class MetricsEndpointAggregator(Object):
                 }
                 for unit_name, target in targets.items()
             ],
-            "relabel_configs": self._relabel_configs
-            + additional_fields.get("relabel_configs", []),
+            "relabel_configs": self._relabel_configs + kwargs.get("relabel_configs", []),
         }
-        job.update(additional_fields.get("updates", {}))
+        job.update(kwargs.get("updates", {}))
 
         return job
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -312,7 +312,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1066,6 +1066,9 @@ class MetricsEndpointConsumer(Object):
                 identifier = self._get_identifier_by_alert_rules(alert_rules)
 
             if not identifier:
+                logger.error(
+                    "Alert rules were found but no usable group or identifier was present"
+                )
                 continue
             alerts[identifier] = alert_rules
 
@@ -1099,7 +1102,7 @@ class MetricsEndpointConsumer(Object):
                 continue
 
         logger.warning(
-            "No labeled alert rules were found, and no 'scrape_metadata'"
+            "No labeled alert rules were found, and no 'scrape_metadata' "
             "was available. Using the alert group name as filename."
         )
         try:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -566,7 +566,7 @@ class JujuTopology:
     def identifier(self) -> str:
         """Format the topology information into a terse string."""
         # This is odd, but may have `None` as a model key
-        return "_".join([str(val) for val in self.as_dict().values()])
+        return "_".join([str(val) for val in self.as_dict().values()]).replace("/", "_")
 
     @property
     def promql_labels(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107", "E203", "D417"]
+ignore = ["W503", "E501", "D107", "E203"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 per-file-ignores = ["tests/*:D100,D101,D102,D103"]
 docstring-convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107", "E203"]
+ignore = ["W503", "E501", "D107", "E203", "D417"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 per-file-ignores = ["tests/*:D100,D101,D102,D103"]
 docstring-convention = "google"


### PR DESCRIPTION
Sync up this library, too. It was missed in the initial proxy work, and resurrecting it from git reflow was not fun.

Essentially, add a public method to invoke building a scrape target, and add the ability to add custom fields to the scrape job.