### PR TITLE
OPENG-588: Do not override provider metrics labels

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -333,6 +333,7 @@ class PrometheusCharm(CharmBase):
         prometheus_config["scrape_configs"].append(default_config)  # type: ignore
         scrape_jobs = self.metrics_consumer.jobs()
         for job in scrape_jobs:
+            job["honor_labels"] = True
             prometheus_config["scrape_configs"].append(job)  # type: ignore
 
         return yaml.dump(prometheus_config)


### PR DESCRIPTION
This commit ensures that metrics labels from the provider are not
overriden by Prometheus. Since the honor labels attribute for all
jobs is enfored by the MetricsEndpointConsumer it can not itself
be overriden by any MetricsEndpointProvider.