### PR TITLE
Load both .rule and .rules files

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -442,7 +442,7 @@ class AlertRules:
         """Helper function for getting all files in a directory that have a matching suffix.
 
         Args:
-            dir_path: path to the director to glob from.
+            dir_path: path to the directory to glob from.
             suffixes: list of suffixes to include in the glob (items should begin with a period).
             recursive: a flag indicating whether a glob is recursive (nested) or not.
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -449,7 +449,7 @@ class AlertRules:
         Returns:
             List of files in `dir_path` that have one of the suffixes specified in `suffixes`.
         """
-        all_files_in_dir = Path(dir_path).glob("**/*" if recursive else "*")
+        all_files_in_dir = dir_path.glob("**/*" if recursive else "*")
         return list(filter(lambda f: f.is_file() and f.suffix in suffixes, all_files_in_dir))
 
     def _from_dir(self, dir_path: Path, recursive: bool) -> List[dict]:

--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -435,6 +435,23 @@ class AlertRules:
         # filter to remove empty strings
         return "_".join(filter(None, group_name_parts))
 
+    @classmethod
+    def _multi_suffix_glob(
+        cls, dir_path: Path, suffixes: List[str], recursive: bool = True
+    ) -> list:
+        """Helper function for getting all files in a directory that have a matching suffix.
+
+        Args:
+            dir_path: path to the director to glob from.
+            suffixes: list of suffixes to include in the glob (items should begin with a period).
+            recursive: a flag indicating whether a glob is recursive (nested) or not.
+
+        Returns:
+            List of files in `dir_path` that have one of the suffixes specified in `suffixes`.
+        """
+        all_files_in_dir = Path(dir_path).glob("**/*" if recursive else "*")
+        return list(filter(lambda f: f.is_file() and f.suffix in suffixes, all_files_in_dir))
+
     def _from_dir(self, dir_path: Path, recursive: bool) -> List[dict]:
         """Read all rule files in a directory.
 
@@ -453,8 +470,7 @@ class AlertRules:
         alert_groups = []  # type: List[dict]
 
         # Gather all alerts into a list of groups
-        paths = dir_path.glob("**/*.rule" if recursive else "*.rule")
-        for file_path in filter(Path.is_file, paths):
+        for file_path in self._multi_suffix_glob(dir_path, [".rule", ".rules"], recursive):
             alert_groups_from_file = self._from_file(dir_path, file_path)
             if alert_groups_from_file:
                 logger.debug("Reading alert rule from %s", file_path)

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -866,7 +866,7 @@ class AlertRules:
         Returns:
             List of files in `dir_path` that have one of the suffixes specified in `suffixes`.
         """
-        all_files_in_dir = Path(dir_path).glob("**/*" if recursive else "*")
+        all_files_in_dir = dir_path.glob("**/*" if recursive else "*")
         return list(filter(lambda f: f.is_file() and f.suffix in suffixes, all_files_in_dir))
 
     def _from_dir(self, dir_path: Path, recursive: bool) -> List[dict]:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -859,7 +859,7 @@ class AlertRules:
         """Helper function for getting all files in a directory that have a matching suffix.
 
         Args:
-            dir_path: path to the director to glob from.
+            dir_path: path to the directory to glob from.
             suffixes: list of suffixes to include in the glob (items should begin with a period).
             recursive: a flag indicating whether a glob is recursive (nested) or not.
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -852,6 +852,23 @@ class AlertRules:
         # filter to remove empty strings
         return "_".join(filter(None, group_name_parts))
 
+    @classmethod
+    def _multi_suffix_glob(
+        cls, dir_path: Path, suffixes: List[str], recursive: bool = True
+    ) -> list:
+        """Helper function for getting all files in a directory that have a matching suffix.
+
+        Args:
+            dir_path: path to the director to glob from.
+            suffixes: list of suffixes to include in the glob (items should begin with a period).
+            recursive: a flag indicating whether a glob is recursive (nested) or not.
+
+        Returns:
+            List of files in `dir_path` that have one of the suffixes specified in `suffixes`.
+        """
+        all_files_in_dir = Path(dir_path).glob("**/*" if recursive else "*")
+        return list(filter(lambda f: f.is_file() and f.suffix in suffixes, all_files_in_dir))
+
     def _from_dir(self, dir_path: Path, recursive: bool) -> List[dict]:
         """Read all rule files in a directory.
 
@@ -870,8 +887,7 @@ class AlertRules:
         alert_groups = []  # type: List[dict]
 
         # Gather all alerts into a list of groups
-        paths = dir_path.glob("**/*.rule" if recursive else "*.rule")
-        for file_path in filter(Path.is_file, paths):
+        for file_path in self._multi_suffix_glob(dir_path, [".rule", ".rules"], recursive):
             alert_groups_from_file = self._from_file(dir_path, file_path)
             if alert_groups_from_file:
                 logger.debug("Reading alert rule from %s", file_path)


### PR DESCRIPTION
Since the introduction of the dual rule format (#161 - one rule per file as well as groups of alert rules), two file extensions emerged: `.rule` and `.rules`.
This PR adds `.rule` to the files being globbed and loaded from disk.