### PR TITLE
Catch uncaught exception

### DIFF
--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -37,7 +37,9 @@ class Prometheus:
           True if reload succeeded (returned 200 OK); False otherwise.
         """
         url = f"{self.base_url}/-/reload"
-        errors = list(range(400, 452)) + list(range(500, 512))
+        # http status codes see:
+        # https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+        http_errors_codes = list(range(400, 452)) + list(range(500, 512))
         retries = 5
         try:
             s = Session()
@@ -46,7 +48,7 @@ class Prometheus:
                 read=retries,
                 connect=retries,
                 backoff_factor=0.1,
-                status_forcelist=errors,
+                status_forcelist=http_errors_codes,
             )
             s.mount("http://", HTTPAdapter(max_retries=retry))
             response = s.post(url)


### PR DESCRIPTION
This PR fixes #228 

The `ReadTiemout` exception was not catched


---
~~To reload Prometheus configuration we were using `response = post(url, timeout=self.api_timeout)`. This is nice and simple but the problem is that networks are unreliable or even Prometheus is under heavy load and cannot respond before `self.api_timeout`.
So it's a good idea to wrap these network calls with retries to avoid "false negatives" .~~ 

~~Now we are using the `Session` and `Retry` objects from the `request` module, with the following [retry setup](https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html?highlight=Retry#urllib3.util.Retry):~~

~~- retries: 5~~
~~- backoff_factor: 0.1~~
  ~~- _A backoff factor to apply between attempts after the second try (most errors are resolved immediately by a second try without a delay). urllib3 will sleep for:_ `{backoff factor} * (2 ** ({number of total retries} - 1))`~~
  
  ~~Some good examples of this implementation can be found [here](https://stackoverflow.com/questions/23267409/how-to-implement-retry-mechanism-into-python-requests-library),  [here](https://stackoverflow.com/questions/58724052/urllib3-how-to-get-response-when-maxretryerror-is-thrown), and [here](https://www.peterbe.com/plog/best-practice-with-retries-with-requests)~~ 
  