### PR TITLE
Add tox envs for deploying a local charm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,8 @@ $ charmcraft pack
 
 ### Deploy
 
-There are two ways of deploying the prometheus-k8s operator, with and without 
-promql-transform.  Deploying the charm without PromQL Transform means you won't 
+There are two ways of deploying the prometheus-k8s operator, with and without
+promql-transform.  Deploying the charm without PromQL Transform means you won't
 get any Juju topology labels  injected into your alert rule expressions.
 
 #### Without PromQL Transform
@@ -74,7 +74,7 @@ $ juju deploy \
 #### With PromQL Transform
 
 Place the binary of your selected promql-transform version in the root of the prometheus-k8s
-charm directory. Official binaries are available from the 
+charm directory. Official binaries are available from the
 [promql-transform repository](https://github.com/canonical/promql-transform).
 
 ```bash
@@ -82,6 +82,12 @@ $ juju deploy \
     ./prometheus-k8s_ubuntu-20.04-amd64.charm \
     --resource prometheus-image=ubuntu/prometheus:latest \
     --resource promql-transform-amd64=./promql-transform
+```
+
+or, using a `tox` environment,
+
+```shell
+$ tox -e deploy-amd64
 ```
 
 ## Linting

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,6 +22,12 @@ For more information about CharmHub channels, refer to the [Juju charm store](ht
 Refer to the [Publish your operator in Charmhub](https://discourse.charmhub.io/t/publish-your-operator-in-charmhub) documentation.
 After a `latest/stable` release, it is expected that the version of the charm is the same as the one in `latest/candidate`, and those two channels will diverge again when we are ramping up through `latest/candidate` releases for a new `latest/stable` release.
 
+Using a `tox` environment, this a can be accomplished with
+
+```shell
+tox -e publish-edge -- --revision=19
+```
+
 ## A note on granularity of revisions
 
 We believe in shipping often and with confidence.

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ src_path = {toxinidir}/src
 tst_path = {toxinidir}/tests
 lib_path = {toxinidir}/lib/charms/prometheus_k8s
 all_path = {[vars]src_path} {[vars]tst_path} {[vars]lib_path}
+promql_amd64_archive = https://github.com/canonical/promql-transform/releases/download/2.25.2-1rc1/promql-transform_2.25.2-1rc1_linux_amd64.tar.gz
+promql_arm64_archive = https://github.com/canonical/promql-transform/releases/download/2.25.2-1rc1/promql-transform_2.25.2-1rc1_linux_arm64.tar.gz
 
 [testenv]
 basepython = python3
@@ -26,6 +28,34 @@ passenv =
   HTTP_PROXY
   HTTPS_PROXY
   NO_PROXY
+
+[testenv:deploy-{amd64,arm64}]
+description = Deploy local charm with promql-transform
+allowlist_externals =
+    wget
+    tar
+    juju
+commands =
+    # Download arch-appropriate promql-transform
+    amd64: wget -O {temp_dir}/promql-transform.tar.gz {[vars]promql_amd64_archive}
+    arm64: wget -O {temp_dir}/promql-transform.tar.gz {[vars]promql_arm64_archive}
+    tar --overwrite -C {temp_dir} -xzvf {temp_dir}/promql-transform.tar.gz promql-transform
+    amd64: juju deploy --resource prometheus-image=ubuntu/prometheus:latest --resource promql-transform-amd64={temp_dir}/promql-transform ./prometheus-k8s_ubuntu-20.04-amd64.charm {posargs}
+    arm64: juju deploy --resource prometheus-image=ubuntu/prometheus:latest --resource promql-transform-arm64={temp_dir}/promql-transform ./prometheus-k8s_ubuntu-20.04-arm64.charm {posargs}
+
+[testenv:refresh-{amd64,arm64}]
+description = refresh charm from local path, with promql-transform
+allowlist_externals =
+    wget
+    tar
+    juju
+commands =
+    # Download arch-appropriate promql-transform
+    amd64: wget -O {temp_dir}/promql-transform.tar.gz {[vars]promql_amd64_archive}
+    arm64: wget -O {temp_dir}/promql-transform.tar.gz {[vars]promql_arm64_archive}
+    tar --overwrite -C {temp_dir} -xzvf promql-transform.tar.gz promql-transform
+    amd64: juju refresh --resource promql-transform-amd64={temp_dir}/promql-transform --path=./prometheus-k8s_ubuntu-20.04-amd64.charm {posargs}
+    arm64: juju refresh --resource promql-transform-arm64={temp_dir}/promql-transform --path=./prometheus-k8s_ubuntu-20.04-arm64.charm {posargs}
 
 [testenv:fmt]
 description = Apply coding style standards to code

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,15 @@ commands =
     amd64: juju refresh --resource promql-transform-amd64={temp_dir}/promql-transform --path=./prometheus-k8s_ubuntu-20.04-amd64.charm {posargs}
     arm64: juju refresh --resource promql-transform-arm64={temp_dir}/promql-transform --path=./prometheus-k8s_ubuntu-20.04-arm64.charm {posargs}
 
+[testenv:publish-{edge,beta}]
+description = release a previously uploaded charm to a charmhub edge/beta channel
+allowlist_externals =
+    charmcraft
+commands =
+    # Usage example: tox -e publish-edge -- --revision=19
+    edge: charmcraft release prometheus-k8s --channel=edge --resource=prometheus-image:1 --resource=promql-transform-amd64:3 {posargs}
+    beta: charmcraft release prometheus-k8s --channel=beta --resource=prometheus-image:1 --resource=promql-transform-amd64:3 {posargs}
+
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =


### PR DESCRIPTION
This PR adds two parametrized tox envs for deploying charms with promql:

```shell
tox -e deploy-amd64
tox -e refresh-amd64 -- prom
```