### PR TITLE
Adjust reload API calls to Prometheus when ingress is related

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -212,9 +212,8 @@ class PrometheusCharm(CharmBase):
             # We need to ensure there is a '/' character at the end
             # of the path, or Prometheus will not correctly
             # concatenate redirect headers, e.g., sending back a
-            # 'Location': '/test-prometheus-k8s-0-/reload' header
-            # (see the lack of '/' between '-/reload' and the previous
-            # part of the path)
+            # 'Location': '/test-prometheus-k8s-0-/reload' header instead of
+            # 'Location': '/test-prometheus-k8s-0/-/reload'
             if not path.endswith("/"):
                 path = f"{path}/"
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -212,18 +212,6 @@ class PrometheusCharm(CharmBase):
         external_url = self._external_url
         args.append(f"--web.external-url={external_url}")
 
-        path = self._web_route_prefix
-        if not external_url and path:
-            # We need to ensure there is a '/' character at the end
-            # of the path, or Prometheus will not correctly
-            # concatenate redirect headers, e.g., sending back a
-            # 'Location': '/test-prometheus-k8s-0-/reload' header instead of
-            # 'Location': '/test-prometheus-k8s-0/-/reload'
-            if not path.endswith("/"):
-                path = f"{path}/"
-
-            args.append(f"--web.route-prefix={path}")
-
         if self.model.get_relation(DEFAULT_REMOTE_WRITE_RELATION_NAME):
             args.append("--enable-feature=remote-write-receiver")
 
@@ -370,13 +358,6 @@ class PrometheusCharm(CharmBase):
             bind_address = str(bind_address)
 
         return bind_address
-
-    @property
-    def _web_route_prefix(self) -> str:
-        if path := urlparse(self._external_url).path:
-            return str(path).strip()
-
-        return None
 
     @property
     def _external_url(self) -> str:

--- a/src/charm.py
+++ b/src/charm.py
@@ -208,7 +208,7 @@ class PrometheusCharm(CharmBase):
         external_url = self._external_url
         args.append(f"--web.external-url={external_url}")
 
-        if path := self._web_route_prefix.strip():
+        if path := self._web_route_prefix:
             # We need to ensure there is a '/' character at the end
             # of the path, or Prometheus will not correctly
             # concatenate redirect headers, e.g., sending back a
@@ -368,7 +368,10 @@ class PrometheusCharm(CharmBase):
 
     @property
     def _web_route_prefix(self) -> str:
-        return urlparse(self._external_url).path or ""
+        if path := urlparse(self._external_url):
+            return str(path).strip()
+
+        return None
 
     @property
     def _external_url(self) -> str:

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -48,7 +48,6 @@ class Prometheus:
             web_route_prefix = f"{web_route_prefix}/"
 
         self.base_url = urljoin(f"http://{host}:{port}", web_route_prefix)
-        logger.error(f"Base URL: {self.base_url}")
         self.api_timeout = api_timeout
 
     def reload_configuration(self) -> bool:

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -44,7 +44,7 @@ class Prometheus:
         """
         url = urljoin(self.base_url, "/-/reload")
         try:
-            response = post(url, timeout=self.api_timeout, allow_redirects=False)
+            response = post(url, timeout=self.api_timeout)
 
             if response.status_code == 200:
                 return True

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -68,6 +68,7 @@ class Prometheus:
 
         try:
             response = get(url, timeout=self.api_timeout)
+
             if response.status_code == 200:
                 info = response.json()
                 if info and info["status"] == "success":
@@ -86,4 +87,4 @@ class Prometheus:
             empty string if Prometheus server is not reachable.
         """
         info = self._build_info()
-        return info.get(f"{self.base_url}/version", "")
+        return info.get("version", "")

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -4,6 +4,7 @@
 """Helper for interacting with Prometheus throughout the charm's lifecycle."""
 
 import logging
+from urllib.parse import urljoin
 
 from requests import get, post
 from requests.exceptions import ConnectionError, ConnectTimeout, ReadTimeout
@@ -30,10 +31,7 @@ class Prometheus:
               when we relate to an ingress.
             api_timeout: Optional; timeout (in seconds) to observe when interacting with the API.
         """
-        if web_route_prefix and not web_route_prefix.startswith("/"):
-            web_route_prefix = f"/{web_route_prefix}"
-
-        self.base_url = f"http://{host}:{port}{web_route_prefix or ''}"
+        self.base_url = urljoin(f"http://{host}:{port}", web_route_prefix)
         self.api_timeout = api_timeout
 
     def reload_configuration(self) -> bool:
@@ -44,7 +42,7 @@ class Prometheus:
         Returns:
           True if reload succeeded (returned 200 OK); False otherwise.
         """
-        url = f"{self.base_url}/-/reload"
+        url = urljoin(self.base_url, "/-/reload")
         try:
             response = post(url, timeout=self.api_timeout, allow_redirects=False)
 
@@ -64,7 +62,7 @@ class Prometheus:
             instance is not reachable then an empty dictionary is
             returned.
         """
-        url = f"{self.base_url}/api/v1/status/buildinfo"
+        url = urljoin(self.base_url, "/api/v1/status/buildinfo")
 
         try:
             response = get(url, timeout=self.api_timeout)

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -31,7 +31,24 @@ class Prometheus:
               when we relate to an ingress.
             api_timeout: Optional; timeout (in seconds) to observe when interacting with the API.
         """
+        if web_route_prefix and not web_route_prefix.endswith("/"):
+            # If we do not add the '/' and the end, we will lose the last
+            # bit of the path:
+            #
+            # BAD:
+            #
+            # >>> urljoin('http://some/more', 'thing')
+            #   'http://some/thing'
+            #
+            # GOOD:
+            #
+            # >>> urljoin('http://some/more/', 'thing')
+            #   'http://some/more/thing'
+            #
+            web_route_prefix = f"{web_route_prefix}/"
+
         self.base_url = urljoin(f"http://{host}:{port}", web_route_prefix)
+        logger.error(f"Base URL: {self.base_url}")
         self.api_timeout = api_timeout
 
     def reload_configuration(self) -> bool:
@@ -42,7 +59,7 @@ class Prometheus:
         Returns:
           True if reload succeeded (returned 200 OK); False otherwise.
         """
-        url = urljoin(self.base_url, "/-/reload")
+        url = urljoin(self.base_url, "-/reload")
         try:
             response = post(url, timeout=self.api_timeout)
 
@@ -62,7 +79,7 @@ class Prometheus:
             instance is not reachable then an empty dictionary is
             returned.
         """
-        url = urljoin(self.base_url, "/api/v1/status/buildinfo")
+        url = urljoin(self.base_url, "api/v1/status/buildinfo")
 
         try:
             response = get(url, timeout=self.api_timeout)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -9,42 +9,84 @@ from prometheus_server import Prometheus
 
 
 class TestServer(unittest.TestCase):
-    def setUp(self):
-        self.prometheus = Prometheus("localhost", 9090)
+    class _TestServerWithoutRoutePrefix(unittest.TestCase):
+        def setUp(self):
+            self.prometheus = Prometheus("localhost", 9090)
 
-    @responses.activate
-    def test_prometheus_server_returns_valid_data(self):
-        version = "1.0.0"
+        @responses.activate
+        def test_prometheus_server_returns_valid_data(self):
+            version = "1.0.0"
 
-        responses.add(
-            responses.GET,
-            "http://localhost:9090/api/v1/status/buildinfo",
-            json={
-                "status": "success",
-                "data": {"version": version},
-            },
-            status=200,
-        )
+            responses.add(
+                responses.GET,
+                "http://localhost:9090/api/v1/status/buildinfo",
+                json={
+                    "status": "success",
+                    "data": {"version": version},
+                },
+                status=200,
+            )
 
-        got_version = self.prometheus.version()
-        self.assertEqual(got_version, version)
+            got_version = self.prometheus.version()
+            self.assertEqual(got_version, version)
 
-    @responses.activate
-    def test_prometheus_server_reload_configuration_success(self):
-        responses.add(
-            responses.POST,
-            "http://localhost:9090/-/reload",
-            status=200,
-        )
+        @responses.activate
+        def test_prometheus_server_reload_configuration_success(self):
+            responses.add(
+                responses.POST,
+                "http://localhost:9090/-/reload",
+                status=200,
+            )
 
-        self.assertTrue(self.prometheus.reload_configuration())
+            self.assertTrue(self.prometheus.reload_configuration())
 
-    @responses.activate
-    def test_prometheus_server_reload_configuration_failure(self):
-        responses.add(
-            responses.POST,
-            "http://localhost:9090/-/reload",
-            status=500,
-        )
+        @responses.activate
+        def test_prometheus_server_reload_configuration_failure(self):
+            responses.add(
+                responses.POST,
+                "http://localhost:9090/-/reload",
+                status=500,
+            )
 
-        self.assertFalse(self.prometheus.reload_configuration())
+            self.assertFalse(self.prometheus.reload_configuration())
+
+    class _TestServerWithRoutePrefix(unittest.TestCase):
+        def setUp(self):
+            self.prometheus = Prometheus("localhost", 9090, "/foobar")
+
+        @responses.activate
+        def test_prometheus_server_returns_valid_data(self):
+            version = "1.0.0"
+
+            responses.add(
+                responses.GET,
+                "http://localhost:9090/foobar/api/v1/status/buildinfo",
+                json={
+                    "status": "success",
+                    "data": {"version": version},
+                },
+                status=200,
+            )
+
+            got_version = self.prometheus.version()
+            self.assertEqual(got_version, version)
+
+        @responses.activate
+        def test_prometheus_server_reload_configuration_success(self):
+            responses.add(
+                responses.POST,
+                "http://localhost:9090/foobar/-/reload",
+                status=200,
+            )
+
+            self.assertTrue(self.prometheus.reload_configuration())
+
+        @responses.activate
+        def test_prometheus_server_reload_configuration_failure(self):
+            responses.add(
+                responses.POST,
+                "http://localhost:9090/foobar/-/reload",
+                status=500,
+            )
+
+            self.assertFalse(self.prometheus.reload_configuration())

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -8,85 +8,89 @@ import responses
 from prometheus_server import Prometheus
 
 
-class TestServer(unittest.TestCase):
-    class _TestServerWithoutRoutePrefix(unittest.TestCase):
-        def setUp(self):
-            self.prometheus = Prometheus("localhost", 9090)
+class TestServerPrefix(unittest.TestCase):
+    @responses.activate
+    def test_prometheus_server_without_route_prefix_returns_valid_data(self):
+        self.prometheus = Prometheus("localhost", 9090)
 
-        @responses.activate
-        def test_prometheus_server_returns_valid_data(self):
-            version = "1.0.0"
+        version = "1.0.0"
 
-            responses.add(
-                responses.GET,
-                "http://localhost:9090/api/v1/status/buildinfo",
-                json={
-                    "status": "success",
-                    "data": {"version": version},
-                },
-                status=200,
-            )
+        responses.add(
+            responses.GET,
+            "http://localhost:9090/api/v1/status/buildinfo",
+            json={
+                "status": "success",
+                "data": {"version": version},
+            },
+            status=200,
+        )
 
-            got_version = self.prometheus.version()
-            self.assertEqual(got_version, version)
+        got_version = self.prometheus.version()
+        self.assertEqual(got_version, version)
 
-        @responses.activate
-        def test_prometheus_server_reload_configuration_success(self):
-            responses.add(
-                responses.POST,
-                "http://localhost:9090/-/reload",
-                status=200,
-            )
+    @responses.activate
+    def test_prometheus_server_without_route_prefix_reload_configuration_success(self):
+        self.prometheus = Prometheus("localhost", 9090)
 
-            self.assertTrue(self.prometheus.reload_configuration())
+        responses.add(
+            responses.POST,
+            "http://localhost:9090/-/reload",
+            status=200,
+        )
 
-        @responses.activate
-        def test_prometheus_server_reload_configuration_failure(self):
-            responses.add(
-                responses.POST,
-                "http://localhost:9090/-/reload",
-                status=500,
-            )
+        self.assertTrue(self.prometheus.reload_configuration())
 
-            self.assertFalse(self.prometheus.reload_configuration())
+    @responses.activate
+    def test_prometheus_server_without_route_prefix_reload_configuration_failure(self):
+        self.prometheus = Prometheus("localhost", 9090)
 
-    class _TestServerWithRoutePrefix(unittest.TestCase):
-        def setUp(self):
-            self.prometheus = Prometheus("localhost", 9090, "/foobar")
+        responses.add(
+            responses.POST,
+            "http://localhost:9090/-/reload",
+            status=500,
+        )
 
-        @responses.activate
-        def test_prometheus_server_returns_valid_data(self):
-            version = "1.0.0"
+        self.assertFalse(self.prometheus.reload_configuration())
 
-            responses.add(
-                responses.GET,
-                "http://localhost:9090/foobar/api/v1/status/buildinfo",
-                json={
-                    "status": "success",
-                    "data": {"version": version},
-                },
-                status=200,
-            )
+    @responses.activate
+    def test_prometheus_server_with_route_prefix_returns_valid_data(self):
+        self.prometheus = Prometheus("localhost", 9090, "/foobar")
 
-            got_version = self.prometheus.version()
-            self.assertEqual(got_version, version)
+        version = "1.0.0"
 
-        @responses.activate
-        def test_prometheus_server_reload_configuration_success(self):
-            responses.add(
-                responses.POST,
-                "http://localhost:9090/foobar/-/reload",
-                status=200,
-            )
+        responses.add(
+            responses.GET,
+            "http://localhost:9090/foobar/api/v1/status/buildinfo",
+            json={
+                "status": "success",
+                "data": {"version": version},
+            },
+            status=200,
+        )
 
-            self.assertTrue(self.prometheus.reload_configuration())
+        got_version = self.prometheus.version()
+        self.assertEqual(got_version, version)
 
-        @responses.activate
-        def test_prometheus_server_reload_configuration_failure(self):
-            responses.add(
-                responses.POST,
-                "http://localhost:9090/foobar/-/reload",
-                status=500,
-            )
+    @responses.activate
+    def test_prometheus_server_with_route_prefix_reload_configuration_success(self):
+        self.prometheus = Prometheus("localhost", 9090, "/foobar")
 
-            self.assertFalse(self.prometheus.reload_configuration())
+        responses.add(
+            responses.POST,
+            "http://localhost:9090/foobar/-/reload",
+            status=200,
+        )
+
+        self.assertTrue(self.prometheus.reload_configuration())
+
+    @responses.activate
+    def test_prometheus_server_with_route_prefix_reload_configuration_failure(self):
+        self.prometheus = Prometheus("localhost", 9090, "/foobar")
+
+        responses.add(
+            responses.POST,
+            "http://localhost:9090/foobar/-/reload",
+            status=500,
+        )
+
+        self.assertFalse(self.prometheus.reload_configuration())


### PR DESCRIPTION
Ensure that, if an ingress is related over the `ingress` relation, if we need to set the `--web.route-prefix` argument, we correctly take it into account for the requests that we issue to Prometheus, e.g., to reload the configurations.