### PR TITLE
Updated release and scrape job name documentation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,6 +22,16 @@ For more information about CharmHub channels, refer to the [Juju charm store](ht
 Refer to the [Publish your operator in Charmhub](https://discourse.charmhub.io/t/publish-your-operator-in-charmhub) documentation.
 After a `latest/stable` release, it is expected that the version of the charm is the same as the one in `latest/candidate`, and those two channels will diverge again when we are ramping up through `latest/candidate` releases for a new `latest/stable` release.
 
+It is **important** to note that when making new releases of this charm **two** resource need to be bound to it
+- The container OCI image : `prometheus-image`
+- The PromQL transform binary : `promql-transform-amd64`
+
+An example of the charmcraft command to publish a new release is shown below.
+```
+charmcraft release prometheus-k8s --channel=beta --revision=19 --resource=prometheus-image:1 --resource=promql-transform-amd64:3
+```
+Note: The charm revision and resource revisions will need to be set appropriately.
+
 ## A note on granularity of revisions
 
 We believe in shipping often and with confidence.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,7 +22,7 @@ For more information about CharmHub channels, refer to the [Juju charm store](ht
 Refer to the [Publish your operator in Charmhub](https://discourse.charmhub.io/t/publish-your-operator-in-charmhub) documentation.
 After a `latest/stable` release, it is expected that the version of the charm is the same as the one in `latest/candidate`, and those two channels will diverge again when we are ramping up through `latest/candidate` releases for a new `latest/stable` release.
 
-It is **important** to note that when making new releases of this charm **two** resources need to be bound to it
+**Important:** when making new releases of this charm, **two** resources need to be bound:
 - The container OCI image : `prometheus-image`
 - The PromQL transform binary : `promql-transform-amd64`
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,7 +22,7 @@ For more information about CharmHub channels, refer to the [Juju charm store](ht
 Refer to the [Publish your operator in Charmhub](https://discourse.charmhub.io/t/publish-your-operator-in-charmhub) documentation.
 After a `latest/stable` release, it is expected that the version of the charm is the same as the one in `latest/candidate`, and those two channels will diverge again when we are ramping up through `latest/candidate` releases for a new `latest/stable` release.
 
-It is **important** to note that when making new releases of this charm **two** resource need to be bound to it
+It is **important** to note that when making new releases of this charm **two** resources need to be bound to it
 - The container OCI image : `prometheus-image`
 - The PromQL transform binary : `promql-transform-amd64`
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -157,7 +157,7 @@ each job must be given a unique name. For example
 ]
 ```
 
-**Important:** that the `job_name` should be a fixed string (e.g. hardcoded literal).
+**Important:** `job_name` should be a fixed string (e.g. hardcoded literal).
 For instance, if you include variable elements, like your `unit.name`, it may break
 the continuity of the metrics time series gathered by Prometheus when the leader unit
 changes (e.g. on upgrade or rescale).

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -157,6 +157,12 @@ each job must be given a unique name. For example
 ]
 ```
 
+It is **important** to note that the `job_name` must be a static
+hardcoded string. For instance **do not** set the job name using your
+charm's `unit.name`. If the job name changes on upgrading your charm,
+scaling the number of units etc., this will break the continuity of
+the metrics time series gathered by Prometheus.
+
 It is also possible to configure other scrape related parameters using
 these job specifications as described by the Prometheus
 [documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -157,11 +157,11 @@ each job must be given a unique name. For example
 ]
 ```
 
-It is **important** to note that the `job_name` must be a static
-hardcoded string. For instance **do not** set the job name using your
-charm's `unit.name`. If the job name changes on upgrading your charm,
-scaling the number of units etc., this will break the continuity of
-the metrics time series gathered by Prometheus.
+It is **important** to note that the `job_name` should be a fixed
+string (e.g. hardcoded literal). For instance, if you include your charm's
+`unit.name`, it would break the continuity of the metrics time series 
+gathered by Prometheus when the leader unit changes (e.g. on upgrade
+or rescale).
 
 It is also possible to configure other scrape related parameters using
 these job specifications as described by the Prometheus

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -157,11 +157,10 @@ each job must be given a unique name. For example
 ]
 ```
 
-It is **important** to note that the `job_name` should be a fixed
-string (e.g. hardcoded literal). For instance, if you include your charm's
-`unit.name`, it would break the continuity of the metrics time series 
-gathered by Prometheus when the leader unit changes (e.g. on upgrade
-or rescale).
+**Important:** that the `job_name` should be a fixed string (e.g. hardcoded literal).
+For instance, if you include variable elements, like your `unit.name`, it may break
+the continuity of the metrics time series gathered by Prometheus when the leader unit
+changes (e.g. on upgrade or rescale).
 
 It is also possible to configure other scrape related parameters using
 these job specifications as described by the Prometheus


### PR DESCRIPTION
This commit refines tow aspects of the charm documentation
1. The charmcraft command to publish the charm is now explicitly
 specified.
2. An advisory on how the select a scrape job name for use with
 the prometheus_scrape interface has now been added.