### PR TITLE
Use hostname instead of IP address

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 import json
+import socket
 import unittest
 from unittest.mock import patch
 
@@ -68,7 +69,8 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(True)
 
         plan = self.harness.get_container_pebble_plan("prometheus")
-        self.assertEqual(cli_arg(plan, "--web.external-url"), "http://1.1.1.1:9090")
+        fqdn = socket.getfqdn()
+        self.assertEqual(cli_arg(plan, "--web.external-url"), f"http://{fqdn}:9090")
 
     @patch_network_get(private_address="1.1.1.1")
     def test_ingress_relation_set(self):
@@ -78,7 +80,8 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation_unit(rel_id, "traefik-ingress/0")
 
         plan = self.harness.get_container_pebble_plan("prometheus")
-        self.assertEqual(cli_arg(plan, "--web.external-url"), "http://1.1.1.1:9090")
+        fqdn = socket.getfqdn()
+        self.assertEqual(cli_arg(plan, "--web.external-url"), f"http://{fqdn}:9090")
 
     @patch_network_get(private_address="1.1.1.1")
     def test_web_external_url_has_precedence_over_ingress_relation(self):

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -163,6 +163,7 @@ class TestRemoteWriteProvider(unittest.TestCase):
 
     @patch.object(KubernetesServicePatch, "_service_object", new=lambda *args: None)
     @patch.object(Prometheus, "reload_configuration", new=lambda _: True)
+    @patch("socket.getfqdn", new=lambda *args: "fqdn")
     @patch_network_get(private_address="1.1.1.1")
     def test_port_is_set(self, *unused):
         self.harness.begin_with_initial_hooks()
@@ -171,7 +172,7 @@ class TestRemoteWriteProvider(unittest.TestCase):
         self.harness.add_relation_unit(rel_id, "consumer/0")
         self.assertEqual(
             self.harness.get_relation_data(rel_id, self.harness.charm.unit.name),
-            {"remote_write": json.dumps({"url": "http://1.1.1.1:9090/api/v1/write"})},
+            {"remote_write": json.dumps({"url": "http://fqdn:9090/api/v1/write"})},
         )
         self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
 


### PR DESCRIPTION
Use hostname instead of IP address to avoid issues with pod churn. Also, make sure we update remote write to use this on charm upgrade.

QA: no specific steps here other than just that Prometheus generally works.