### PR TITLE
Clarify the expected value of the web_external_url config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,15 @@ options:
       Prometheus itself. If the URL has a path portion, it will be used to
       prefix all HTTP endpoints served by Prometheus.
 
+      The URL provided must point to the root of the Prometheus web application,
+      e.g.:
+
+      http://foo.bar/
+      
+      Note, do *not* set this configuration to a specific to an API path, e.g.,
+      
+      http://foo.bar//api/v1/write  # DO NOT TRY THIS AT HOME
+
       This configuration option takes precedence over the URL provided over
       the "ingress" relation.
     type: string


### PR DESCRIPTION
## Issue

The current description of `web_external_url` caused doubts in one of our devs, so it is likely to cause the same or more in others.

## Solution

Improved the configuration description.

## Context

N/A

## Testing Instructions

Grab a random colleague, let them read the new config description and ask them if it is likely to make sense to someone not well-versed in Prometheus.

## Release Notes

* Clarified the expected value for the `web_external_url` configuration option to point to the root of the Prometheus Web API, rather than one HTTP endpoint like the one for remote-write