### PR TITLE
Make sure that ingress works flexibly with `GrafanaSourceProvider`

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -74,7 +74,6 @@ class PrometheusCharm(CharmBase):
             charm=self,
             source_type="prometheus",
             source_url=self._external_url,
-            refresh_event=self.on.prometheus_pebble_ready,
         )
 
         # Maintains list of Alertmanagers to which alerts are forwarded

--- a/src/charm.py
+++ b/src/charm.py
@@ -51,12 +51,6 @@ class PrometheusCharm(CharmBase):
 
         # Relation handler objects
 
-        # Allows Grafana to aggregate metrics
-        self.grafana_source_consumer = GrafanaSourceProvider(
-            charm=self,
-            refresh_event=self.on.prometheus_pebble_ready,
-        )
-
         # Gathers scrape job information from metrics endpoints
         self.metrics_consumer = MetricsEndpointConsumer(self)
 
@@ -73,6 +67,13 @@ class PrometheusCharm(CharmBase):
             endpoint_port=external_url.port or self._port,
             endpoint_schema=external_url.scheme,
             endpoint_path=f"{external_url.path}/api/v1/write",
+        )
+
+        # Allows Grafana to aggregate metrics
+        self.grafana_source_consumer = GrafanaSourceProvider(
+            charm=self,
+            refresh_event=self.on.prometheus_pebble_ready,
+            source_uri=self._external_url,
         )
 
         # Maintains list of Alertmanagers to which alerts are forwarded
@@ -155,6 +156,7 @@ class PrometheusCharm(CharmBase):
 
         # Make sure that if the remote_write endpoint changes, it is reflected in relation data.
         self.remote_write_provider.update_endpoint()
+        self.grafana_source_consumer.update_source(self._external_url)
 
         self.unit.status = ActiveStatus()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -72,8 +72,9 @@ class PrometheusCharm(CharmBase):
         # Allows Grafana to aggregate metrics
         self.grafana_source_consumer = GrafanaSourceProvider(
             charm=self,
+            source_type="prometheus",
+            source_url=self._external_url,
             refresh_event=self.on.prometheus_pebble_ready,
-            source_uri=self._external_url,
         )
 
         # Maintains list of Alertmanagers to which alerts are forwarded

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -45,8 +45,6 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(True)
         self.harness.update_config({"web_external_url": "http://test:80/foo/bar"})
 
-        ingress_rel_id = self.harness.add_relation("ingress", "traefik-ingress")
-        self.harness.add_relation_unit(ingress_rel_id, "traefik-ingress/0")
         grafana_rel_id = self.harness.add_relation("grafana-source", "grafana")
         self.harness.add_relation_unit(grafana_rel_id, "grafana/0")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -34,10 +34,27 @@ class TestCharm(unittest.TestCase):
     def test_grafana_is_provided_port_and_source(self, *unused):
         rel_id = self.harness.add_relation("grafana-source", "grafana")
         self.harness.add_relation_unit(rel_id, "grafana/0")
+        fqdn = socket.getfqdn()
         grafana_host = self.harness.get_relation_data(rel_id, self.harness.model.unit.name)[
             "grafana_source_host"
         ]
-        self.assertEqual(grafana_host, "{}:{}".format("1.1.1.1", "9090"))
+        self.assertEqual(grafana_host, "http://{}:{}".format(fqdn, "9090"))
+
+    @patch_network_get(private_address="1.1.1.1")
+    def test_web_external_url_is_passed_to_grafana(self, *unused):
+        self.harness.set_leader(True)
+        self.harness.update_config({"web_external_url": "http://test:80/foo/bar"})
+
+        ingress_rel_id = self.harness.add_relation("ingress", "traefik-ingress")
+        self.harness.add_relation_unit(ingress_rel_id, "traefik-ingress/0")
+        grafana_rel_id = self.harness.add_relation("grafana-source", "grafana")
+        self.harness.add_relation_unit(grafana_rel_id, "grafana/0")
+
+        grafana_host = self.harness.get_relation_data(
+            grafana_rel_id, self.harness.model.unit.name
+        )["grafana_source_host"]
+
+        self.assertEqual(grafana_host, "http://test:80/foo/bar")
 
     def test_default_cli_log_level_is_info(self):
         plan = self.harness.get_container_pebble_plan("prometheus")


### PR DESCRIPTION
## Issue
Previously, `GrafanaSourceProvider` assumed that a bare `{host}:{port}` would be sufficient as a condition, but Prometheus, when `web.external-url` is set, also changes all web entrypoints to subpath routing. The majority of the work here happened in Grafana, but some changes were necessary to actually get the values from Prometheus in.

## Solution
Instantiate `GrafanaSourceProvider` with `_external_url`.

## Testing Instructions
Easy way to check: use the explore tab of Grafana to query Prometheus data. If it does not work, you’ll be told by Grafana that there are “Bad gateway” issues.

Make sure Traefik is in Active status (https://github.com/canonical/traefik-k8s-operator#setup), otherwise it does not pass URLs to Prometheus and you are not testing much.

Also try to change a few times, back and forth, the routing_mode setting for Traefik (https://github.com/canonical/traefik-k8s-operator#configurations), as that affects changes that need to cascade through the Grafana Source relation.

You can check which URLs are provided by Traefik to Prometheus and others using this action: https://github.com/canonical/traefik-k8s-operator/blob/afb2e1f2aca5b1d2e8ee479aa21df9d5e4417b3b/actions.yaml#L1

## Release Notes
Make sure that ingress works flexibly with `GrafanaSourceProvider`