### PR TITLE
remote_write_2

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -451,9 +451,8 @@ class AlertRules:
 
     def _is_already_modified(self, name: str) -> bool:
         """Detect whether a group name has already been modified with juju topology."""
-        uuid_regex = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
-        final_regex = ".*_{}_.*_alerts".format(uuid_regex)
-        if re.match(final_regex, name) is not None:
+        modified_matcher = re.compile(r"^.*?_[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}_.*?alerts$")
+        if modified_matcher.match(name) is not None:
             return True
         return False
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import platform
+import re
 import subprocess
 from collections import OrderedDict
 from pathlib import Path
@@ -32,7 +33,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 logger = logging.getLogger(__name__)
@@ -131,6 +132,10 @@ class JujuTopology:
             application: an application name as a string
             unit: a unit name as a string
             charm_name: name of charm as a string
+
+        Note:
+            `JujuTopology` should not be constructed directly by charm code. Please
+            use `ProviderTopology` or `AggregatorTopology`.
         """
         self.model = model
         self.model_uuid = model_uuid
@@ -167,6 +172,7 @@ class JujuTopology:
                 - "application"
                 - "unit"
                 - "charm_name"
+
                 `unit` and `charm_name` may be empty, but will result in more limited
                 labels. However, this allows us to support payload-only charms.
 
@@ -185,16 +191,15 @@ class JujuTopology:
     def identifier(self) -> str:
         """Format the topology information into a terse string."""
         # This is odd, but may have `None` as a model key
-        return "_".join([str(val) for val in self.as_dict().values()]).replace("/", "_")
+        return "_".join([str(val) for val in self.as_promql_label_dict().values()]).replace(
+            "/", "_"
+        )
 
     @property
     def promql_labels(self) -> str:
         """Format the topology information into a verbose string."""
         return ", ".join(
-            [
-                'juju_{}="{}"'.format(key, value)
-                for key, value in self.as_dict(rename_keys={"charm_name": "charm"}).items()
-            ]
+            ['{}="{}"'.format(key, value) for key, value in self.as_promql_label_dict().items()]
         )
 
     def as_dict(self, rename_keys: Optional[Dict[str, str]] = None) -> OrderedDict:
@@ -234,6 +239,10 @@ class JujuTopology:
             "juju_{}".format(key): val
             for key, val in self.as_dict(rename_keys={"charm_name": "charm"}).items()
         }
+        # The leader is the only unit that sets alert rules, if "juju_unit" is present,
+        # then the rules will only be evaluated for that unit
+        if "juju_unit" in vals:
+            vals.pop("juju_unit")
 
         return vals
 
@@ -392,12 +401,13 @@ class AlertRules:
 
             # update rules with additional metadata
             for alert_group in alert_groups:
-                # update group name with topology and sub-path
-                alert_group["name"] = self._group_name(
-                    str(root_path),
-                    str(file_path),
-                    alert_group["name"],
-                )
+                if not self._is_already_modified(alert_group["name"]):
+                    # update group name with topology and sub-path
+                    alert_group["name"] = self._group_name(
+                        str(root_path),
+                        str(file_path),
+                        alert_group["name"],
+                    )
 
                 # add "juju_" topology labels
                 for alert_rule in alert_group["rules"]:
@@ -405,7 +415,10 @@ class AlertRules:
                         alert_rule["labels"] = {}
 
                     if self.topology:
-                        alert_rule["labels"].update(self.topology.as_promql_label_dict())
+                        # only insert labels that do not already exist
+                        for label, val in self.topology.as_promql_label_dict().items():
+                            if label not in alert_rule["labels"]:
+                                alert_rule["labels"][label] = val
                         # insert juju topology filters into a prometheus alert rule
                         alert_rule["expr"] = self.topology.render(alert_rule["expr"])
 
@@ -435,6 +448,14 @@ class AlertRules:
         group_name_parts.extend([rel_path, group_name, "alerts"])
         # filter to remove empty strings
         return "_".join(filter(None, group_name_parts))
+
+    def _is_already_modified(self, name: str) -> bool:
+        """Detect whether a group name has already been modified with juju topology."""
+        uuid_regex = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+        final_regex = ".*_{}_.*_alerts".format(uuid_regex)
+        if re.match(final_regex, name) is not None:
+            return True
+        return False
 
     @classmethod
     def _multi_suffix_glob(
@@ -793,7 +814,7 @@ class PrometheusRemoteWriteConsumer(Object):
     def _push_alerts_on_relation_joined(self, event: RelationEvent) -> None:
         self._push_alerts_to_relation_databag(event.relation)
 
-    def _push_alerts_to_all_relation_databags(self, _: HookEvent) -> None:
+    def _push_alerts_to_all_relation_databags(self, _: Optional[HookEvent]) -> None:
         for relation in self.model.relations[self._relation_name]:
             self._push_alerts_to_relation_databag(relation)
 
@@ -808,6 +829,10 @@ class PrometheusRemoteWriteConsumer(Object):
 
         if alert_rules_as_dict:
             relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
+
+    def reload_alerts(self) -> None:
+        """Reload alert rules from disk and push to relation data."""
+        self._push_alerts_to_all_relation_databags(None)
 
     @property
     def endpoints(self) -> List[Dict[str, str]]:
@@ -1027,32 +1052,24 @@ class PrometheusRemoteWriteProvider(Object):
             if not alert_rules:
                 continue
 
-            try:
-                scrape_metadata = json.loads(relation.data[relation.app]["scrape_metadata"])
-                identifier = ProviderTopology.from_relation_data(scrape_metadata).identifier
-                alerts[identifier] = self._transformer.apply_label_matchers(alert_rules)
-            except KeyError as e:
-                logger.warning(
-                    "Relation %s has no 'scrape_metadata': %s",
-                    relation.id,
-                    e,
-                )
-
-                if "groups" not in alert_rules:
-                    logger.warning("No alert groups were found in relation data")
-                    continue
-                # Construct an ID based on what's in the alert rules
-                for group in alert_rules["groups"]:
-                    try:
-                        labels = group["rules"][0]["labels"]
-                        identifier = "{}_{}_{}".format(
-                            labels["juju_model"],
-                            labels["juju_model_uuid"],
-                            labels["juju_application"],
-                        )
-                        alerts[identifier] = alert_rules
-                    except KeyError:
-                        logger.error("Alert rules were found but no usable labels were present")
+            if "groups" not in alert_rules:
+                logger.warning("No alert groups were found in relation data")
+                continue
+            # Construct an ID based on what's in the alert rules
+            for group in alert_rules["groups"]:
+                try:
+                    labels = group["rules"][0]["labels"]
+                    identifier = "{}_{}_{}".format(
+                        labels["juju_model"],
+                        labels["juju_model_uuid"],
+                        labels["juju_application"],
+                    )
+                    if identifier not in alerts:
+                        alerts[identifier] = {"groups": [group]}
+                    else:
+                        alerts[identifier]["groups"].append(group)
+                except KeyError:
+                    logger.error("Alert rules were found but no usable labels were present")
 
         return alerts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ profile = "black"
 [tool.flake8]
 max-line-length = 99
 max-doc-length = 99
-max-complexity = 10
 exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this

--- a/tests/unit/prometheus_alert_rules/with_template_string_and_unit.rule
+++ b/tests/unit/prometheus_alert_rules/with_template_string_and_unit.rule
@@ -1,0 +1,9 @@
+alert: PrometheusTargetMissing
+expr: up{%%juju_topology%%, juju_unit="app/0"} == 0
+for: 0m
+labels:
+  severity: critical
+  juju_unit: app/0
+annotations:
+  summary: Prometheus target missing (instance {{ $labels.instance }})
+  description: "A Prometheus target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -192,18 +192,29 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertIn("alert_rules", data)
         alerts = json.loads(data["alert_rules"])
         self.assertIn("groups", alerts)
-        self.assertEqual(len(alerts["groups"]), 5)
+        self.assertEqual(len(alerts["groups"]), 6)
         for group in alerts["groups"]:
             for rule in group["rules"]:
-                self.assertIn("labels", rule)
-                labels = rule["labels"]
-                self.assertIn("juju_model", labels)
-                self.assertIn("juju_application", labels)
-                self.assertIn("juju_model_uuid", labels)
-                self.assertIn("juju_charm", labels)
-                # alerts should not have unit information if not already present
-                self.assertNotIn("juju_unit", rule["labels"])
-                self.assertNotIn("juju_unit=", rule["expr"])
+                if "and_unit" not in group["name"]:
+                    self.assertIn("labels", rule)
+                    labels = rule["labels"]
+                    self.assertIn("juju_model", labels)
+                    self.assertIn("juju_application", labels)
+                    self.assertIn("juju_model_uuid", labels)
+                    self.assertIn("juju_charm", labels)
+                    # alerts should not have unit information if not already present
+                    self.assertNotIn("juju_unit", rule["labels"])
+                    self.assertNotIn("juju_unit=", rule["expr"])
+                else:
+                    self.assertIn("labels", rule)
+                    labels = rule["labels"]
+                    self.assertIn("juju_model", labels)
+                    self.assertIn("juju_application", labels)
+                    self.assertIn("juju_model_uuid", labels)
+                    self.assertIn("juju_charm", labels)
+                    # unit information is already present
+                    self.assertIn("juju_unit", rule["labels"])
+                    self.assertIn("juju_unit=", rule["expr"])
 
     @patch("ops.testing._TestingModelBackend.network_get")
     def test_each_alert_expression_is_topology_labeled(self, _):
@@ -213,7 +224,7 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertIn("alert_rules", data)
         alerts = json.loads(data["alert_rules"])
         self.assertIn("groups", alerts)
-        self.assertEqual(len(alerts["groups"]), 5)
+        self.assertEqual(len(alerts["groups"]), 6)
         group = alerts["groups"][0]
         for rule in group["rules"]:
             self.assertIn("expr", rule)

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -153,7 +153,7 @@ class TestRemoteWriteConsumer(unittest.TestCase):
         self.harness.update_relation_data(rel_id, "provider/0", {})
         assert list(self.harness.charm.remote_write_consumer.endpoints) == []
 
-    def test_alert_rule_is_correct(self):
+    def test_alert_rule_has_correct_labels(self):
         rel_id = self.harness.add_relation(RELATION_NAME, "provider")
         self.harness.add_relation_unit(rel_id, "provider/0")
         rules = json.loads(
@@ -181,7 +181,7 @@ class TestRemoteWriteConsumer(unittest.TestCase):
         else:
             assert False  # Could not find the correct alert rule to check
 
-    def test_alert_rule_is_correct_with_unit(self):
+    def test_alert_rule_has_correct_labels_with_unit(self):
         rel_id = self.harness.add_relation(RELATION_NAME, "provider")
         self.harness.add_relation_unit(rel_id, "provider/0")
         rules = json.loads(


### PR DESCRIPTION
Update the remote write library with various improvements.

## Issue
There are two significant issues that this addresses:
* Alert rules do not get propagated from the workload charm, through grafana-agent, to prometheus
* Alert rules get `juju_unit` added to the expression and the labels

## Solution
* Make sure to only modify an alert rule if it has not already been modified
* Use the same updated JujuTopology class that prometheus_scrape uses

## Testing Instructions
1. Deploy prometheus, grafana-agent (remote_write_2 branch), and a workload (cassandra, spring-music, etc.)
2. Relate prometheus->grafana-agent->workload
3. Ensure alert rules from workload are present and labeled correctly (no unit)
4. Ensure metrics are present and labeled correctly (optionally relate prometheus to grafana)
5. Michele style tests

## Release Notes
* Overhaul of prometheus_remote_write bringing it up to working order
