### PR TITLE
Explain rationale for not using some prometheus scrape settings in charms

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -309,7 +309,7 @@ over unit relation data using the `prometheus_scrape_unit_name` and
 `scrape_jobs` and `alert_rules` keys in application relation data
 of Metrics provider charms hold eponymous information.
 
-"""
+"""  # noqa: W505
 
 import json
 import logging

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -162,11 +162,9 @@ For instance, if you include variable elements, like your `unit.name`, it may br
 the continuity of the metrics time series gathered by Prometheus when the leader unit
 changes (e.g. on upgrade or rescale).
 
-It is also possible to configure other scrape related parameters using
-these job specifications as described by the Prometheus
-[documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
-The permissible subset of job specific scrape configuration parameters
-supported in a `MetricsEndpointProvider` job specification are:
+It is also technically possible, but **strongly discouraged**, to configure the following
+scrape-related parameters as described by the
+[Prometheus documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
 
 - `job_name`
 - `metrics_path`
@@ -180,6 +178,16 @@ supported in a `MetricsEndpointProvider` job specification are:
 - `label_limit`
 - `label_name_length_limit`
 - `label_value_length_limit`
+
+These options are technically allows to be
+specified over the relation interface to enable
+facilities like the [Prometheus Scrape Config](https://charmhub.io/prometheus-scrape-config-k8s)
+charm. These settings **should not** be exposed
+as configuration options for specific charms,
+as they would reduce the composability of the
+existing setup, duplicate functionality, and
+make more complicated than necessary the moving
+parts of your charms.
 
 ## Consumer Library Usage
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -126,7 +126,7 @@ name". However unit name is associated only with wildcard targets but
 not with fully qualified targets.
 
 Multiple jobs with different metrics paths and labels are allowed, but
-each job must be given a unique name. For example
+each job must be given a unique name:
 
 ```
 [
@@ -162,12 +162,10 @@ For instance, if you include variable elements, like your `unit.name`, it may br
 the continuity of the metrics time series gathered by Prometheus when the leader unit
 changes (e.g. on upgrade or rescale).
 
-It is also technically possible, but **strongly discouraged**, to configure the following
-scrape-related parameters as described by the
-[Prometheus documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
+Additionally, it is also technically possible, but **strongly discouraged**, to
+configure the following scrape-related settings, which behave as described by the
+[Prometheus documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config):
 
-- `job_name`
-- `metrics_path`
 - `static_configs`
 - `scrape_interval`
 - `scrape_timeout`
@@ -179,15 +177,10 @@ scrape-related parameters as described by the
 - `label_name_length_limit`
 - `label_value_length_limit`
 
-These options are technically allows to be
-specified over the relation interface to enable
-facilities like the [Prometheus Scrape Config](https://charmhub.io/prometheus-scrape-config-k8s)
-charm. These settings **should not** be exposed
-as configuration options for specific charms,
-as they would reduce the composability of the
-existing setup, duplicate functionality, and
-make more complicated than necessary the moving
-parts of your charms.
+The settings above are supported by the `prometheus_scrape` library only for the sake of
+specialized facilities like the [Prometheus Scrape Config](https://charmhub.io/prometheus-scrape-config-k8s)
+charm. Virtually all charms **should not** use these settings and definitely **should not**
+expose them to the Juju administrator via configuration options.
 
 ## Consumer Library Usage
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -179,7 +179,7 @@ configure the following scrape-related settings, which behave as described by th
 
 The settings above are supported by the `prometheus_scrape` library only for the sake of
 specialized facilities like the [Prometheus Scrape Config](https://charmhub.io/prometheus-scrape-config-k8s)
-charm. Virtually all charms **should not** use these settings and definitely **should not**
+charm. Virtually no charms should use these settings, and charmers definitely **should not**
 expose them to the Juju administrator via configuration options.
 
 ## Consumer Library Usage


### PR DESCRIPTION
## Issue

clarify what some of the allowed settings are supported by the `prometheus_scrape` library, but should not be used directly by charmers.

## Solution

More docu.

## Context

We have seen PRs for charms like Kubeflow exposing config options for scrape-interval that should not be exposed directly by their charms.

## Testing Instructions

N/A


## Release Notes

Provide guidance in terms of which Job settings should be used by charmers integrating the library, and which not.

