### PR TITLE
Upgrade ingress_per_unit to to LIBPATCH 7

### DIFF
--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -14,9 +14,7 @@ To get started using the library, you just need to fetch the library using `char
 charm's `requirements.txt`.**
 
 ```shell
-cd some-charm
 charmcraft fetch-lib charms.traefik_k8s.v0.ingress_per_unit
-echo -e "serialized_data_interface\n" >> requirements.txt
 ```
 
 ```yaml
@@ -48,34 +46,23 @@ class SomeCharm(CharmBase):
         logger.info("This unit's ingress URL: %s", self.ingress_per_unit.url)
 ```
 """
-
 import logging
-from typing import Optional
+import warnings
+from typing import Dict, Optional, Tuple, TypeVar, Union
 
-from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent, RelationRole
-from ops.framework import EventSource
-from ops.model import Relation, Unit
-
-try:
-    from serialized_data_interface import EndpointWrapper
-    from serialized_data_interface.errors import RelationDataError
-    from serialized_data_interface.events import EndpointWrapperEvents
-except ImportError:
-    import os
-
-    library_name = os.path.basename(__file__)
-    raise ModuleNotFoundError(
-        "To use the '{}' library, you must include "
-        "the '{}' package in your dependencies".format(library_name, "serialized_data_interface")
-    ) from None  # Suppress original ImportError
-
-try:
-    # introduced in 3.9
-    from functools import cache  # type: ignore
-except ImportError:
-    from functools import lru_cache
-
-    cache = lru_cache(maxsize=None)
+import jsonschema
+import yaml
+from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
+from ops.framework import EventSource, Object, ObjectEvents
+from ops.model import (
+    ActiveStatus,
+    Application,
+    BlockedStatus,
+    Relation,
+    StatusBase,
+    Unit,
+    WaitingStatus,
+)
 
 # The unique Charmhub library identifier, never change it
 LIBID = "7ef06111da2945ed84f4f5d4eb5b353a"  # can't register a library until the charm is in the store 9_9
@@ -85,114 +72,432 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 log = logging.getLogger(__name__)
 
-INGRESS_SCHEMA = {
-    "v1": {
-        "requires": {
-            "unit": {
-                "type": "object",
-                "properties": {
-                    "model": {"type": "string"},
-                    "name": {"type": "string"},
-                    "host": {"type": "string"},
-                    "port": {"type": "integer"},
-                },
-                "required": ["model", "name", "host", "port"],
-            }
-        },
-        "provides": {
-            "app": {
-                "type": "object",
-                "properties": {
-                    "ingress": {
-                        "type": "object",
-                        "patternProperties": {
-                            "": {
-                                "type": "object",
-                                "properties": {"url": {"type": "string"}},
-                                "required": ["url"],
-                            }
-                        },
-                    }
-                },
-                "required": ["ingress"],
-            }
-        },
-    }
+# ======================= #
+#      LIBRARY GLOBS      #
+# ======================= #
+
+RELATION_INTERFACE = "ingress_per_unit"
+DEFAULT_RELATION_NAME = RELATION_INTERFACE.replace("_", "-")
+
+INGRESS_REQUIRES_UNIT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "model": {"type": "string"},
+        "name": {"type": "string"},
+        "host": {"type": "string"},
+        "port": {"type": "integer"},
+    },
+    "required": ["model", "name", "host", "port"],
 }
+INGRESS_PROVIDES_APP_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "ingress": {
+            "type": "object",
+            "patternProperties": {
+                "": {
+                    "type": "object",
+                    "properties": {
+                        # Optional key for backwards compatibility
+                        # with legacy requirers based on SDI
+                        "_supported_versions": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                    "required": ["url"],
+                }
+            },
+        }
+    },
+    "required": ["ingress"],
+}
+
+
+# ======================= #
+#  SERIALIZATION UTILS    #
+# ======================= #
+
+
+def _deserialize_data(data):
+    # return json.loads(data) # TODO port to json
+    return yaml.safe_load(data)
+
+
+def _serialize_data(data):
+    # return json.dumps(data) # TODO port to json
+    return yaml.safe_dump(data, indent=2)
+
+
+def _validate_data(data, schema):
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        raise DataValidationError(data, schema) from e
+
+
+# ======================= #
+#       EXCEPTIONS        #
+# ======================= #
+
+
+class IngressPerUnitException(RuntimeError):
+    """Base class for errors raised by Ingress Per Unit."""
+
+
+class DataValidationError(IngressPerUnitException):
+    """Raised when data validation fails on IPU relation data."""
+
+
+class UnknownUnitException(IngressPerUnitException):
+    """Raised when a unit passed to API methods does not belong to the relation."""
+
+    def __init__(self, relation: Relation, unit: Unit):
+        super().__init__(relation, unit)
+
+
+class RelationException(IngressPerUnitException):
+    """Base class for relation exceptions from this library.
+
+    Attributes:
+        relation: The Relation which caused the exception.
+        entity: The Application or Unit which caused the exception.
+    """
+
+    def __init__(self, relation: Relation, entity: Union[Application, Unit]):
+        super().__init__(relation)
+        self.args = (
+            "There is an error with the relation {}:{} with {}".format(
+                relation.name, relation.id, entity.name
+            ),
+        )
+        self.relation = relation
+        self.entity = entity
+
+
+class RelationDataMismatchError(RelationException):
+    """Data from different units do not match where they should."""
+
+
+class RelationPermissionError(IngressPerUnitException):
+    """Ingress is requested to do something for which it lacks permissions."""
+
+    def __init__(self, relation: Relation, entity: Union[Application, Unit], message: str):
+        self.args = "Unable to write data to relation '{}:{}' with {}: {}".format(
+            relation.name, relation.id, entity.name, message
+        )
+        self.relation = relation
+
+
+# ======================= #
+#         EVENTS          #
+# ======================= #
+
+
+class RelationAvailableEvent(RelationEvent):
+    """Event triggered when a relation is ready for requests."""
+
+
+class RelationFailedEvent(RelationEvent):
+    """Event triggered when something went wrong with a relation."""
+
+
+class RelationReadyEvent(RelationEvent):
+    """Event triggered when a remote relation has the expected data."""
+
+
+class IngressPerUnitEvents(ObjectEvents):
+    """Container for events for IngressPerUnit."""
+
+    available = EventSource(RelationAvailableEvent)
+    ready = EventSource(RelationReadyEvent)
+    failed = EventSource(RelationFailedEvent)
+    broken = EventSource(RelationBrokenEvent)
 
 
 class IngressPerUnitRequestEvent(RelationEvent):
     """Event representing an incoming request.
 
-    This is equivalent to the "ready" event, but is more semantically meaningful.
+    This is equivalent to the "ready" event.
     """
 
 
-class IngressPerUnitProviderEvents(EndpointWrapperEvents):
+class IngressPerUnitProviderEvents(IngressPerUnitEvents):
     """Container for IUP events."""
 
     request = EventSource(IngressPerUnitRequestEvent)
 
 
-class IngressPerUnitProvider(EndpointWrapper):
-    """Implementation of the provider of ingress_per_unit."""
+class _IngressPerUnitBase(Object):
+    """Base class for IngressPerUnit interface classes."""
 
-    ROLE = RelationRole.provides.name
-    INTERFACE = "ingress_per_unit"
-    SCHEMA = INGRESS_SCHEMA
+    _IngressPerUnitEventType = TypeVar("_IngressPerUnitEventType", bound=IngressPerUnitEvents)
+    on: _IngressPerUnitEventType
 
-    on = IngressPerUnitProviderEvents()
-
-    def __init__(self, charm: CharmBase, endpoint: str = None):
-        """Constructor for IngressPerUnitProvider.
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        """Constructor for _IngressPerUnitBase.
 
         Args:
             charm: The charm that is instantiating the instance.
-            endpoint: The name of the relation endpoint to bind to
+            relation_name: The name of the relation name to bind to
                 (defaults to "ingress-per-unit").
         """
-        super().__init__(charm, endpoint)
-        self.framework.observe(self.on.ready, self._emit_request_event)
+        super().__init__(charm, relation_name)
+        self.charm: CharmBase = charm
+
+        self.relation_name = relation_name
+        self.app = self.charm.app
+        self.unit = self.charm.unit
+
+        observe = self.framework.observe
+        rel_events = charm.on[relation_name]
+        observe(rel_events.relation_created, self._handle_relation)
+        observe(rel_events.relation_joined, self._handle_relation)
+        observe(rel_events.relation_changed, self._handle_relation)
+        observe(rel_events.relation_broken, self._handle_relation_broken)
+        observe(charm.on.leader_elected, self._handle_upgrade_or_leader)
+        observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)
+
+    @property
+    def relations(self):
+        """The list of Relation instances associated with this relation_name."""
+        return list(self.charm.model.relations[self.relation_name])
+
+    def _handle_relation(self, event):
+        relation = event.relation
+        if self.is_ready(relation):
+            self.on.ready.emit(relation)
+        elif self.is_available(relation):
+            self.on.available.emit(relation)
+        elif self.is_failed(relation):
+            self.on.failed.emit(relation)
+        else:
+            log.debug(
+                "Relation {} is neither ready, nor available, nor failed. "
+                "Something fishy's going on...".format(relation)
+            )
+
+    def get_status(self, relation: Relation) -> StatusBase:
+        """Get the suggested status for the given Relation."""
+        if self.is_failed(relation):
+            return BlockedStatus(
+                "Error handling relation {}:{}".format(relation.name, relation.id)
+            )
+        elif not self.is_available(relation):
+            return WaitingStatus("Waiting on relation {}:{}".format(relation.name, relation.id))
+        elif not self.is_ready(relation):
+            return WaitingStatus("Waiting on relation {}:{}".format(relation.name, relation.id))
+        else:
+            return ActiveStatus()
+
+    def _handle_relation_broken(self, event):
+        self.on.broken.emit(event.relation)
+
+    def _handle_upgrade_or_leader(self, _):
+        pass
 
     def _emit_request_event(self, event):
         self.on.request.emit(event.relation)
 
-    def get_request(self, relation: Relation):
-        """Get the IngressRequest for the given Relation."""
-        return IngressRequest(self, relation)
+    def is_available(self, relation: Relation = None):
+        """Check whether the given relation is available.
 
-    @cache
+        Or any relation if not specified.
+        """
+        if relation is None:
+            return any(self.is_available(relation) for relation in self.relations)
+
+        if not relation.app.name:
+            # Juju doesn't provide JUJU_REMOTE_APP during relation-broken
+            # hooks. See https://github.com/canonical/operator/issues/693.
+            # Relation in the process of breaking cannot be available.
+            return False
+
+        return True
+
+    def is_ready(self, relation: Relation = None):
+        """Checks whether the given relation is ready.
+
+        Or any relation if not specified.
+        A given relation is ready if the remote side has sent valid data.
+        """
+        if relation is None:
+            return any(self.is_ready(relation) for relation in self.relations)
+
+        if not relation.app.name:  # type: ignore
+            # Juju doesn't provide JUJU_REMOTE_APP during relation-broken
+            # hooks. See https://github.com/canonical/operator/issues/693
+            return False
+
+    def is_failed(self, _: Relation = None):
+        """Checks whether the given relation is failed.
+
+        Or any relation if not specified.
+        """
+        raise NotImplementedError("implement in subclass")
+
+
+class IngressPerUnitProvider(_IngressPerUnitBase):
+    """Implementation of the provider of ingress_per_unit."""
+
+    on = IngressPerUnitProviderEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        """Constructor for IngressPerUnitProvider.
+
+        Args:
+            charm: The charm that is instantiating the instance.
+            relation_name: The name of the relation relation_name to bind to
+                (defaults to "ingress-per-unit").
+        """
+        super().__init__(charm, relation_name)
+        observe = self.framework.observe
+        observe(self.on.ready, self._emit_request_event)
+        observe(self.charm.on[relation_name].relation_joined, self._share_version_info)
+
+    def _share_version_info(self, event):
+        """Backwards-compatibility shim for version negotiation.
+
+        Allows older versions of IPU (requirer side) to interact with this
+        provider without breaking.
+        Will be removed in a future version of this library.
+        Do not use.
+        """
+        relation = event.relation
+        if self.charm.unit.is_leader():
+            log.info("shared supported_versions shim information")
+            relation.data[self.charm.app]["_supported_versions"] = "- v1"
+
+    def is_ready(self, relation: Relation = None):
+        """Checks whether the given relation is ready.
+
+        Or any relation if not specified.
+        A given relation is ready if SOME remote side has sent valid data.
+        """
+        if relation is None:
+            return any(self.is_ready(relation) for relation in self.relations)
+
+        if super().is_ready(relation) is False:
+            return False
+
+        try:
+            _, requirers_unit_data = self._fetch_relation_data(relation)
+        except Exception:
+            log.exception("Cannot fetch ingress data for the '{}' relation".format(relation))
+            return False
+
+        return any(requirers_unit_data.values())
+
     def is_failed(self, relation: Relation = None):
-        """Checks whether the given relation, or any relation if not specified, has an error."""
+        """Checks whether the given relation is failed.
+
+        Or any relation if not specified.
+        """
         if relation is None:
             return any(self.is_failed(relation) for relation in self.relations)
-        if not relation.units:
+
+        if not relation.app.name:  # type: ignore
+            # Juju doesn't provide JUJU_REMOTE_APP during relation-broken
+            # hooks. See https://github.com/canonical/operator/issues/693
             return False
-        if super().is_failed(relation):
+
+        if not relation.units:
+            # Relations without requiring units cannot be in failed state
+            return False
+
+        try:
+            # grab the data and validate it; might raise
+            _, requirers_unit_data = self._fetch_relation_data(relation, validate=True)
+        except DataValidationError as e:
+            log.warning("Failed to validate relation data for {} relation: {}".format(relation, e))
             return True
-        data = self.unwrap(relation)
-        prev_fields = None
-        for unit in relation.units:
-            if not data[unit]:
-                continue
-            new_fields = {field: data[unit][field] for field in ("model", "port")}
-            if prev_fields is None:
-                prev_fields = new_fields
-            if new_fields != prev_fields:
-                raise RelationDataMismatchError(relation, unit)
+
+        # verify that all remote units (requirer's side) publish the same model.
+        # We do not validate the port because, in case of changes to the configuration
+        # of the charm or a new version of the charmed workload, e.g. over an upgrade,
+        # the remote port may be different among units.
+        expected_model = None  # It may be none for units that have not yet written data
+
+        for remote_unit, remote_unit_data in requirers_unit_data.items():
+            if "model" in remote_unit_data:
+                remote_model = remote_unit_data["model"]
+                if not expected_model:
+                    expected_model = remote_model
+                elif expected_model != remote_model:
+                    raise RelationDataMismatchError(relation, remote_unit)
+
         return False
 
+    def get_request(self, relation: Relation):
+        """Get the IngressRequest for the given Relation."""
+        provider_app_data, requirers_unit_data = self._fetch_relation_data(relation)
+        return IngressRequest(self, relation, provider_app_data, requirers_unit_data)
+
+    def _fetch_relation_data(
+        self, relation: Relation, validate=False
+    ) -> Tuple[Dict[str, Dict[str, str]], Dict[str, Dict[str, str]]]:
+        """Fetch and validate the databags.
+
+        For the provider side: the application databag.
+        For the requirer side: the unit databag.
+        """
+        this_unit = self.unit
+        this_app = self.app
+
+        if not relation.app or not relation.app.name:
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return {}, {}
+
+        provider_app_data = {}
+        # we start by looking at the provider's app databag
+        if this_unit.is_leader():
+            # only leaders can read their app's data
+            data = relation.data[this_app].get("data")
+            deserialized = {}
+            if data:
+                deserialized = _deserialize_data(data)
+                if validate:
+                    _validate_data(deserialized, INGRESS_PROVIDES_APP_SCHEMA)
+            provider_app_data = deserialized.get("ingress", {})
+
+        # then look at the requirer's (thus remote) unit databags
+        remote_units = [unit for unit in relation.units if unit.app is not this_app]
+
+        requirers_unit_data = {}
+        for remote_unit in remote_units:
+            remote_data = relation.data[remote_unit].get("data")
+            remote_deserialized = {}
+            if remote_data:
+                remote_deserialized = _deserialize_data(remote_data)
+                if validate:
+                    _validate_data(remote_deserialized, INGRESS_REQUIRES_UNIT_SCHEMA)
+            requirers_unit_data[remote_unit] = remote_deserialized
+
+        return provider_app_data, requirers_unit_data
+
+    def publish_ingress_data(self, relation: Relation, data: Dict[str, Dict[str, str]]):
+        """Publish ingress data to the relation databag."""
+        if not self.unit.is_leader():
+            raise RelationPermissionError(relation, self.unit, "This unit is not the leader")
+
+        wrapped_data = {"ingress": data}
+
+        _validate_data(wrapped_data, INGRESS_PROVIDES_APP_SCHEMA)
+        # if all is well, write the data
+        relation.data[self.app]["data"] = _serialize_data(wrapped_data)
+
     @property
-    def proxied_endpoints(self):
-        """Returns the ingress settings provided to units by this IngressPerUnitProvider.
+    def proxied_endpoints(self) -> dict:
+        """The ingress settings provided to units by this provider.
 
         For example, when this IngressPerUnitProvider has provided the
-        `http://foo.bar/my-model.my-app-1` and `http://foo.bar/my-model.my-app-2` URLs to
-        the two units of the my-app application, the returned dictionary will be:
+        `http://foo.bar/my-model.my-app-1` and
+        `http://foo.bar/my-model.my-app-2` URLs to the two units of the
+        my-app application, the returned dictionary will be:
 
         ```
         {
@@ -207,8 +512,9 @@ class IngressPerUnitProvider(EndpointWrapper):
         """
         results = {}
 
-        for ingress_relation in self.charm.model.relations[self.endpoint]:
-            results.update(self.unwrap(ingress_relation)[self.charm.app].get("ingress", {}))
+        for ingress_relation in self.relations:
+            provider_app_data, _ = self._fetch_relation_data(ingress_relation)
+            results.update(provider_app_data)
 
         return results
 
@@ -216,11 +522,18 @@ class IngressPerUnitProvider(EndpointWrapper):
 class IngressRequest:
     """A request for per-unit ingress."""
 
-    def __init__(self, provider: IngressPerUnitProvider, relation: Relation):
+    def __init__(
+        self,
+        provider: IngressPerUnitProvider,
+        relation: Relation,
+        provider_app_data: Dict[str, Dict[str, str]],
+        requirers_unit_data: Dict[str, Dict[str, str]],
+    ):
         """Construct an IngressRequest."""
         self._provider = provider
         self._relation = relation
-        self._data = provider.unwrap(relation)
+        self._provider_app_data = provider_app_data
+        self._requirers_unit_data = requirers_unit_data
 
     @property
     def model(self):
@@ -228,16 +541,12 @@ class IngressRequest:
         return self._get_data_from_first_unit("model")
 
     @property
-    def app(self):
-        """The remote application."""
-        return self._relation.app
-
-    @property
     def app_name(self):
         """The name of the remote app.
 
-        Note: This is not the same as `self.app.name` when using CMR relations,
-        since `self.app.name` is replaced by a `remote-{UUID}` pattern.
+        Note: This is not the same for the other charm as `self.app.name`
+        when using cross-model relations (CMRs), since `self.app.name` is
+        replaced by a `remote-{UUID}` pattern on the other side of a CMR.
         """
         first_unit_name = self._get_data_from_first_unit("name")
 
@@ -248,29 +557,70 @@ class IngressRequest:
 
     @property
     def units(self):
-        """The remote units."""
-        return sorted(self._relation.units, key=lambda unit: unit.name)
+        """The remote units that have posted requests, i.e., those that have provided the name."""
+        ready_units = filter(self.is_unit_ready, self._relation.units)
+        return sorted(ready_units, key=lambda unit: unit.name)
+
+    def is_unit_ready(self, unit: Unit) -> bool:
+        """Whether the given unit has provided its name, model, host and port data."""
+        self._check_unit_belongs_to_relation(unit)
+
+        return (
+            self.get_unit_host(unit)
+            and self.get_unit_name(unit)
+            and self.get_unit_model(unit)
+            and self.get_unit_port(unit)
+        )
 
     @property
     def port(self):
         """The backend port."""
         return self._get_data_from_first_unit("port")
 
+    # deprecated
     def get_host(self, unit: Unit):
         """The hostname (DNS address, ip) of the given unit."""
+        warnings.warn(
+            "The 'get_host' method is deprecated, use 'get_unit_host' instead", DeprecationWarning
+        )
+        return self.get_unit_host(unit)
+
+    def get_unit_host(self, unit: Unit):
+        """The hostname (DNS address, ip) of the given unit."""
+        self._check_unit_belongs_to_relation(unit)
+
         return self._get_unit_data(unit, "host")
 
-    def get_unit_name(self, unit: Unit):
+    def get_unit_port(self, unit: Unit) -> Optional[int]:
+        """The port of the given unit."""
+        self._check_unit_belongs_to_relation(unit)
+
+        port = self._get_unit_data(unit, "port")
+        return str(port) if port else None
+
+    def get_unit_model(self, unit: Unit) -> Optional[str]:
+        """The model of the remote unit.
+
+        Note: This is not the same as `self.model.name` when using CMR relations,
+        since `self.model.name` is replaced by a `remote-{UUID}` pattern.
+        """
+        self._check_unit_belongs_to_relation(unit)
+
+        return self._get_unit_data(unit, "model")
+
+    def get_unit_name(self, unit: Unit) -> Optional[str]:
         """The name of the remote unit.
 
         Note: This is not the same as `self.unit.name` when using CMR relations,
         since `self.unit.name` is replaced by a `remote-{UUID}` pattern.
         """
+        self._check_unit_belongs_to_relation(unit)
+
         return self._get_unit_data(unit, "name")
 
     def _get_data_from_first_unit(self, key: str):
-        if self.units:
-            first_unit_data = self._data[self.units[0]]
+        if self._relation.units:
+            first_unit_data = self._requirers_unit_data[self.units[0]]
 
             if key in first_unit_data:
                 return first_unit_data[key]
@@ -278,55 +628,60 @@ class IngressRequest:
         return None
 
     def _get_unit_data(self, unit: Unit, key: str):
-        if self.units:
-            if unit in self.units:
-                unit_data = self._data[unit]
+        self._check_unit_belongs_to_relation(unit)
 
-                if key in unit_data:
-                    return unit_data[key]
-
-        return None
+        # Could be that the unit did not share any data yet (not ready),
+        # so we have to guard against `unit` not being in `self._data`.
+        return self._requirers_unit_data.get(unit, {}).get(key, None)
 
     def respond(self, unit: Unit, url: str):
         """Send URL back for the given unit.
 
         Note: only the leader can send URLs.
         """
-        # Can't use `unit.name` because with CMR it's a UUID.
+        this_unit = self._provider.charm.unit
+        if not this_unit.is_leader():
+            raise RelationPermissionError(self._relation, this_unit, "This unit is not the leader")
+
+        self._check_unit_belongs_to_relation(unit)
+
+        if not self.is_unit_ready(unit):
+            raise IngressPerUnitException(
+                "Unable to get name of unit {}: this unit has not responded yet.".format(unit)
+            )
+
         remote_unit_name = self.get_unit_name(unit)
-        ingress = self._data[self._provider.charm.app].setdefault("ingress", {})
-        ingress.setdefault(remote_unit_name, {})["url"] = url
-        self._provider.wrap(self._relation, self._data)
 
+        assert remote_unit_name, "The remote unit has not provided its name in the relation yet"
 
-class RelationDataMismatchError(RelationDataError):
-    """Data from different units do not match where they should."""
+        self._provider_app_data[remote_unit_name] = {"url": url}
+
+        self._provider.publish_ingress_data(self._relation, self._provider_app_data)
+
+    def _check_unit_belongs_to_relation(self, unit: Unit):
+        if unit not in self._relation.units:
+            raise UnknownUnitException(self._relation, unit)
 
 
 class IngressPerUnitConfigurationChangeEvent(RelationEvent):
     """Event representing a change in the data sent by the ingress."""
 
 
-class IngressPerUnitRequirerEvents(EndpointWrapperEvents):
+class IngressPerUnitRequirerEvents(IngressPerUnitEvents):
     """Container for IUP events."""
 
     ingress_changed = EventSource(IngressPerUnitConfigurationChangeEvent)
 
 
-class IngressPerUnitRequirer(EndpointWrapper):
+class IngressPerUnitRequirer(_IngressPerUnitBase):
     """Implementation of the requirer of ingress_per_unit."""
 
     on = IngressPerUnitRequirerEvents()
 
-    ROLE = RelationRole.requires.name
-    INTERFACE = "ingress_per_unit"
-    SCHEMA = INGRESS_SCHEMA
-    LIMIT = 1
-
     def __init__(
         self,
         charm: CharmBase,
-        endpoint: str = None,
+        relation_name: str = DEFAULT_RELATION_NAME,
         *,
         host: str = None,
         port: int = None,
@@ -340,28 +695,99 @@ class IngressPerUnitRequirer(EndpointWrapper):
 
         Args:
             charm: the charm that is instantiating the library.
-            endpoint: the name of the relation endpoint to bind to
-                (defaults to "ingress-per-unit"; relation must be of interface type
-                "ingress_per_unit" and have "limit: 1")
-            host: Hostname to be used by the ingress provider to address the requirer
-                unit; if unspecified, the pod ip of the unit will be used instead
+            relation_name: the name of the relation name to bind to
+                (defaults to "ingress-per-unit"; relation must be of interface
+                type "ingress_per_unit" and have "limit: 1")
+            host: Hostname to be used by the ingress provider to address the
+            requirer unit; if unspecified, the pod ip of the unit will be used
+            instead
         Request Args:
             port: the port of the service
         """
-        super().__init__(charm, endpoint)
+        super().__init__(charm, relation_name)
+
+        # if instantiated with a port, and we are related, then
+        # we immediately publish our ingress data  to speed up the process.
         if port:
-            self.auto_data = self._complete_request(host or "", port)
+            self._auto_data = host, port
+        else:
+            self._auto_data = None
 
         # Workaround for SDI not marking the EndpointWrapper as not
         # ready upon a relation broken event
         self.is_relation_broken = False
 
         self.framework.observe(
-            self.charm.on[self.endpoint].relation_changed, self._emit_ingress_change_event
+            self.charm.on[self.relation_name].relation_changed, self._emit_ingress_change_event
         )
         self.framework.observe(
-            self.charm.on[self.endpoint].relation_broken, self._emit_ingress_change_event
+            self.charm.on[self.relation_name].relation_broken, self._emit_ingress_change_event
         )
+
+    def _handle_relation(self, event):
+        super()._handle_relation(event)
+        self._publish_auto_data(event.relation)
+
+    def _handle_upgrade_or_leader(self, event):
+        for relation in self.relations:
+            self._publish_auto_data(relation)
+
+    def _publish_auto_data(self, relation: Relation):
+        if self._auto_data and self.is_available(relation):
+            self._publish_ingress_data(*self._auto_data)
+
+    @property
+    def relation(self) -> Optional[Relation]:
+        """The established Relation instance, or None if still unrelated."""
+        return self.relations[0] if self.relations else None
+
+    def is_ready(self, relation: Relation = None):
+        """Checks whether the given relation is ready.
+
+        Or any relation if not specified.
+        A given relation is ready if the remote side has sent valid data.
+        """
+        if super().is_ready(relation) is False:
+            return False
+
+        return bool(self.url)
+
+    def is_failed(self, relation: Relation = None):
+        """Checks whether the given relation is failed.
+
+        Or any relation if not specified.
+        """
+        if not self.relations:  # can't fail if you can't try
+            return False
+
+        if relation is None:
+            return any(self.is_failed(relation) for relation in self.relations)
+
+        if not relation.app.name:  # type: ignore
+            # Juju doesn't provide JUJU_REMOTE_APP during relation-broken
+            # hooks. See https://github.com/canonical/operator/issues/693
+            return False
+
+        if not relation.units:
+            return False
+
+        try:
+            # grab the data and validate it; might raise
+            raw = self.relation.data[self.unit].get("data")
+        except Exception:
+            log.exception("Error accessing relation databag")
+            return True
+
+        if raw:
+            # validate data
+            data = _deserialize_data(raw)
+            try:
+                _validate_data(data, INGRESS_REQUIRES_UNIT_SCHEMA)
+            except jsonschema.ValidationError:
+                log.exception("Error validating relation data")
+                return True
+
+        return False
 
     def _emit_ingress_change_event(self, event):
         if isinstance(event, RelationBrokenEvent):
@@ -370,49 +796,57 @@ class IngressPerUnitRequirer(EndpointWrapper):
         # TODO Avoid spurious events, emit only when URL changes
         self.on.ingress_changed.emit(self.relation)
 
-    def _complete_request(self, host: Optional[str], port: int):
+    def _publish_ingress_data(self, host: Optional[str], port: int):
         if not host:
-            binding = self.charm.model.get_binding(self.endpoint)
+            binding = self.charm.model.get_binding(self.relation_name)
             host = str(binding.network.bind_address)
 
-        return {
-            self.charm.unit: {
-                "model": self.model.name,
-                "name": self.charm.unit.name,
-                "host": host,
-                "port": port,
-            },
+        data = {
+            "model": self.model.name,
+            "name": self.unit.name,
+            "host": host,
+            "port": port,
         }
+        self.relation.data[self.unit]["data"] = _serialize_data(data)
 
     def request(self, *, host: str = None, port: int):
         """Request ingress to this unit.
 
         Args:
-            host: Hostname to be used by the ingress provider to address the requirer
-                unit; if unspecified, the pod ip of the unit will be used instead
+            host: Hostname to be used by the ingress provider to address the
+             requirer unit; if unspecified, the pod ip of the unit will be used
+             instead
             port: the port of the service (required)
         """
-        self.wrap(self.relation, self._complete_request(host, port))
+        self._publish_ingress_data(host, port)
 
     @property
-    def relation(self):
-        """The established Relation instance, or None."""
-        return self.relations[0] if self.relations else None
-
-    @property
-    def urls(self):
+    def urls(self) -> dict:
         """The full ingress URLs to reach every unit.
 
         May return an empty dict if the URLs aren't available yet.
         """
-        if self.is_relation_broken or not self.is_ready():
+        relation = self.relation
+        if not relation or self.is_relation_broken:
             return {}
-        data = self.unwrap(self.relation)
-        ingress = data[self.relation.app].get("ingress", {})
+
+        raw = None
+        if relation.app.name:  # type: ignore
+            # FIXME Workaround for https://github.com/canonical/operator/issues/693
+            # We must be in a relation_broken hook
+            raw = relation.data.get(relation.app, {}).get("data")
+
+        if not raw:
+            return {}
+
+        data = _deserialize_data(raw)
+        _validate_data(data, INGRESS_PROVIDES_APP_SCHEMA)
+
+        ingress = data.get("ingress", {})
         return {unit_name: unit_data["url"] for unit_name, unit_data in ingress.items()}
 
     @property
-    def url(self):
+    def url(self) -> Optional[str]:
         """The full ingress URL to reach the current unit.
 
         May return None if the URL isn't available yet.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pyaml
 requests
 lightkube >= 0.8.1
 lightkube-models >= 1.22.0.4
-serialized-data-interface >= 0.4.0
+jsonschema

--- a/src/charm.py
+++ b/src/charm.py
@@ -55,7 +55,7 @@ class PrometheusCharm(CharmBase):
         self.metrics_consumer = MetricsEndpointConsumer(self)
 
         # Manages ingress for this charm
-        self.ingress = IngressPerUnitRequirer(self, endpoint="ingress", port=self._port)
+        self.ingress = IngressPerUnitRequirer(self, relation_name="ingress", port=self._port)
 
         external_url = urlparse(self._external_url)
 


### PR DESCRIPTION
## Issue

1. Fixes issues when breaking the relation between `prometheus-k8s:ingress` and `traefik-k8s`, see https://github.com/canonical/traefik-k8s-operator/issues/34
2. Removes `serialized-data-interface` as dependency, replacing it with `jsonschema` (which was imported transitively from `serialized-data-interface`)

## Solution

Library update, requirements.txt adjustment, kwarg rename.

## Context

N/A

## Testing Instructions

```sh
charmcraft pack
juju deploy traefik-k8s --channel edge --trust
juju config traefik-k8s external_hostname=foo.bar
juju deploy prometheus-k8s ./*.charm
juju relate prometheus-k8s:ingress traefik-k8s
juju remove-relation prometheus-k8s:ingress traefik-k8s
```

Then, check no errors in the logs and all green in `juju status`

## Release Notes

Fixing a bug when breaking the `ingress` relation between [`traefik-k8s`](https://charmhub.io/traefik-k8s) and [`prometheus-k8s`](https://charmhub.io/prometheus-k8s).