### PR TITLE
Fix the duration validator so it matches what prom actually uses

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -256,7 +256,10 @@ class PrometheusCharm(CharmBase):
         Returns:
             True if time specification is valid and False otherwise.
         """
-        if not (matched := re.match(r"[1-9][0-9]*[ymwdhs]", timeval)):
+        timespec_re = re.compile(
+            r"^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$"
+        )
+        if not (matched := timespec_re.search(timeval)):
             self.unit.status = BlockedStatus(f"Invalid time spec : {timeval}")
 
         return bool(matched)

--- a/src/charm.py
+++ b/src/charm.py
@@ -256,6 +256,11 @@ class PrometheusCharm(CharmBase):
         Returns:
             True if time specification is valid and False otherwise.
         """
+        # Prometheus checks here:
+        # https://github.com/prometheus/common/blob/627089d3a7af73be778847aa577192b937b8d89a/model/time.go#L186
+        # Which is where this regex is sourced from. The validation is done
+        # when parsing flags as part of binary invocation here:
+        # https://github.com/prometheus/prometheus/blob/c40e269c3e514953299e9ba1f6265e067ab43e64/cmd/prometheus/main.go#L302
         timespec_re = re.compile(
             r"^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$"
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -156,7 +156,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(cli_arg(plan, "--storage.tsdb.retention.time"), None)
 
         # invalid time value
-        retention_time = "0d"
+        retention_time = "5m1y2d"
         retention_time_config["metrics_retention_time"] = retention_time
 
         self.harness.update_config(retention_time_config)


### PR DESCRIPTION
## Issue
The validator in `prometheus-k8s-operator` to determine what was and was not a valid date for the purposes of configuration had an unclear alignment with what was actually accepted. Updated it to reflect Prometheus.

Closes #128 
## Solution
The [duration must be greater than 0](https://github.com/prometheus/prometheus/blob/c40e269c3e514953299e9ba1f6265e067ab43e64/promql/parser/parse_test.go#L2045), which is actually sort-of at adds with the [actual regex](https://github.com/prometheus/common/blob/627089d3a7af73be778847aa577192b937b8d89a/model/time.go#L186). Except that [prometheus overtly checks for a return value of 0 (ok from the parser) and re-raises an error](https://github.com/prometheus/prometheus/blob/5a754bc043b8e8c2d57cf906386734a73761e2a2/promql/parser/parse.go#L633).

For the actual config, though, this is tricky. Which is _actually_ checked from prometheus/common, so [`0` is ok](https://github.com/prometheus/common/blob/627089d3a7af73be778847aa577192b937b8d89a/model/time.go#L175),  (the type is declared [here](https://github.com/prometheus/prometheus/blob/c40e269c3e514953299e9ba1f6265e067ab43e64/cmd/prometheus/main.go#L214), and the `SetValue()` call [here](https://github.com/prometheus/prometheus/blob/c40e269c3e514953299e9ba1f6265e067ab43e64/cmd/prometheus/main.go#L302) will call back out to `Set` in prometheus/common, which checks `model.ParseDuration`, which **does** allow zeros).


## Testing Instructions
Try to test "broken" dates (such as `5s2m1w`) which are out of order.

## Release Notes
Fix the duration validator so it matches what prom actually uses