### PR TITLE
Don't emit a bunch of warning logs during normal operation

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -518,7 +518,7 @@ class AlertRules:
         elif path.is_file():
             self.alert_groups.extend(self._from_file(path.parent, path))
         else:
-            logger.warning("path does not exist: %s", path)
+            logger.debug("Alert rules path does not exist: %s", path)
 
     def as_dict(self) -> dict:
         """Return standard alert rules file in dict representation.
@@ -1052,7 +1052,7 @@ class PrometheusRemoteWriteProvider(Object):
                 continue
 
             if "groups" not in alert_rules:
-                logger.warning("No alert groups were found in relation data")
+                logger.debug("No alert groups were found in relation data")
                 continue
             # Construct an ID based on what's in the alert rules
             for group in alert_rules["groups"]:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -923,7 +923,7 @@ class AlertRules:
         elif path.is_file():
             self.alert_groups.extend(self._from_file(path.parent, path))
         else:
-            logger.warning("path does not exist: %s", path)
+            logger.debug("Alert rules path does not exist: %s", path)
 
     def as_dict(self) -> dict:
         """Return standard alert rules file in dict representation.
@@ -1130,7 +1130,7 @@ class MetricsEndpointConsumer(Object):
             rules: a dict of alert rules
         """
         if "groups" not in rules:
-            logger.warning("No alert groups were found in relation data")
+            logger.debug("No alert groups were found in relation data")
             return None
 
         # Construct an ID based on what's in the alert rules if they have labels
@@ -1543,7 +1543,7 @@ class MetricsEndpointProvider(Object):
         try:
             alert_rules_path = _resolve_dir_against_charm_path(charm, alert_rules_path)
         except InvalidAlertRulePathError as e:
-            logger.warning(
+            logger.debug(
                 "Invalid Prometheus alert rules folder at %s: %s",
                 e.alert_rules_absolute_path,
                 e.message,
@@ -1702,7 +1702,7 @@ class PrometheusRulesProvider(Object):
         try:
             dir_path = _resolve_dir_against_charm_path(charm, dir_path)
         except InvalidAlertRulePathError as e:
-            logger.warning(
+            logger.debug(
                 "Invalid Prometheus alert rules folder at %s: %s",
                 e.alert_rules_absolute_path,
                 e.message,

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -436,7 +436,7 @@ class TestEndpointConsumer(unittest.TestCase):
         with self.assertLogs(level="WARNING") as logger:
             _ = self.harness.charm.prometheus_consumer.alerts()
             messages = logger.output
-            self.assertEqual(len(messages), 2)
+            self.assertEqual(len(messages), 1)
             self.assertIn(
                 "Alert rules were found but no usable group or identifier was present", messages[1]
             )

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -438,7 +438,7 @@ class TestEndpointConsumer(unittest.TestCase):
             messages = logger.output
             self.assertEqual(len(messages), 1)
             self.assertIn(
-                "Alert rules were found but no usable group or identifier was present", messages[1]
+                "Alert rules were found but no usable group or identifier was present", messages[0]
             )
 
     def test_consumer_accepts_rules_with_no_identifier(self):


### PR DESCRIPTION
## Issue
Various alert rules checks currently emit terrifying-looking warning messages on every invocation of charms, even when "must provide alert rules" is not a requirement.

Closes #266 

## Solution
Use logger.debug instead


## Testing Instructions
Deploy. Make sure there aren't scary warning logs if alert rules aren't present.

## Release Notes
Don't emit  warning logs during normal operation