### PR TITLE
set relation data on leader elected so alert rules are properly set

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1577,6 +1577,9 @@ class MetricsEndpointProvider(Object):
 
         self.framework.observe(self._charm.on.upgrade_charm, self._set_scrape_job_spec)
 
+        # If there is no leader during relation_joined we will still need to set alert rules.
+        self.framework.observe(self._charm.on.leader_elected, self._set_scrape_job_spec)
+
     def _set_scrape_job_spec(self, event):
         """Ensure scrape target information is made available to prometheus.
 

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -637,4 +637,4 @@ class TestNoLeader(unittest.TestCase):
             "alert_rules"
         )
         self.assertIsNotNone(data)
-        self.assertGreater(len(data), 0)
+        self.assertGreater(len(data), 0)  # type: ignore[arg-type]

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -636,4 +636,5 @@ class TestNoLeader(unittest.TestCase):
         data = self.harness.get_relation_data(rel_id, self.harness.model.app.name).get(
             "alert_rules"
         )
+        self.assertIsNotNone(data)
         self.assertGreater(len(data), 0)


### PR DESCRIPTION
## Issue
#104


## Solution
Set relation data as part of `leader_elected`


## Testing Instructions
General broken or not.


## Release Notes
Fixed a bug where alert rules are sometimes not set
