### PR TITLE
Stop setting unit IP on every possible event and choose the right one instead

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1569,8 +1569,10 @@ class MetricsEndpointProvider(Object):
         if not refresh_event:
             if len(self._charm.meta.containers) == 1:
                 if "kubernetes" in self._charm.meta.series:
+                    # This is a podspec charm
                     refresh_event = [self._charm.on.update_status]
                 else:
+                    # This is a sidecar/pebble charm
                     container = list(self._charm.meta.containers.values())[0]
                     refresh_event = [self._charm.on[container.name.replace("-", "_")].pebble_ready]
             else:
@@ -1588,8 +1590,6 @@ class MetricsEndpointProvider(Object):
         for ev in refresh_event:
             self.framework.observe(ev, self._set_unit_ip)
 
-        # dirty fix: set the ip address when the containers start, as a workaround
-        # for not being able to lookup the pod ip
         for container_name in charm.unit.containers:
             self.framework.observe(
                 charm.on[container_name].pebble_ready,

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1579,7 +1579,8 @@ class MetricsEndpointProvider(Object):
                 logger.warning(
                     "%d containers are present in metadata.yaml and "
                     "refresh_event was not specified. Defaulting to update_status. "
-                    "Metrics IP may not be set in a timely fashion."
+                    "Metrics IP may not be set in a timely fashion.",
+                    len(self._charm.meta.containers),
                 )
                 refresh_event = [self._charm.on.update_status]
 
@@ -1589,12 +1590,6 @@ class MetricsEndpointProvider(Object):
 
         for ev in refresh_event:
             self.framework.observe(ev, self._set_unit_ip)
-
-        for container_name in charm.unit.containers:
-            self.framework.observe(
-                charm.on[container_name].pebble_ready,
-                self._set_unit_ip,
-            )
 
         self.framework.observe(self._charm.on.upgrade_charm, self._set_scrape_job_spec)
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -324,7 +324,7 @@ from typing import Dict, List, Optional, Union
 
 import yaml
 from ops.charm import CharmBase, RelationRole
-from ops.framework import EventBase, EventSource, Object, ObjectEvents
+from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
 
 # The unique Charmhub library identifier, never change it
 from ops.model import ModelError
@@ -1432,6 +1432,7 @@ class MetricsEndpointProvider(Object):
         relation_name: str = DEFAULT_RELATION_NAME,
         jobs=None,
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
+        refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
     ):
         """Construct a metrics provider for a Prometheus charm.
 
@@ -1525,6 +1526,8 @@ class MetricsEndpointProvider(Object):
                 files.  Defaults to "./prometheus_alert_rules",
                 resolved relative to the directory hosting the charm entry file.
                 The alert rules are automatically updated on charm upgrade.
+            refresh_event: an optional bound event or list of bound events which
+                will be observed to re-set scrape job data (IP address and others)
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -1563,6 +1566,28 @@ class MetricsEndpointProvider(Object):
         self.framework.observe(events.relation_joined, self._set_scrape_job_spec)
         self.framework.observe(events.relation_changed, self._set_scrape_job_spec)
 
+        if not refresh_event:
+            if len(self._charm.meta.containers) == 1:
+                if "kubernetes" in self._charm.meta.series:
+                    refresh_event = [self._charm.on.update_status]
+                else:
+                    container = list(self._charm.meta.containers.values())[0]
+                    refresh_event = [self._charm.on[container.name.replace("-", "_")].pebble_ready]
+            else:
+                logger.warning(
+                    "%d containers are present in metadata.yaml and "
+                    "refresh_event was not specified. Defaulting to update_status. "
+                    "Metrics IP may not be set in a timely fashion."
+                )
+                refresh_event = [self._charm.on.update_status]
+
+        else:
+            if not isinstance(refresh_event, list):
+                refresh_event = [refresh_event]
+
+        for ev in refresh_event:
+            self.framework.observe(ev, self._set_unit_ip)
+
         # dirty fix: set the ip address when the containers start, as a workaround
         # for not being able to lookup the pod ip
         for container_name in charm.unit.containers:
@@ -1570,10 +1595,6 @@ class MetricsEndpointProvider(Object):
                 charm.on[container_name].pebble_ready,
                 self._set_unit_ip,
             )
-
-        # podspec charms do not have a pebble ready event so unit ips need to be set these events
-        self.framework.observe(self._charm.on.update_status, self._set_unit_ip)
-        self.framework.observe(self._charm.on.config_changed, self._set_unit_ip)
 
         self.framework.observe(self._charm.on.upgrade_charm, self._set_scrape_job_spec)
 

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -151,6 +151,17 @@ class TestEndpointProvider(unittest.TestCase):
         # This is gonna be a LITTLE bit of internals
         # Get ready to poke at ops.framework guts to build it
         # so we can assert it's really true
+        #
+        # The format of framework._observers (which is a list containing
+        # lookups when `self.framework.observe(...)` is called, and subsequently
+        # checked when an event is emitted is:
+        #
+        # (
+        #   <handle_to_object_observing_the_event>
+        #   <method_to_call>
+        #   <handle_path_to_object_being_observed>
+        #   <BoundEvent_which_is_being_observed>
+        # )
         observer_details = (
             str(self.harness.charm.provider.handle),
             "_set_unit_ip",


### PR DESCRIPTION
## Issue
In order to work around the fact that podspec charms don't actually emit any events we can keep tabs on, `prometheus_scrape` was blindly setting (and re-setting) it on every `update_status` and `config_changed` in order to catch it.

This potentially causes strain on the Juju controller with a large number of `MetricsEndpointProviders`.

Closes #269

## Solution
Choose the correct event based on whether it's a sidecar (use `pebble_ready`) or other (use `update_status`).

If there are no containers at all, we no idea, so log a warning telling the author they should specify and choose `update_status`

## Testing Instructions
Run the unit tests. Relate to a podspec charm and a sidecar charm and make sure it's sane.

## Release Notes
Stop setting unit IP on every possible event and choose the right one instead