### PR TITLE
Fix scrape jobs so that there are no duplicate job names.

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -311,6 +311,8 @@ of Metrics provider charms hold eponymous information.
 
 """  # noqa: W505
 
+import copy
+import hashlib
 import ipaddress
 import json
 import logging
@@ -881,6 +883,8 @@ class MetricsEndpointConsumer(Object):
             if static_scrape_jobs:
                 scrape_jobs.extend(static_scrape_jobs)
 
+        scrape_jobs = _dedupe_job_names(scrape_jobs)
+
         return scrape_jobs
 
     def alerts(self) -> dict:
@@ -1233,6 +1237,38 @@ class MetricsEndpointConsumer(Object):
             static_config["targets"] = [host_address]  # type: ignore
 
         return static_config
+
+
+def _dedupe_job_names(jobs):
+    # Convert to a dict with job names as keys
+    # I think this line is O(n^2) but it should be okay given the list sizes
+    jobs_copy = copy.deepcopy(jobs)
+    jobs_dict = {job["job_name"]: list(filter(lambda x: x["job_name"] == job["job_name"], jobs_copy)) for job in jobs_copy}
+
+    # If multiple jobs have the same name, convert the name to "name_<hash-of-job>"
+    for key in jobs_dict:
+        if len(jobs_dict[key]) > 1:
+            for job in jobs_dict[key]:
+                job_json = json.dumps(job)
+                hashed = hashlib.sha256(job_json.encode()).hexdigest()
+                job["job_name"] = '{}_{}'.format(job["job_name"], hashed)
+    new_jobs = []
+    for key in jobs_dict:
+        new_jobs.extend([i for i in jobs_dict[key]])
+
+    # Deduplicate jobs which are deeply equal
+    # Again this in O(n^2) but it should be okay
+    deduped_jobs = []
+    seen = []
+    for job in new_jobs:
+        job_json = json.dumps(job)
+        hashed = hashlib.sha256(job_json.encode()).hexdigest()
+        if hashed in seen:
+            continue
+        seen.append(hashed)
+        deduped_jobs.append(job)
+
+    return deduped_jobs
 
 
 def _resolve_dir_against_charm_path(charm: CharmBase, *path_elements: str) -> str:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1239,7 +1239,7 @@ class MetricsEndpointConsumer(Object):
         return static_config
 
 
-def _dedupe_job_names(jobs):
+def _dedupe_job_names(jobs: List[dict]):
     """Deduplicate a list of dicts by appending a hash to the value of the 'job_name' key.
 
     Additionally fully dedeuplicate any identical jobs.

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1240,9 +1240,17 @@ class MetricsEndpointConsumer(Object):
 
 
 def _dedupe_job_names(jobs):
+    """Deduplicate a list of dicts by appending a hash to the value of the 'job_name' key.
+
+    Additionally fully dedeuplicate any identical jobs.
+
+    Args:
+        jobs: A list of prometheus scrape jobs
+    """
+    jobs_copy = copy.deepcopy(jobs)
+
     # Convert to a dict with job names as keys
     # I think this line is O(n^2) but it should be okay given the list sizes
-    jobs_copy = copy.deepcopy(jobs)
     jobs_dict = {
         job["job_name"]: list(filter(lambda x: x["job_name"] == job["job_name"], jobs_copy))
         for job in jobs_copy
@@ -1259,7 +1267,7 @@ def _dedupe_job_names(jobs):
     for key in jobs_dict:
         new_jobs.extend([i for i in jobs_dict[key]])
 
-    # Deduplicate jobs which are deeply equal
+    # Deduplicate jobs which are equal
     # Again this in O(n^2) but it should be okay
     deduped_jobs = []
     seen = []

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1243,7 +1243,10 @@ def _dedupe_job_names(jobs):
     # Convert to a dict with job names as keys
     # I think this line is O(n^2) but it should be okay given the list sizes
     jobs_copy = copy.deepcopy(jobs)
-    jobs_dict = {job["job_name"]: list(filter(lambda x: x["job_name"] == job["job_name"], jobs_copy)) for job in jobs_copy}
+    jobs_dict = {
+        job["job_name"]: list(filter(lambda x: x["job_name"] == job["job_name"], jobs_copy))
+        for job in jobs_copy
+    }
 
     # If multiple jobs have the same name, convert the name to "name_<hash-of-job>"
     for key in jobs_dict:
@@ -1251,7 +1254,7 @@ def _dedupe_job_names(jobs):
             for job in jobs_dict[key]:
                 job_json = json.dumps(job)
                 hashed = hashlib.sha256(job_json.encode()).hexdigest()
-                job["job_name"] = '{}_{}'.format(job["job_name"], hashed)
+                job["job_name"] = "{}_{}".format(job["job_name"], hashed)
     new_jobs = []
     for key in jobs_dict:
         new_jobs.extend([i for i in jobs_dict[key]])

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -82,7 +82,7 @@ async def get_prometheus_config(ops_test: OpsTest, app_name: str, unit_num: int)
 
 
 async def get_prometheus_active_targets(
-    ops_test: OpsTest, app_name: str, unit_num: int
+    ops_test: OpsTest, app_name: str, unit_num: int = 0
 ) -> List[dict]:
     """Fetch Prometheus active scrape targets.
 

--- a/tests/integration/prometheus-tester/config.yaml
+++ b/tests/integration/prometheus-tester/config.yaml
@@ -10,3 +10,7 @@ options:
     default: src/prometheus_alert_rules
     description: "Path for alert rules passed to the Provider"
     type: string
+  scrape_jobs:
+    default: "[]"
+    description: "Scrape jobs to pass to the MetricsEndpointProvider constructor"
+    type: string

--- a/tests/integration/prometheus-tester/src/charm.py
+++ b/tests/integration/prometheus-tester/src/charm.py
@@ -24,11 +24,16 @@ class PrometheusTesterCharm(CharmBase):
         self._name = "prometheus-tester"
         self._pip_path = "/usr/local/bin/pip"
         self._metrics_exporter_script = Path("src/metrics.py")
+        # The consumer lib should dedupe this properly
         jobs = [
             {
                 "scrape_interval": self.model.config["scrape-interval"],
                 "static_configs": [{"targets": ["*:8000"], "labels": {"name": self._name}}],
-            }
+            },
+            {
+                "scrape_interval": self.model.config["scrape-interval"],
+                "static_configs": [{"targets": ["*:8001"], "labels": {"name": self._name}}],
+            },
         ]
         logger.warning("Rules path is: %s", self.model.config["alert-rules-path"])
         self.prometheus = MetricsEndpointProvider(

--- a/tests/integration/prometheus-tester/src/charm.py
+++ b/tests/integration/prometheus-tester/src/charm.py
@@ -25,7 +25,6 @@ class PrometheusTesterCharm(CharmBase):
         self._name = "prometheus-tester"
         self._pip_path = "/usr/local/bin/pip"
         self._metrics_exporter_script = Path("src/metrics.py")
-        # The consumer lib should dedupe this properly
         if not (jobs := json.loads(self.config["scrape_jobs"])):
             jobs = [
                 {

--- a/tests/integration/test_deduplication.py
+++ b/tests/integration/test_deduplication.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import json
+
+from helpers import get_prometheus_active_targets, oci_image
+from pytest_operator.plugin import OpsTest
+
+prometheus_app_name = "prometheus"
+prometheus_resources = {"prometheus-image": "prom/prometheus:v2.35.0"}
+tester_app_name = "tester"
+tester_resources = {
+    "prometheus-tester-image": oci_image(
+        "./tests/integration/prometheus-tester/metadata.yaml",
+        "prometheus-tester-image",
+    )
+}
+
+
+async def test_multiple_scrape_jobs_in_constructor(
+    ops_test: OpsTest, prometheus_charm, prometheus_tester_charm
+):
+    """Test that jobs are properly deduped when there is more than one in the constructor."""
+    jobs = [
+        {
+            "scrape_interval": "10s",
+            "static_configs": [{"targets": ["*:8000"]}],
+        },
+        {
+            "scrape_interval": "10s",
+            "static_configs": [{"targets": ["*:8000"]}],
+        },
+        {
+            "scrape_interval": "10s",
+            "static_configs": [{"targets": ["*:8001"]}],
+        },
+    ]
+    await asyncio.gather(
+        ops_test.model.deploy(
+            prometheus_charm,
+            resources=prometheus_resources,
+            application_name=prometheus_app_name,
+        ),
+        ops_test.model.deploy(
+            prometheus_tester_charm,
+            resources=tester_resources,
+            application_name=tester_app_name,
+            config={"scrape_jobs": json.dumps(jobs)},
+        ),
+    )
+    await ops_test.model.add_relation(prometheus_app_name, tester_app_name)
+    await ops_test.model.wait_for_idle(status="active")
+
+    targets = await get_prometheus_active_targets(ops_test, prometheus_app_name)
+    # Two unique jobs above plus an additional an additional job for self scraping.
+    assert len(targets) == 3

--- a/tests/integration/test_deduplication.py
+++ b/tests/integration/test_deduplication.py
@@ -22,7 +22,7 @@ tester_resources = {
 async def test_multiple_scrape_jobs_in_constructor(
     ops_test: OpsTest, prometheus_charm, prometheus_tester_charm
 ):
-    """Test that job names are properly deduped when they are non-unique in the same consumer unit."""
+    """Test that job names are properly deduped when in the same consumer unit."""
     jobs = [
         {
             "scrape_interval": "10s",

--- a/tests/integration/test_deduplication.py
+++ b/tests/integration/test_deduplication.py
@@ -42,6 +42,7 @@ async def test_multiple_scrape_jobs_in_constructor(
             prometheus_charm,
             resources=prometheus_resources,
             application_name=prometheus_app_name,
+            trust=True,
         ),
         ops_test.model.deploy(
             prometheus_tester_charm,

--- a/tests/integration/test_deduplication.py
+++ b/tests/integration/test_deduplication.py
@@ -22,7 +22,7 @@ tester_resources = {
 async def test_multiple_scrape_jobs_in_constructor(
     ops_test: OpsTest, prometheus_charm, prometheus_tester_charm
 ):
-    """Test that jobs are properly deduped when there is more than one in the constructor."""
+    """Test that job names are properly deduped when they are non-unique in the same consumer unit."""
     jobs = [
         {
             "scrape_interval": "10s",

--- a/tests/integration/test_deduplication.py
+++ b/tests/integration/test_deduplication.py
@@ -9,7 +9,7 @@ from helpers import get_prometheus_active_targets, oci_image
 from pytest_operator.plugin import OpsTest
 
 prometheus_app_name = "prometheus"
-prometheus_resources = {"prometheus-image": "prom/prometheus:v2.35.0"}
+prometheus_resources = {"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")}
 tester_app_name = "tester"
 tester_resources = {
     "prometheus-tester-image": oci_image(

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,0 +1,44 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+
+import deepdiff
+
+from charms.prometheus_k8s.v0.prometheus_scrape import _dedupe_job_names
+
+
+class TestFunctions(unittest.TestCase):
+    def test_dedupe_job_names(self):
+        jobs = [
+            {"job_name": "job0",
+             "static_configs": [{"targets": ["localhost:9090"]}],
+             "scrape_interval": "5s"},
+            {"job_name": "job0",
+             "static_configs": [{"targets": ["localhost:9090"]}],
+             "scrape_interval": "5s"},
+            {"job_name": "job1",
+             "static_configs": [{"targets": ["localhost:9090"]}],
+             "scrape_interval": "5s"},
+            {"job_name": "job0",
+             "static_configs": [{"targets": ["localhost:9090"]}],
+             "scrape_interval": "10s"},
+            {"job_name": "job0",
+             "static_configs": [{"targets": ["localhost:9091"]}],
+             "scrape_interval": "5s"},
+        ]
+        expected = [
+            {'job_name': 'job0_6f9f1c305506707b952aef3885fa099fe36158f6359b8a06634068270645aefd',
+             'scrape_interval': '5s',
+             'static_configs': [{'targets': ['localhost:9090']}]},
+            {'job_name': 'job0_c651cf3a8cd1b85abc0cf7620e058b87ef43e2296d1520328ce5a796e9b20993',
+             'scrape_interval': '10s',
+             'static_configs': [{'targets': ['localhost:9090']}]},
+            {'job_name': 'job0_546b5bbb56e719d894b0a557975e0926ed093ea547c87051595d953122d2a7d6',
+             'scrape_interval': '5s',
+             'static_configs': [{'targets': ['localhost:9091']}]},
+            {'job_name': 'job1',
+             'scrape_interval': '5s',
+             'static_configs': [{'targets': ['localhost:9090']}]}
+        ]
+        self.assertTrue(len(deepdiff.DeepDiff(_dedupe_job_names(jobs), expected)) == 0)

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import copy
 import unittest
 
 import deepdiff
@@ -36,6 +37,7 @@ class TestFunctions(unittest.TestCase):
                 "scrape_interval": "5s",
             },
         ]
+        jobs_original = copy.deepcopy(jobs)
         expected = [
             {
                 "job_name": "job0_6f9f1c305506707b952aef3885fa099fe36158f6359b8a06634068270645aefd",
@@ -59,3 +61,5 @@ class TestFunctions(unittest.TestCase):
             },
         ]
         self.assertTrue(len(deepdiff.DeepDiff(_dedupe_job_names(jobs), expected)) == 0)
+        # Make sure the function does not modify its argument
+        self.assertEqual(jobs, jobs_original)

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -4,41 +4,58 @@
 import unittest
 
 import deepdiff
-
 from charms.prometheus_k8s.v0.prometheus_scrape import _dedupe_job_names
 
 
 class TestFunctions(unittest.TestCase):
     def test_dedupe_job_names(self):
         jobs = [
-            {"job_name": "job0",
-             "static_configs": [{"targets": ["localhost:9090"]}],
-             "scrape_interval": "5s"},
-            {"job_name": "job0",
-             "static_configs": [{"targets": ["localhost:9090"]}],
-             "scrape_interval": "5s"},
-            {"job_name": "job1",
-             "static_configs": [{"targets": ["localhost:9090"]}],
-             "scrape_interval": "5s"},
-            {"job_name": "job0",
-             "static_configs": [{"targets": ["localhost:9090"]}],
-             "scrape_interval": "10s"},
-            {"job_name": "job0",
-             "static_configs": [{"targets": ["localhost:9091"]}],
-             "scrape_interval": "5s"},
+            {
+                "job_name": "job0",
+                "static_configs": [{"targets": ["localhost:9090"]}],
+                "scrape_interval": "5s",
+            },
+            {
+                "job_name": "job0",
+                "static_configs": [{"targets": ["localhost:9090"]}],
+                "scrape_interval": "5s",
+            },
+            {
+                "job_name": "job1",
+                "static_configs": [{"targets": ["localhost:9090"]}],
+                "scrape_interval": "5s",
+            },
+            {
+                "job_name": "job0",
+                "static_configs": [{"targets": ["localhost:9090"]}],
+                "scrape_interval": "10s",
+            },
+            {
+                "job_name": "job0",
+                "static_configs": [{"targets": ["localhost:9091"]}],
+                "scrape_interval": "5s",
+            },
         ]
         expected = [
-            {'job_name': 'job0_6f9f1c305506707b952aef3885fa099fe36158f6359b8a06634068270645aefd',
-             'scrape_interval': '5s',
-             'static_configs': [{'targets': ['localhost:9090']}]},
-            {'job_name': 'job0_c651cf3a8cd1b85abc0cf7620e058b87ef43e2296d1520328ce5a796e9b20993',
-             'scrape_interval': '10s',
-             'static_configs': [{'targets': ['localhost:9090']}]},
-            {'job_name': 'job0_546b5bbb56e719d894b0a557975e0926ed093ea547c87051595d953122d2a7d6',
-             'scrape_interval': '5s',
-             'static_configs': [{'targets': ['localhost:9091']}]},
-            {'job_name': 'job1',
-             'scrape_interval': '5s',
-             'static_configs': [{'targets': ['localhost:9090']}]}
+            {
+                "job_name": "job0_6f9f1c305506707b952aef3885fa099fe36158f6359b8a06634068270645aefd",
+                "scrape_interval": "5s",
+                "static_configs": [{"targets": ["localhost:9090"]}],
+            },
+            {
+                "job_name": "job0_c651cf3a8cd1b85abc0cf7620e058b87ef43e2296d1520328ce5a796e9b20993",
+                "scrape_interval": "10s",
+                "static_configs": [{"targets": ["localhost:9090"]}],
+            },
+            {
+                "job_name": "job0_546b5bbb56e719d894b0a557975e0926ed093ea547c87051595d953122d2a7d6",
+                "scrape_interval": "5s",
+                "static_configs": [{"targets": ["localhost:9091"]}],
+            },
+            {
+                "job_name": "job1",
+                "scrape_interval": "5s",
+                "static_configs": [{"targets": ["localhost:9090"]}],
+            },
         ]
         self.assertTrue(len(deepdiff.DeepDiff(_dedupe_job_names(jobs), expected)) == 0)


### PR DESCRIPTION
This is because duplicate job names cause errors in the prometheus config

## Issue
https://github.com/canonical/prometheus-k8s-operator/issues/263


## Solution
Append a hash to then end of each duplicate job name


## Testing Instructions
Ensure that if duplicate job name or no job names are used, Prometheus does not crash.


## Release Notes
Fixed an issue where duplicate job names were causing Prometheus to crash.
