### PR TITLE
Use fqdn instead of bind_address

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -34,7 +34,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 logger = logging.getLogger(__name__)
@@ -922,8 +922,7 @@ class PrometheusRemoteWriteProvider(Object):
             endpoint_address: The URL host for your remote_write endpoint as reachable
                 from the client. This might be either the pod IP, or you might want to
                 expose an address routable from outside the Kubernetes cluster, e.g., the
-                host address of an Ingress. If not provided, it defaults to the relation's
-                `bind_address`.
+                host address of an Ingress. If not provided, it defaults to the unit's FQDN.
             endpoint_port: The URL port for your remote_write endpoint. Defaults to `9090`.
             endpoint_path: The URL path for your remote_write endpoint.
                 Defaults to `/api/v1/write`.

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -311,12 +311,12 @@ of Metrics provider charms hold eponymous information.
 
 """  # noqa: W505
 
-import contextlib
 import ipaddress
 import json
 import logging
 import os
 import platform
+import socket
 import subprocess
 from collections import OrderedDict
 from pathlib import Path
@@ -334,7 +334,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 19
+LIBPATCH = 20
 
 logger = logging.getLogger(__name__)
 
@@ -1634,16 +1634,7 @@ class MetricsEndpointProvider(Object):
         event is actually needed.
         """
         for relation in self._charm.model.relations[self._relation_name]:
-            unit_ip = str(self._charm.model.get_binding(relation).network.bind_address)
-
-            if not self._is_valid_unit_address(unit_ip):
-                # relation data will be updated later when a valid address becomes available
-                with contextlib.suppress(KeyError):
-                    del relation.data[self._charm.unit]["prometheus_scrape_unit_address"]
-                    del relation.data[self._charm.unit]["prometheus_scrape_unit_name"]
-                continue
-
-            relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = unit_ip
+            relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = socket.getfqdn()
             relation.data[self._charm.unit]["prometheus_scrape_unit_name"] = str(
                 self._charm.model.unit.name
             )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -24,14 +24,13 @@ SCRAPE_METADATA = {
 
 class TestCharm(unittest.TestCase):
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
-    @patch_network_get(private_address="1.1.1.1")
+    @patch_network_get()
     def setUp(self, *unused):
         self.harness = Harness(PrometheusCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin_with_initial_hooks()
 
-    @patch_network_get(private_address="1.1.1.1")
-    def test_grafana_is_provided_port_and_source(self, *unused):
+    def test_grafana_is_provided_port_and_source(self):
         rel_id = self.harness.add_relation("grafana-source", "grafana")
         self.harness.add_relation_unit(rel_id, "grafana/0")
         fqdn = socket.getfqdn()
@@ -40,8 +39,7 @@ class TestCharm(unittest.TestCase):
         ]
         self.assertEqual(grafana_host, "http://{}:{}".format(fqdn, "9090"))
 
-    @patch_network_get(private_address="1.1.1.1")
-    def test_web_external_url_is_passed_to_grafana(self, *unused):
+    def test_web_external_url_is_passed_to_grafana(self):
         self.harness.set_leader(True)
         self.harness.update_config({"web_external_url": "http://test:80/foo/bar"})
 
@@ -79,7 +77,6 @@ class TestCharm(unittest.TestCase):
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(cli_arg(plan, "--log.level"), "warn")
 
-    @patch_network_get(private_address="1.1.1.1")
     def test_ingress_relation_not_set(self):
         self.harness.set_leader(True)
 
@@ -87,7 +84,6 @@ class TestCharm(unittest.TestCase):
         fqdn = socket.getfqdn()
         self.assertEqual(cli_arg(plan, "--web.external-url"), f"http://{fqdn}:9090")
 
-    @patch_network_get(private_address="1.1.1.1")
     def test_ingress_relation_set(self):
         self.harness.set_leader(True)
 
@@ -98,7 +94,6 @@ class TestCharm(unittest.TestCase):
         fqdn = socket.getfqdn()
         self.assertEqual(cli_arg(plan, "--web.external-url"), f"http://{fqdn}:9090")
 
-    @patch_network_get(private_address="1.1.1.1")
     def test_web_external_url_has_precedence_over_ingress_relation(self):
         self.harness.set_leader(True)
 
@@ -110,7 +105,6 @@ class TestCharm(unittest.TestCase):
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(cli_arg(plan, "--web.external-url"), "http://test:80")
 
-    @patch_network_get(private_address="1.1.1.1")
     def test_web_external_url_set(self):
         self.harness.set_leader(True)
 

--- a/tests/unit/test_charm_status.py
+++ b/tests/unit/test_charm_status.py
@@ -37,7 +37,7 @@ class TestActiveStatus(unittest.TestCase):
         # AND the current unit is a leader
         self.harness.set_leader(True)
 
-    @patch_network_get(private_address="1.1.1.1")
+    @patch_network_get()
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     def test_unit_is_active_if_deployed_without_relations_or_config(self):
         """Scenario: Unit is deployed without any user-provided config or regular relations."""
@@ -54,7 +54,7 @@ class TestActiveStatus(unittest.TestCase):
             plan = self.harness.get_container_pebble_plan(self.harness.charm._name)
             self.assertTrue(plan.to_dict())
 
-    @patch_network_get(private_address="1.1.1.1")
+    @patch_network_get()
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     def test_unit_is_blocked_if_reload_configuration_fails(self):
         """Scenario: Unit is deployed but reload configuration fails."""

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -214,7 +214,7 @@ class TestRemoteWriteProvider(unittest.TestCase):
     @patch.object(Prometheus, "reload_configuration", new=lambda _: True)
     @patch("socket.getfqdn", new=lambda *args: "fqdn")
     @patch_network_get()
-    def test_port_is_set(self, *unused):
+    def test_port_is_set(self):
         self.harness.begin_with_initial_hooks()
 
         rel_id = self.harness.add_relation(RELATION_NAME, "consumer")
@@ -228,7 +228,7 @@ class TestRemoteWriteProvider(unittest.TestCase):
     @patch.object(KubernetesServicePatch, "_service_object", new=lambda *args: None)
     @patch.object(Prometheus, "reload_configuration", new=lambda _: True)
     @patch_network_get()
-    def test_alert_rules(self, *unused):
+    def test_alert_rules(self):
         self.harness.begin_with_initial_hooks()
 
         rel_id = self.harness.add_relation(RELATION_NAME, "consumer")

--- a/tox.ini
+++ b/tox.ini
@@ -68,8 +68,8 @@ deps =
     types-requests
     charm: -r{toxinidir}/requirements.txt
     lib: ops
-    responses==0.20.0
-    httpcore==0.14.7
+    charm: responses==0.20.0
+    charm: httpcore==0.14.7
 commands =
     charm: mypy {[vars]src_path} {posargs}
     lib: mypy --python-version 3.5 {[vars]lib_path} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,8 @@ deps =
     types-requests
     charm: -r{toxinidir}/requirements.txt
     lib: ops
+    responses==0.20.0
+    httpcore==0.14.7
 commands =
     charm: mypy {[vars]src_path} {posargs}
     lib: mypy --python-version 3.5 {[vars]lib_path} {posargs}


### PR DESCRIPTION
## Issue
`bind_address` sometimes returns None. Recently observed during load test.

Closes #251.

Crossref: [OPENG-785](https://warthogs.atlassian.net/browse/OPENG-785)


## Solution
Use `socket.getfqdn` instead of `bind_address`.


## Context
NTA


## Testing Instructions
Run integration tests.


## Release Notes
Replace bind_address with fqdn.