### PR TITLE
Add maximum retention size config option (in percent)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,18 +36,18 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -61,4 +61,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -105,5 +105,6 @@ jobs:
         with:
           juju-channel: latest/stable
           provider: microk8s
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Run Prometheus integration tests
         run: tox -vve integration

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -19,8 +19,6 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          comment-on-pr: false
-          fail-build: true
 
   static-lib:
     name: Static analysis of /lib for Python 3.5

--- a/.github/workflows/release-edge.yaml
+++ b/.github/workflows/release-edge.yaml
@@ -101,6 +101,7 @@ jobs:
         with:
           juju-channel: latest/stable
           provider: microk8s
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Run Prometheus integration tests
         run: tox -vve integration
 

--- a/.jujuignore
+++ b/.jujuignore
@@ -7,3 +7,4 @@ tox.ini
 CONTRIBUTING.md
 INTEGRATING.md
 RELEASE.md
+promql-transform-*

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,6 +31,12 @@ charmcraft release prometheus-k8s --channel=beta --revision=19 --resource=promet
 ```
 Note: The charm revision and resource revisions will need to be set appropriately.
 
+### Publish charm libraries
+```shell
+charmcraft publish-lib charms.prometheus_k8s.v0.prometheus_scrape
+charmcraft publish-lib charms.prometheus_k8s.v0.prometheus_remote_write
+```
+
 ## A note on granularity of revisions
 
 We believe in shipping often and with confidence.

--- a/config.yaml
+++ b/config.yaml
@@ -20,9 +20,9 @@ options:
       e.g.:
 
       http://foo.bar/
-      
+
       Note, do *not* set this configuration to a specific to an API path, e.g.,
-      
+
       http://foo.bar//api/v1/write  # DO NOT TRY THIS AT HOME
 
       This configuration option takes precedence over the URL provided over
@@ -35,6 +35,15 @@ options:
       Units Supported: y, w, d, h, m, s
     type: string
     default: 15d
+  maximum_retention_size:
+    description: |
+      The maximum storage to retain, expressed as a percentage (0-100) of the PVC capacity (e.g.
+      "80%").
+      The percentage value is then converted to bytes and passed to prometheus with the
+      `--storage.tsdb.retention.size` argument.
+      Default is 80%.
+    type: string
+    default: "80%"
   metrics_wal_compression:
     description: |
       This flag enables compression of the write-ahead log (WAL).

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -10,14 +10,12 @@ ingress.
 ## Getting Started
 
 To get started using the library, you just need to fetch the library using `charmcraft`.
-**Note that you also need to add the `serialized_data_interface` dependency to your
-charm's `requirements.txt`.**
 
 ```shell
-cd some-charm
 charmcraft fetch-lib charms.traefik_k8s.v0.ingress_per_unit
-echo -e "serialized_data_interface\n" >> requirements.txt
 ```
+
+Add the `jsonschema` dependency to the `requirements.txt` of your charm.
 
 ```yaml
 requires:
@@ -48,151 +46,492 @@ class SomeCharm(CharmBase):
         logger.info("This unit's ingress URL: %s", self.ingress_per_unit.url)
 ```
 """
-
 import logging
-from typing import Optional
+from typing import Dict, Optional, TypeVar, Union
 
-from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent, RelationRole
-from ops.framework import EventSource
-from ops.model import Relation, Unit
-
-try:
-    from serialized_data_interface import EndpointWrapper
-    from serialized_data_interface.errors import RelationDataError
-    from serialized_data_interface.events import EndpointWrapperEvents
-except ImportError:
-    import os
-
-    library_name = os.path.basename(__file__)
-    raise ModuleNotFoundError(
-        "To use the '{}' library, you must include "
-        "the '{}' package in your dependencies".format(library_name, "serialized_data_interface")
-    ) from None  # Suppress original ImportError
-
-try:
-    # introduced in 3.9
-    from functools import cache  # type: ignore
-except ImportError:
-    from functools import lru_cache
-
-    cache = lru_cache(maxsize=None)
+import ops.model
+import yaml
+from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
+from ops.framework import EventSource, Object, ObjectEvents
+from ops.model import (
+    ActiveStatus,
+    Application,
+    BlockedStatus,
+    Relation,
+    StatusBase,
+    Unit,
+    WaitingStatus,
+)
 
 # The unique Charmhub library identifier, never change it
-LIBID = "7ef06111da2945ed84f4f5d4eb5b353a"  # can't register a library until the charm is in the store 9_9
+LIBID = "7ef06111da2945ed84f4f5d4eb5b353a"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 10
 
 log = logging.getLogger(__name__)
 
-INGRESS_SCHEMA = {
-    "v1": {
-        "requires": {
-            "unit": {
-                "type": "object",
-                "properties": {
-                    "model": {"type": "string"},
-                    "name": {"type": "string"},
-                    "host": {"type": "string"},
-                    "port": {"type": "integer"},
-                },
-                "required": ["model", "name", "host", "port"],
-            }
+try:
+    import jsonschema
+
+    DO_VALIDATION = True
+except ModuleNotFoundError:
+    log.warning(
+        "The `ingress_per_unit` library needs the `jsonschema` package to be able "
+        "to do runtime data validation; without it, it will still work but validation "
+        "will be disabled. \n"
+        "It is recommended to add `jsonschema` to the 'requirements.txt' of your charm, "
+        "which will enable this feature."
+    )
+    DO_VALIDATION = False
+
+# LIBRARY GLOBS
+RELATION_INTERFACE = "ingress_per_unit"
+DEFAULT_RELATION_NAME = RELATION_INTERFACE.replace("_", "-")
+
+INGRESS_REQUIRES_UNIT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "model": {"type": "string"},
+        "name": {"type": "string"},
+        "host": {"type": "string"},
+        "port": {"type": "integer"},
+    },
+    "required": ["model", "name", "host", "port"],
+}
+INGRESS_PROVIDES_APP_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "ingress": {
+            "type": "object",
+            "patternProperties": {
+                "": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string"},
+                    },
+                    "required": ["url"],
+                }
+            },
         },
-        "provides": {
-            "app": {
-                "type": "object",
-                "properties": {
-                    "ingress": {
-                        "type": "object",
-                        "patternProperties": {
-                            "": {
-                                "type": "object",
-                                "properties": {"url": {"type": "string"}},
-                                "required": ["url"],
-                            }
-                        },
-                    }
-                },
-                "required": ["ingress"],
-            }
-        },
-    }
+        # Optional key for backwards compatibility
+        # with legacy requirers based on SDI
+        "_supported_versions": {"type": "string"},
+    },
+    "required": ["ingress"],
 }
 
 
-class IngressPerUnitRequestEvent(RelationEvent):
-    """Event representing an incoming request.
+# TYPES
+try:
+    from typing import TypedDict
+except ImportError:
+    from typing_extensions import TypedDict  # py35 compat
 
-    This is equivalent to the "ready" event, but is more semantically meaningful.
+
+class RequirerData(TypedDict):
+    """Model of the data a unit implementing the requirer will need to provide."""
+
+    model: str
+    name: str
+    host: str
+    port: int
+
+
+RequirerUnitData = Dict[Unit, "RequirerData"]
+KeyValueMapping = Dict[str, str]
+ProviderApplicationData = Dict[str, KeyValueMapping]
+
+
+def _validate_data(data, schema):
+    """Checks whether `data` matches `schema`.
+
+    Will raise DataValidationError if the data is not valid, else return None.
+    """
+    if not DO_VALIDATION:
+        return
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        raise DataValidationError(data, schema) from e
+
+
+# EXCEPTIONS
+class DataValidationError(RuntimeError):
+    """Raised when data validation fails on IPU relation data."""
+
+
+class RelationException(RuntimeError):
+    """Base class for relation exceptions from this library.
+
+    Attributes:
+        relation: The Relation which caused the exception.
+        entity: The Application or Unit which caused the exception.
     """
 
+    def __init__(self, relation: Relation, entity: Union[Application, Unit]):
+        super().__init__(relation)
+        self.args = (
+            "There is an error with the relation {}:{} with {}".format(
+                relation.name, relation.id, entity.name
+            ),
+        )
+        self.relation = relation
+        self.entity = entity
 
-class IngressPerUnitProviderEvents(EndpointWrapperEvents):
-    """Container for IUP events."""
 
-    request = EventSource(IngressPerUnitRequestEvent)
+class RelationDataMismatchError(RelationException):
+    """Data from different units do not match where they should."""
 
 
-class IngressPerUnitProvider(EndpointWrapper):
+class RelationPermissionError(RelationException):
+    """Ingress is requested to do something for which it lacks permissions."""
+
+    def __init__(self, relation: Relation, entity: Union[Application, Unit], message: str):
+        super(RelationPermissionError, self).__init__(relation, entity)
+        self.args = (
+            "Unable to write data to relation '{}:{}' with {}: {}".format(
+                relation.name, relation.id, entity.name, message
+            ),
+        )
+
+
+# EVENTS
+class RelationAvailableEvent(RelationEvent):
+    """Event triggered when a relation is ready to provide ingress."""
+
+
+class RelationFailedEvent(RelationEvent):
+    """Event triggered when something went wrong with a relation."""
+
+
+class RelationReadyEvent(RelationEvent):
+    """Event triggered when a remote relation has the expected data."""
+
+
+class IngressPerUnitEvents(ObjectEvents):
+    """Container for events for IngressPerUnit."""
+
+    available = EventSource(RelationAvailableEvent)
+    ready = EventSource(RelationReadyEvent)
+    failed = EventSource(RelationFailedEvent)
+    broken = EventSource(RelationBrokenEvent)
+
+
+class _IngressPerUnitBase(Object):
+    """Base class for IngressPerUnit interface classes."""
+
+    _IngressPerUnitEventType = TypeVar("_IngressPerUnitEventType", bound=IngressPerUnitEvents)
+    on: _IngressPerUnitEventType
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        """Constructor for _IngressPerUnitBase.
+
+        Args:
+            charm: The charm that is instantiating the instance.
+            relation_name: The name of the relation name to bind to
+                (defaults to "ingress-per-unit").
+        """
+        super().__init__(charm, relation_name)
+        self.charm: CharmBase = charm
+
+        self.relation_name = relation_name
+        self.app = self.charm.app
+        self.unit = self.charm.unit
+
+        observe = self.framework.observe
+        rel_events = charm.on[relation_name]
+        observe(rel_events.relation_created, self._handle_relation)
+        observe(rel_events.relation_joined, self._handle_relation)
+        observe(rel_events.relation_changed, self._handle_relation)
+        observe(rel_events.relation_broken, self._handle_relation_broken)
+        observe(charm.on.leader_elected, self._handle_upgrade_or_leader)
+        observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)
+
+    @property
+    def relations(self):
+        """The list of Relation instances associated with this relation_name."""
+        return list(self.charm.model.relations[self.relation_name])
+
+    def _handle_relation(self, event):
+        relation = event.relation
+        if self.is_ready(relation):
+            self.on.ready.emit(relation)
+        elif self.is_available(relation):
+            self.on.available.emit(relation)
+        elif self.is_failed(relation):
+            self.on.failed.emit(relation)
+        else:
+            log.debug(
+                "Relation {} is neither ready, nor available, nor failed. "
+                "Something fishy's going on...".format(relation)
+            )
+
+    def get_status(self, relation: Relation) -> StatusBase:
+        """Get the suggested status for the given Relation."""
+        if self.is_failed(relation):
+            return BlockedStatus(
+                "Error handling relation {}:{}".format(relation.name, relation.id)
+            )
+        elif not self.is_available(relation):
+            return WaitingStatus("Waiting on relation {}:{}".format(relation.name, relation.id))
+        elif not self.is_ready(relation):
+            return WaitingStatus("Waiting on relation {}:{}".format(relation.name, relation.id))
+        else:
+            return ActiveStatus()
+
+    def _handle_relation_broken(self, event):
+        self.on.broken.emit(event.relation)
+
+    def _handle_upgrade_or_leader(self, _):
+        pass
+
+    def is_available(self, relation: Relation = None) -> bool:
+        """Check whether the given relation is available.
+
+        Or any relation if not specified.
+        """
+        if relation is None:
+            return any(map(self.is_available, self.relations))
+
+        if not relation.app.name:
+            # Juju doesn't provide JUJU_REMOTE_APP during relation-broken
+            # hooks. See https://github.com/canonical/operator/issues/693.
+            # Relation in the process of breaking cannot be available.
+            return False
+
+        return True
+
+    def is_ready(self, relation: Relation = None) -> bool:
+        """Checks whether the given relation is ready.
+
+        Or any relation if not specified.
+        A given relation is ready if the remote side has sent valid data.
+        """
+        if relation is None:
+            return any(map(self.is_ready, self.relations))
+        if relation.app is None:
+            # No idea why, but this happened once.
+            return False
+        if not relation.app.name:  # type: ignore
+            # Juju doesn't provide JUJU_REMOTE_APP during relation-broken
+            # hooks. See https://github.com/canonical/operator/issues/693
+            return False
+        return True
+
+    def is_failed(self, _: Relation = None) -> bool:
+        """Checks whether the given relation is failed.
+
+        Or any relation if not specified.
+        """
+        raise NotImplementedError("implement in subclass")
+
+
+class IngressPerUnitProvider(_IngressPerUnitBase):
     """Implementation of the provider of ingress_per_unit."""
 
-    ROLE = RelationRole.provides.name
-    INTERFACE = "ingress_per_unit"
-    SCHEMA = INGRESS_SCHEMA
+    on = IngressPerUnitEvents()
 
-    on = IngressPerUnitProviderEvents()
-
-    def __init__(self, charm: CharmBase, endpoint: str = None):
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
         """Constructor for IngressPerUnitProvider.
 
         Args:
             charm: The charm that is instantiating the instance.
-            endpoint: The name of the relation endpoint to bind to
+            relation_name: The name of the relation relation_name to bind to
                 (defaults to "ingress-per-unit").
         """
-        super().__init__(charm, endpoint)
-        self.framework.observe(self.on.ready, self._emit_request_event)
+        super().__init__(charm, relation_name)
+        observe = self.framework.observe
+        observe(self.charm.on[relation_name].relation_joined, self._share_version_info)
 
-    def _emit_request_event(self, event):
-        self.on.request.emit(event.relation)
+    def _share_version_info(self, event):
+        """Backwards-compatibility shim for version negotiation.
 
-    def get_request(self, relation: Relation):
-        """Get the IngressRequest for the given Relation."""
-        return IngressRequest(self, relation)
+        Allows older versions of IPU (requirer side) to interact with this
+        provider without breaking.
+        Will be removed in a future version of this library.
+        Do not use.
+        """
+        relation = event.relation
+        if self.charm.unit.is_leader():
+            log.info("shared supported_versions shim information")
+            relation.data[self.charm.app]["_supported_versions"] = "- v1"
 
-    @cache
-    def is_failed(self, relation: Relation = None):
-        """Checks whether the given relation, or any relation if not specified, has an error."""
+    def is_ready(self, relation: Relation = None) -> bool:
+        """Checks whether the given relation is ready.
+
+        Or any relation if not specified.
+        A given relation is ready if SOME remote side has sent valid data.
+        """
         if relation is None:
-            return any(self.is_failed(relation) for relation in self.relations)
-        if not relation.units:
+            return any(map(self.is_ready, self.relations))
+
+        if not super().is_ready(relation):
             return False
-        if super().is_failed(relation):
+
+        try:
+            requirer_unit_data = self._requirer_unit_data(relation)
+        except Exception:
+            log.exception("Cannot fetch ingress data for the '{}' relation".format(relation))
+            return False
+
+        return any(requirer_unit_data.values())
+
+    def is_failed(self, relation: Relation = None) -> bool:
+        """Checks whether the given relation is failed.
+
+        Or any relation if not specified.
+        """
+        if relation is None:
+            return any(map(self.is_failed, self.relations))
+
+        if not relation.app.name:  # type: ignore
+            # Juju doesn't provide JUJU_REMOTE_APP during relation-broken
+            # hooks. See https://github.com/canonical/operator/issues/693
+            return False
+
+        if not relation.units:
+            # Relations without requiring units cannot be in failed state
+            return False
+
+        try:
+            # grab the data and validate it; might raise
+            requirer_unit_data = self._requirer_unit_data(relation)
+        except DataValidationError as e:
+            log.warning("Failed to validate relation data for {} relation: {}".format(relation, e))
             return True
-        data = self.unwrap(relation)
-        prev_fields = None
-        for unit in relation.units:
-            if not data[unit]:
-                continue
-            new_fields = {field: data[unit][field] for field in ("model", "port")}
-            if prev_fields is None:
-                prev_fields = new_fields
-            if new_fields != prev_fields:
-                raise RelationDataMismatchError(relation, unit)
+
+        # verify that all remote units (requirer's side) publish the same model.
+        # We do not validate the port because, in case of changes to the configuration
+        # of the charm or a new version of the charmed workload, e.g. over an upgrade,
+        # the remote port may be different among units.
+        expected_model = None  # It may be none for units that have not yet written data
+
+        for remote_unit, remote_unit_data in requirer_unit_data.items():
+            if "model" in remote_unit_data:
+                remote_model = remote_unit_data["model"]
+                if not expected_model:
+                    expected_model = remote_model
+                elif expected_model != remote_model:
+                    raise RelationDataMismatchError(relation, remote_unit)
+
         return False
 
+    def is_unit_ready(self, relation: Relation, unit: Unit) -> bool:
+        """Report whether the given unit has shared data in its unit data bag."""
+        # sanity check: this should not occur in production, but it may happen
+        # during testing: cfr https://github.com/canonical/traefik-k8s-operator/issues/39
+        assert (
+            unit in relation.units
+        ), "attempting to get ready state for unit that does not belong to relation"
+        if relation.data.get(unit, {}).get("data"):
+            # TODO consider doing schema-based validation here
+            return True
+        return False
+
+    def get_data(self, relation: Relation, unit: Unit) -> "RequirerData":
+        """Fetch the data shared by the specified unit on the relation (Requirer side)."""
+        data = yaml.safe_load(relation.data[unit]["data"])
+        _validate_data(data, INGRESS_REQUIRES_UNIT_SCHEMA)
+        return data
+
+    def publish_url(self, relation: Relation, unit_name: str, url: str):
+        """Place the ingress url in the application data bag for the units on the requires side.
+
+        Assumes that this unit is leader.
+        """
+        raw_data = relation.data[self.app].get("data", None)
+        data = yaml.safe_load(raw_data) if raw_data else {"ingress": {}}
+
+        # we ensure that the application databag has the shape we think it
+        # should have; to catch any inconsistencies early on.
+        try:
+            _validate_data(data, INGRESS_PROVIDES_APP_SCHEMA)
+        except DataValidationError as e:
+            log.error(
+                "unable to publish url to {}: corrupted application databag ({})".format(
+                    unit_name, e
+                )
+            )
+            return
+
+        # we update the data with a new url
+        data["ingress"][unit_name] = {"url": url}
+
+        # we validate the data **again**, to ensure that we respected the schema
+        # and did not accidentally corrupt our own databag.
+        _validate_data(data, INGRESS_PROVIDES_APP_SCHEMA)
+
+        try:
+            relation.data[self.app]["data"] = yaml.safe_dump(data)
+        except ops.model.RelationDataError:
+            unit = self.unit
+            raise RelationPermissionError(
+                relation,
+                unit,
+                "failed to write application data: leader={}".format(unit.is_leader()),
+            )
+
+    def wipe_ingress_data(self, relation):
+        """Remove all published ingress data.
+
+        Assumes that this unit is leader.
+        """
+        relation.data[self.app]["data"] = ""
+
+    def _requirer_unit_data(self, relation: Relation) -> RequirerUnitData:
+        """Fetch and validate the requirer's unit databag."""
+        if not relation.app or not relation.app.name:
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return {}
+
+        remote_units = [unit for unit in relation.units if unit.app is not self.app]
+
+        requirer_unit_data = {}
+        for remote_unit in remote_units:
+            remote_data = relation.data[remote_unit].get("data")
+            remote_deserialized = {}
+            if remote_data:
+                remote_deserialized = yaml.safe_load(remote_data)
+                _validate_data(remote_deserialized, INGRESS_REQUIRES_UNIT_SCHEMA)
+            requirer_unit_data[remote_unit] = remote_deserialized
+        return requirer_unit_data
+
+    def _provider_app_data(self, relation: Relation) -> ProviderApplicationData:
+        """Fetch and validate the provider's app databag."""
+        if not relation.app or not relation.app.name:
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return {}
+
+        provider_app_data = {}
+        # we start by looking at the provider's app databag
+        if self.unit.is_leader():
+            # only leaders can read their app's data
+            data = relation.data[self.app].get("data")
+            deserialized = {}
+            if data:
+                deserialized = yaml.safe_load(data)
+                _validate_data(deserialized, INGRESS_PROVIDES_APP_SCHEMA)
+            provider_app_data = deserialized.get("ingress", {})
+
+        return provider_app_data
+
     @property
-    def proxied_endpoints(self):
-        """Returns the ingress settings provided to units by this IngressPerUnitProvider.
+    def proxied_endpoints(self) -> dict:
+        """The ingress settings provided to units by this provider.
 
         For example, when this IngressPerUnitProvider has provided the
-        `http://foo.bar/my-model.my-app-1` and `http://foo.bar/my-model.my-app-2` URLs to
-        the two units of the my-app application, the returned dictionary will be:
+        `http://foo.bar/my-model.my-app-1` and
+        `http://foo.bar/my-model.my-app-2` URLs to the two units of the
+        my-app application, the returned dictionary will be:
 
         ```
         {
@@ -207,126 +546,32 @@ class IngressPerUnitProvider(EndpointWrapper):
         """
         results = {}
 
-        for ingress_relation in self.charm.model.relations[self.endpoint]:
-            results.update(self.unwrap(ingress_relation)[self.charm.app].get("ingress", {}))
+        for ingress_relation in self.relations:
+            provider_app_data = self._provider_app_data(ingress_relation)
+            results.update(provider_app_data)
 
         return results
-
-
-class IngressRequest:
-    """A request for per-unit ingress."""
-
-    def __init__(self, provider: IngressPerUnitProvider, relation: Relation):
-        """Construct an IngressRequest."""
-        self._provider = provider
-        self._relation = relation
-        self._data = provider.unwrap(relation)
-
-    @property
-    def model(self):
-        """The name of the model the request was made from."""
-        return self._get_data_from_first_unit("model")
-
-    @property
-    def app(self):
-        """The remote application."""
-        return self._relation.app
-
-    @property
-    def app_name(self):
-        """The name of the remote app.
-
-        Note: This is not the same as `self.app.name` when using CMR relations,
-        since `self.app.name` is replaced by a `remote-{UUID}` pattern.
-        """
-        first_unit_name = self._get_data_from_first_unit("name")
-
-        if first_unit_name:
-            return first_unit_name.split("/")[0]
-
-        return None
-
-    @property
-    def units(self):
-        """The remote units."""
-        return sorted(self._relation.units, key=lambda unit: unit.name)
-
-    @property
-    def port(self):
-        """The backend port."""
-        return self._get_data_from_first_unit("port")
-
-    def get_host(self, unit: Unit):
-        """The hostname (DNS address, ip) of the given unit."""
-        return self._get_unit_data(unit, "host")
-
-    def get_unit_name(self, unit: Unit):
-        """The name of the remote unit.
-
-        Note: This is not the same as `self.unit.name` when using CMR relations,
-        since `self.unit.name` is replaced by a `remote-{UUID}` pattern.
-        """
-        return self._get_unit_data(unit, "name")
-
-    def _get_data_from_first_unit(self, key: str):
-        if self.units:
-            first_unit_data = self._data[self.units[0]]
-
-            if key in first_unit_data:
-                return first_unit_data[key]
-
-        return None
-
-    def _get_unit_data(self, unit: Unit, key: str):
-        if self.units:
-            if unit in self.units:
-                unit_data = self._data[unit]
-
-                if key in unit_data:
-                    return unit_data[key]
-
-        return None
-
-    def respond(self, unit: Unit, url: str):
-        """Send URL back for the given unit.
-
-        Note: only the leader can send URLs.
-        """
-        # Can't use `unit.name` because with CMR it's a UUID.
-        remote_unit_name = self.get_unit_name(unit)
-        ingress = self._data[self._provider.charm.app].setdefault("ingress", {})
-        ingress.setdefault(remote_unit_name, {})["url"] = url
-        self._provider.wrap(self._relation, self._data)
-
-
-class RelationDataMismatchError(RelationDataError):
-    """Data from different units do not match where they should."""
 
 
 class IngressPerUnitConfigurationChangeEvent(RelationEvent):
     """Event representing a change in the data sent by the ingress."""
 
 
-class IngressPerUnitRequirerEvents(EndpointWrapperEvents):
+class IngressPerUnitRequirerEvents(IngressPerUnitEvents):
     """Container for IUP events."""
 
     ingress_changed = EventSource(IngressPerUnitConfigurationChangeEvent)
 
 
-class IngressPerUnitRequirer(EndpointWrapper):
+class IngressPerUnitRequirer(_IngressPerUnitBase):
     """Implementation of the requirer of ingress_per_unit."""
 
     on = IngressPerUnitRequirerEvents()
 
-    ROLE = RelationRole.requires.name
-    INTERFACE = "ingress_per_unit"
-    SCHEMA = INGRESS_SCHEMA
-    LIMIT = 1
-
     def __init__(
         self,
         charm: CharmBase,
-        endpoint: str = None,
+        relation_name: str = DEFAULT_RELATION_NAME,
         *,
         host: str = None,
         port: int = None,
@@ -340,28 +585,100 @@ class IngressPerUnitRequirer(EndpointWrapper):
 
         Args:
             charm: the charm that is instantiating the library.
-            endpoint: the name of the relation endpoint to bind to
-                (defaults to "ingress-per-unit"; relation must be of interface type
-                "ingress_per_unit" and have "limit: 1")
-            host: Hostname to be used by the ingress provider to address the requirer
-                unit; if unspecified, the pod ip of the unit will be used instead
+            relation_name: the name of the relation name to bind to
+                (defaults to "ingress-per-unit"; relation must be of interface
+                type "ingress_per_unit" and have "limit: 1")
+            host: Hostname to be used by the ingress provider to address the
+            requirer unit; if unspecified, the pod ip of the unit will be used
+            instead
         Request Args:
             port: the port of the service
         """
-        super().__init__(charm, endpoint)
+        super().__init__(charm, relation_name)
+
+        # if instantiated with a port, and we are related, then
+        # we immediately publish our ingress data  to speed up the process.
         if port:
-            self.auto_data = self._complete_request(host or "", port)
+            self._auto_data = host, port
+        else:
+            self._auto_data = None
 
         # Workaround for SDI not marking the EndpointWrapper as not
         # ready upon a relation broken event
         self.is_relation_broken = False
 
         self.framework.observe(
-            self.charm.on[self.endpoint].relation_changed, self._emit_ingress_change_event
+            self.charm.on[self.relation_name].relation_changed, self._emit_ingress_change_event
         )
         self.framework.observe(
-            self.charm.on[self.endpoint].relation_broken, self._emit_ingress_change_event
+            self.charm.on[self.relation_name].relation_broken, self._emit_ingress_change_event
         )
+
+    def _handle_relation(self, event):
+        super()._handle_relation(event)
+        self._publish_auto_data(event.relation)
+
+    def _handle_upgrade_or_leader(self, event):
+        for relation in self.relations:
+            self._publish_auto_data(relation)
+
+    def _publish_auto_data(self, relation: Relation):
+        if self._auto_data and self.is_available(relation):
+            host, port = self._auto_data
+            self.provide_ingress_requirements(host=host, port=port)
+
+    @property
+    def relation(self) -> Optional[Relation]:
+        """The established Relation instance, or None if still unrelated."""
+        return self.relations[0] if self.relations else None
+
+    def is_ready(self, relation: Relation = None) -> bool:
+        """Checks whether the given relation is ready.
+
+        Or any relation if not specified.
+        A given relation is ready if the remote side has sent valid data.
+        """
+        if super().is_ready(relation) is False:
+            return False
+
+        return bool(self.url)
+
+    def is_failed(self, relation: Relation = None) -> bool:
+        """Checks whether the given relation is failed.
+
+        Or any relation if not specified.
+        """
+        if not self.relations:  # can't fail if you can't try
+            return False
+
+        if relation is None:
+            return any(map(self.is_failed, self.relations))
+
+        if not relation.app.name:  # type: ignore
+            # Juju doesn't provide JUJU_REMOTE_APP during relation-broken
+            # hooks. See https://github.com/canonical/operator/issues/693
+            return False
+
+        if not relation.units:
+            return False
+
+        try:
+            # grab the data and validate it; might raise
+            raw = self.relation.data[self.unit].get("data")
+        except Exception:
+            log.exception("Error accessing relation databag")
+            return True
+
+        if raw:
+            # validate data
+            data = yaml.safe_load(raw)
+            try:
+                _validate_data(data, INGRESS_REQUIRES_UNIT_SCHEMA)
+            except DataValidationError:
+                log.exception("Error validating relation data")
+                return True
+
+        return False
 
     def _emit_ingress_change_event(self, event):
         if isinstance(event, RelationBrokenEvent):
@@ -370,49 +687,55 @@ class IngressPerUnitRequirer(EndpointWrapper):
         # TODO Avoid spurious events, emit only when URL changes
         self.on.ingress_changed.emit(self.relation)
 
-    def _complete_request(self, host: Optional[str], port: int):
-        if not host:
-            binding = self.charm.model.get_binding(self.endpoint)
-            host = str(binding.network.bind_address)
-
-        return {
-            self.charm.unit: {
-                "model": self.model.name,
-                "name": self.charm.unit.name,
-                "host": host,
-                "port": port,
-            },
-        }
-
-    def request(self, *, host: str = None, port: int):
-        """Request ingress to this unit.
+    def provide_ingress_requirements(self, *, host: str = None, port: int):
+        """Publishes the data that Traefik needs to provide ingress.
 
         Args:
-            host: Hostname to be used by the ingress provider to address the requirer
-                unit; if unspecified, the pod ip of the unit will be used instead
+            host: Hostname to be used by the ingress provider to address the
+             requirer unit; if unspecified, the pod ip of the unit will be used
+             instead
             port: the port of the service (required)
         """
-        self.wrap(self.relation, self._complete_request(host, port))
+        if not host:
+            binding = self.charm.model.get_binding(self.relation_name)
+            host = str(binding.network.bind_address)
+
+        data = {
+            "model": self.model.name,
+            "name": self.unit.name,
+            "host": host,
+            "port": port,
+        }
+        _validate_data(data, INGRESS_REQUIRES_UNIT_SCHEMA)
+        self.relation.data[self.unit]["data"] = yaml.safe_dump(data)
 
     @property
-    def relation(self):
-        """The established Relation instance, or None."""
-        return self.relations[0] if self.relations else None
-
-    @property
-    def urls(self):
+    def urls(self) -> dict:
         """The full ingress URLs to reach every unit.
 
         May return an empty dict if the URLs aren't available yet.
         """
-        if self.is_relation_broken or not self.is_ready():
+        relation = self.relation
+        if not relation or self.is_relation_broken:
             return {}
-        data = self.unwrap(self.relation)
-        ingress = data[self.relation.app].get("ingress", {})
+
+        raw = None
+        if relation.app.name:  # type: ignore
+            # FIXME Workaround for https://github.com/canonical/operator/issues/693
+            # We must be in a relation_broken hook
+            raw = relation.data.get(relation.app, {}).get("data")
+
+        if not raw:
+            return {}
+
+        data = yaml.safe_load(raw)
+        _validate_data(data, INGRESS_PROVIDES_APP_SCHEMA)
+
+        ingress = data.get("ingress", {})
         return {unit_name: unit_data["url"] for unit_name, unit_data in ingress.items()}
 
     @property
-    def url(self):
+    def url(self) -> Optional[str]:
         """The full ingress URL to reach the current unit.
 
         May return None if the URL isn't available yet.

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -10,12 +10,14 @@ ingress.
 ## Getting Started
 
 To get started using the library, you just need to fetch the library using `charmcraft`.
+**Note that you also need to add the `serialized_data_interface` dependency to your
+charm's `requirements.txt`.**
 
 ```shell
+cd some-charm
 charmcraft fetch-lib charms.traefik_k8s.v0.ingress_per_unit
+echo -e "serialized_data_interface\n" >> requirements.txt
 ```
-
-Add the `jsonschema` dependency to the `requirements.txt` of your charm.
 
 ```yaml
 requires:
@@ -46,492 +48,151 @@ class SomeCharm(CharmBase):
         logger.info("This unit's ingress URL: %s", self.ingress_per_unit.url)
 ```
 """
-import logging
-from typing import Dict, Optional, TypeVar, Union
 
-import ops.model
-import yaml
-from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
-from ops.framework import EventSource, Object, ObjectEvents
-from ops.model import (
-    ActiveStatus,
-    Application,
-    BlockedStatus,
-    Relation,
-    StatusBase,
-    Unit,
-    WaitingStatus,
-)
+import logging
+from typing import Optional
+
+from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent, RelationRole
+from ops.framework import EventSource
+from ops.model import Relation, Unit
+
+try:
+    from serialized_data_interface import EndpointWrapper
+    from serialized_data_interface.errors import RelationDataError
+    from serialized_data_interface.events import EndpointWrapperEvents
+except ImportError:
+    import os
+
+    library_name = os.path.basename(__file__)
+    raise ModuleNotFoundError(
+        "To use the '{}' library, you must include "
+        "the '{}' package in your dependencies".format(library_name, "serialized_data_interface")
+    ) from None  # Suppress original ImportError
+
+try:
+    # introduced in 3.9
+    from functools import cache  # type: ignore
+except ImportError:
+    from functools import lru_cache
+
+    cache = lru_cache(maxsize=None)
 
 # The unique Charmhub library identifier, never change it
-LIBID = "7ef06111da2945ed84f4f5d4eb5b353a"
+LIBID = "7ef06111da2945ed84f4f5d4eb5b353a"  # can't register a library until the charm is in the store 9_9
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 6
 
 log = logging.getLogger(__name__)
 
-try:
-    import jsonschema
-
-    DO_VALIDATION = True
-except ModuleNotFoundError:
-    log.warning(
-        "The `ingress_per_unit` library needs the `jsonschema` package to be able "
-        "to do runtime data validation; without it, it will still work but validation "
-        "will be disabled. \n"
-        "It is recommended to add `jsonschema` to the 'requirements.txt' of your charm, "
-        "which will enable this feature."
-    )
-    DO_VALIDATION = False
-
-# LIBRARY GLOBS
-RELATION_INTERFACE = "ingress_per_unit"
-DEFAULT_RELATION_NAME = RELATION_INTERFACE.replace("_", "-")
-
-INGRESS_REQUIRES_UNIT_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "model": {"type": "string"},
-        "name": {"type": "string"},
-        "host": {"type": "string"},
-        "port": {"type": "integer"},
-    },
-    "required": ["model", "name", "host", "port"],
-}
-INGRESS_PROVIDES_APP_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "ingress": {
-            "type": "object",
-            "patternProperties": {
-                "": {
-                    "type": "object",
-                    "properties": {
-                        "url": {"type": "string"},
-                    },
-                    "required": ["url"],
-                }
-            },
+INGRESS_SCHEMA = {
+    "v1": {
+        "requires": {
+            "unit": {
+                "type": "object",
+                "properties": {
+                    "model": {"type": "string"},
+                    "name": {"type": "string"},
+                    "host": {"type": "string"},
+                    "port": {"type": "integer"},
+                },
+                "required": ["model", "name", "host", "port"],
+            }
         },
-        # Optional key for backwards compatibility
-        # with legacy requirers based on SDI
-        "_supported_versions": {"type": "string"},
-    },
-    "required": ["ingress"],
+        "provides": {
+            "app": {
+                "type": "object",
+                "properties": {
+                    "ingress": {
+                        "type": "object",
+                        "patternProperties": {
+                            "": {
+                                "type": "object",
+                                "properties": {"url": {"type": "string"}},
+                                "required": ["url"],
+                            }
+                        },
+                    }
+                },
+                "required": ["ingress"],
+            }
+        },
+    }
 }
 
 
-# TYPES
-try:
-    from typing import TypedDict
-except ImportError:
-    from typing_extensions import TypedDict  # py35 compat
+class IngressPerUnitRequestEvent(RelationEvent):
+    """Event representing an incoming request.
 
-
-class RequirerData(TypedDict):
-    """Model of the data a unit implementing the requirer will need to provide."""
-
-    model: str
-    name: str
-    host: str
-    port: int
-
-
-RequirerUnitData = Dict[Unit, "RequirerData"]
-KeyValueMapping = Dict[str, str]
-ProviderApplicationData = Dict[str, KeyValueMapping]
-
-
-def _validate_data(data, schema):
-    """Checks whether `data` matches `schema`.
-
-    Will raise DataValidationError if the data is not valid, else return None.
-    """
-    if not DO_VALIDATION:
-        return
-    try:
-        jsonschema.validate(instance=data, schema=schema)
-    except jsonschema.ValidationError as e:
-        raise DataValidationError(data, schema) from e
-
-
-# EXCEPTIONS
-class DataValidationError(RuntimeError):
-    """Raised when data validation fails on IPU relation data."""
-
-
-class RelationException(RuntimeError):
-    """Base class for relation exceptions from this library.
-
-    Attributes:
-        relation: The Relation which caused the exception.
-        entity: The Application or Unit which caused the exception.
+    This is equivalent to the "ready" event, but is more semantically meaningful.
     """
 
-    def __init__(self, relation: Relation, entity: Union[Application, Unit]):
-        super().__init__(relation)
-        self.args = (
-            "There is an error with the relation {}:{} with {}".format(
-                relation.name, relation.id, entity.name
-            ),
-        )
-        self.relation = relation
-        self.entity = entity
+
+class IngressPerUnitProviderEvents(EndpointWrapperEvents):
+    """Container for IUP events."""
+
+    request = EventSource(IngressPerUnitRequestEvent)
 
 
-class RelationDataMismatchError(RelationException):
-    """Data from different units do not match where they should."""
-
-
-class RelationPermissionError(RelationException):
-    """Ingress is requested to do something for which it lacks permissions."""
-
-    def __init__(self, relation: Relation, entity: Union[Application, Unit], message: str):
-        super(RelationPermissionError, self).__init__(relation, entity)
-        self.args = (
-            "Unable to write data to relation '{}:{}' with {}: {}".format(
-                relation.name, relation.id, entity.name, message
-            ),
-        )
-
-
-# EVENTS
-class RelationAvailableEvent(RelationEvent):
-    """Event triggered when a relation is ready to provide ingress."""
-
-
-class RelationFailedEvent(RelationEvent):
-    """Event triggered when something went wrong with a relation."""
-
-
-class RelationReadyEvent(RelationEvent):
-    """Event triggered when a remote relation has the expected data."""
-
-
-class IngressPerUnitEvents(ObjectEvents):
-    """Container for events for IngressPerUnit."""
-
-    available = EventSource(RelationAvailableEvent)
-    ready = EventSource(RelationReadyEvent)
-    failed = EventSource(RelationFailedEvent)
-    broken = EventSource(RelationBrokenEvent)
-
-
-class _IngressPerUnitBase(Object):
-    """Base class for IngressPerUnit interface classes."""
-
-    _IngressPerUnitEventType = TypeVar("_IngressPerUnitEventType", bound=IngressPerUnitEvents)
-    on: _IngressPerUnitEventType
-
-    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
-        """Constructor for _IngressPerUnitBase.
-
-        Args:
-            charm: The charm that is instantiating the instance.
-            relation_name: The name of the relation name to bind to
-                (defaults to "ingress-per-unit").
-        """
-        super().__init__(charm, relation_name)
-        self.charm: CharmBase = charm
-
-        self.relation_name = relation_name
-        self.app = self.charm.app
-        self.unit = self.charm.unit
-
-        observe = self.framework.observe
-        rel_events = charm.on[relation_name]
-        observe(rel_events.relation_created, self._handle_relation)
-        observe(rel_events.relation_joined, self._handle_relation)
-        observe(rel_events.relation_changed, self._handle_relation)
-        observe(rel_events.relation_broken, self._handle_relation_broken)
-        observe(charm.on.leader_elected, self._handle_upgrade_or_leader)
-        observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)
-
-    @property
-    def relations(self):
-        """The list of Relation instances associated with this relation_name."""
-        return list(self.charm.model.relations[self.relation_name])
-
-    def _handle_relation(self, event):
-        relation = event.relation
-        if self.is_ready(relation):
-            self.on.ready.emit(relation)
-        elif self.is_available(relation):
-            self.on.available.emit(relation)
-        elif self.is_failed(relation):
-            self.on.failed.emit(relation)
-        else:
-            log.debug(
-                "Relation {} is neither ready, nor available, nor failed. "
-                "Something fishy's going on...".format(relation)
-            )
-
-    def get_status(self, relation: Relation) -> StatusBase:
-        """Get the suggested status for the given Relation."""
-        if self.is_failed(relation):
-            return BlockedStatus(
-                "Error handling relation {}:{}".format(relation.name, relation.id)
-            )
-        elif not self.is_available(relation):
-            return WaitingStatus("Waiting on relation {}:{}".format(relation.name, relation.id))
-        elif not self.is_ready(relation):
-            return WaitingStatus("Waiting on relation {}:{}".format(relation.name, relation.id))
-        else:
-            return ActiveStatus()
-
-    def _handle_relation_broken(self, event):
-        self.on.broken.emit(event.relation)
-
-    def _handle_upgrade_or_leader(self, _):
-        pass
-
-    def is_available(self, relation: Relation = None) -> bool:
-        """Check whether the given relation is available.
-
-        Or any relation if not specified.
-        """
-        if relation is None:
-            return any(map(self.is_available, self.relations))
-
-        if not relation.app.name:
-            # Juju doesn't provide JUJU_REMOTE_APP during relation-broken
-            # hooks. See https://github.com/canonical/operator/issues/693.
-            # Relation in the process of breaking cannot be available.
-            return False
-
-        return True
-
-    def is_ready(self, relation: Relation = None) -> bool:
-        """Checks whether the given relation is ready.
-
-        Or any relation if not specified.
-        A given relation is ready if the remote side has sent valid data.
-        """
-        if relation is None:
-            return any(map(self.is_ready, self.relations))
-        if relation.app is None:
-            # No idea why, but this happened once.
-            return False
-        if not relation.app.name:  # type: ignore
-            # Juju doesn't provide JUJU_REMOTE_APP during relation-broken
-            # hooks. See https://github.com/canonical/operator/issues/693
-            return False
-        return True
-
-    def is_failed(self, _: Relation = None) -> bool:
-        """Checks whether the given relation is failed.
-
-        Or any relation if not specified.
-        """
-        raise NotImplementedError("implement in subclass")
-
-
-class IngressPerUnitProvider(_IngressPerUnitBase):
+class IngressPerUnitProvider(EndpointWrapper):
     """Implementation of the provider of ingress_per_unit."""
 
-    on = IngressPerUnitEvents()
+    ROLE = RelationRole.provides.name
+    INTERFACE = "ingress_per_unit"
+    SCHEMA = INGRESS_SCHEMA
 
-    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+    on = IngressPerUnitProviderEvents()
+
+    def __init__(self, charm: CharmBase, endpoint: str = None):
         """Constructor for IngressPerUnitProvider.
 
         Args:
             charm: The charm that is instantiating the instance.
-            relation_name: The name of the relation relation_name to bind to
+            endpoint: The name of the relation endpoint to bind to
                 (defaults to "ingress-per-unit").
         """
-        super().__init__(charm, relation_name)
-        observe = self.framework.observe
-        observe(self.charm.on[relation_name].relation_joined, self._share_version_info)
+        super().__init__(charm, endpoint)
+        self.framework.observe(self.on.ready, self._emit_request_event)
 
-    def _share_version_info(self, event):
-        """Backwards-compatibility shim for version negotiation.
+    def _emit_request_event(self, event):
+        self.on.request.emit(event.relation)
 
-        Allows older versions of IPU (requirer side) to interact with this
-        provider without breaking.
-        Will be removed in a future version of this library.
-        Do not use.
-        """
-        relation = event.relation
-        if self.charm.unit.is_leader():
-            log.info("shared supported_versions shim information")
-            relation.data[self.charm.app]["_supported_versions"] = "- v1"
+    def get_request(self, relation: Relation):
+        """Get the IngressRequest for the given Relation."""
+        return IngressRequest(self, relation)
 
-    def is_ready(self, relation: Relation = None) -> bool:
-        """Checks whether the given relation is ready.
-
-        Or any relation if not specified.
-        A given relation is ready if SOME remote side has sent valid data.
-        """
+    @cache
+    def is_failed(self, relation: Relation = None):
+        """Checks whether the given relation, or any relation if not specified, has an error."""
         if relation is None:
-            return any(map(self.is_ready, self.relations))
-
-        if not super().is_ready(relation):
-            return False
-
-        try:
-            requirer_unit_data = self._requirer_unit_data(relation)
-        except Exception:
-            log.exception("Cannot fetch ingress data for the '{}' relation".format(relation))
-            return False
-
-        return any(requirer_unit_data.values())
-
-    def is_failed(self, relation: Relation = None) -> bool:
-        """Checks whether the given relation is failed.
-
-        Or any relation if not specified.
-        """
-        if relation is None:
-            return any(map(self.is_failed, self.relations))
-
-        if not relation.app.name:  # type: ignore
-            # Juju doesn't provide JUJU_REMOTE_APP during relation-broken
-            # hooks. See https://github.com/canonical/operator/issues/693
-            return False
-
+            return any(self.is_failed(relation) for relation in self.relations)
         if not relation.units:
-            # Relations without requiring units cannot be in failed state
             return False
-
-        try:
-            # grab the data and validate it; might raise
-            requirer_unit_data = self._requirer_unit_data(relation)
-        except DataValidationError as e:
-            log.warning("Failed to validate relation data for {} relation: {}".format(relation, e))
+        if super().is_failed(relation):
             return True
-
-        # verify that all remote units (requirer's side) publish the same model.
-        # We do not validate the port because, in case of changes to the configuration
-        # of the charm or a new version of the charmed workload, e.g. over an upgrade,
-        # the remote port may be different among units.
-        expected_model = None  # It may be none for units that have not yet written data
-
-        for remote_unit, remote_unit_data in requirer_unit_data.items():
-            if "model" in remote_unit_data:
-                remote_model = remote_unit_data["model"]
-                if not expected_model:
-                    expected_model = remote_model
-                elif expected_model != remote_model:
-                    raise RelationDataMismatchError(relation, remote_unit)
-
+        data = self.unwrap(relation)
+        prev_fields = None
+        for unit in relation.units:
+            if not data[unit]:
+                continue
+            new_fields = {field: data[unit][field] for field in ("model", "port")}
+            if prev_fields is None:
+                prev_fields = new_fields
+            if new_fields != prev_fields:
+                raise RelationDataMismatchError(relation, unit)
         return False
-
-    def is_unit_ready(self, relation: Relation, unit: Unit) -> bool:
-        """Report whether the given unit has shared data in its unit data bag."""
-        # sanity check: this should not occur in production, but it may happen
-        # during testing: cfr https://github.com/canonical/traefik-k8s-operator/issues/39
-        assert (
-            unit in relation.units
-        ), "attempting to get ready state for unit that does not belong to relation"
-        if relation.data.get(unit, {}).get("data"):
-            # TODO consider doing schema-based validation here
-            return True
-        return False
-
-    def get_data(self, relation: Relation, unit: Unit) -> "RequirerData":
-        """Fetch the data shared by the specified unit on the relation (Requirer side)."""
-        data = yaml.safe_load(relation.data[unit]["data"])
-        _validate_data(data, INGRESS_REQUIRES_UNIT_SCHEMA)
-        return data
-
-    def publish_url(self, relation: Relation, unit_name: str, url: str):
-        """Place the ingress url in the application data bag for the units on the requires side.
-
-        Assumes that this unit is leader.
-        """
-        raw_data = relation.data[self.app].get("data", None)
-        data = yaml.safe_load(raw_data) if raw_data else {"ingress": {}}
-
-        # we ensure that the application databag has the shape we think it
-        # should have; to catch any inconsistencies early on.
-        try:
-            _validate_data(data, INGRESS_PROVIDES_APP_SCHEMA)
-        except DataValidationError as e:
-            log.error(
-                "unable to publish url to {}: corrupted application databag ({})".format(
-                    unit_name, e
-                )
-            )
-            return
-
-        # we update the data with a new url
-        data["ingress"][unit_name] = {"url": url}
-
-        # we validate the data **again**, to ensure that we respected the schema
-        # and did not accidentally corrupt our own databag.
-        _validate_data(data, INGRESS_PROVIDES_APP_SCHEMA)
-
-        try:
-            relation.data[self.app]["data"] = yaml.safe_dump(data)
-        except ops.model.RelationDataError:
-            unit = self.unit
-            raise RelationPermissionError(
-                relation,
-                unit,
-                "failed to write application data: leader={}".format(unit.is_leader()),
-            )
-
-    def wipe_ingress_data(self, relation):
-        """Remove all published ingress data.
-
-        Assumes that this unit is leader.
-        """
-        relation.data[self.app]["data"] = ""
-
-    def _requirer_unit_data(self, relation: Relation) -> RequirerUnitData:
-        """Fetch and validate the requirer's unit databag."""
-        if not relation.app or not relation.app.name:
-            # Handle edge case where remote app name can be missing, e.g.,
-            # relation_broken events.
-            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
-            return {}
-
-        remote_units = [unit for unit in relation.units if unit.app is not self.app]
-
-        requirer_unit_data = {}
-        for remote_unit in remote_units:
-            remote_data = relation.data[remote_unit].get("data")
-            remote_deserialized = {}
-            if remote_data:
-                remote_deserialized = yaml.safe_load(remote_data)
-                _validate_data(remote_deserialized, INGRESS_REQUIRES_UNIT_SCHEMA)
-            requirer_unit_data[remote_unit] = remote_deserialized
-        return requirer_unit_data
-
-    def _provider_app_data(self, relation: Relation) -> ProviderApplicationData:
-        """Fetch and validate the provider's app databag."""
-        if not relation.app or not relation.app.name:
-            # Handle edge case where remote app name can be missing, e.g.,
-            # relation_broken events.
-            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
-            return {}
-
-        provider_app_data = {}
-        # we start by looking at the provider's app databag
-        if self.unit.is_leader():
-            # only leaders can read their app's data
-            data = relation.data[self.app].get("data")
-            deserialized = {}
-            if data:
-                deserialized = yaml.safe_load(data)
-                _validate_data(deserialized, INGRESS_PROVIDES_APP_SCHEMA)
-            provider_app_data = deserialized.get("ingress", {})
-
-        return provider_app_data
 
     @property
-    def proxied_endpoints(self) -> dict:
-        """The ingress settings provided to units by this provider.
+    def proxied_endpoints(self):
+        """Returns the ingress settings provided to units by this IngressPerUnitProvider.
 
         For example, when this IngressPerUnitProvider has provided the
-        `http://foo.bar/my-model.my-app-1` and
-        `http://foo.bar/my-model.my-app-2` URLs to the two units of the
-        my-app application, the returned dictionary will be:
+        `http://foo.bar/my-model.my-app-1` and `http://foo.bar/my-model.my-app-2` URLs to
+        the two units of the my-app application, the returned dictionary will be:
 
         ```
         {
@@ -546,32 +207,126 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
         """
         results = {}
 
-        for ingress_relation in self.relations:
-            provider_app_data = self._provider_app_data(ingress_relation)
-            results.update(provider_app_data)
+        for ingress_relation in self.charm.model.relations[self.endpoint]:
+            results.update(self.unwrap(ingress_relation)[self.charm.app].get("ingress", {}))
 
         return results
+
+
+class IngressRequest:
+    """A request for per-unit ingress."""
+
+    def __init__(self, provider: IngressPerUnitProvider, relation: Relation):
+        """Construct an IngressRequest."""
+        self._provider = provider
+        self._relation = relation
+        self._data = provider.unwrap(relation)
+
+    @property
+    def model(self):
+        """The name of the model the request was made from."""
+        return self._get_data_from_first_unit("model")
+
+    @property
+    def app(self):
+        """The remote application."""
+        return self._relation.app
+
+    @property
+    def app_name(self):
+        """The name of the remote app.
+
+        Note: This is not the same as `self.app.name` when using CMR relations,
+        since `self.app.name` is replaced by a `remote-{UUID}` pattern.
+        """
+        first_unit_name = self._get_data_from_first_unit("name")
+
+        if first_unit_name:
+            return first_unit_name.split("/")[0]
+
+        return None
+
+    @property
+    def units(self):
+        """The remote units."""
+        return sorted(self._relation.units, key=lambda unit: unit.name)
+
+    @property
+    def port(self):
+        """The backend port."""
+        return self._get_data_from_first_unit("port")
+
+    def get_host(self, unit: Unit):
+        """The hostname (DNS address, ip) of the given unit."""
+        return self._get_unit_data(unit, "host")
+
+    def get_unit_name(self, unit: Unit):
+        """The name of the remote unit.
+
+        Note: This is not the same as `self.unit.name` when using CMR relations,
+        since `self.unit.name` is replaced by a `remote-{UUID}` pattern.
+        """
+        return self._get_unit_data(unit, "name")
+
+    def _get_data_from_first_unit(self, key: str):
+        if self.units:
+            first_unit_data = self._data[self.units[0]]
+
+            if key in first_unit_data:
+                return first_unit_data[key]
+
+        return None
+
+    def _get_unit_data(self, unit: Unit, key: str):
+        if self.units:
+            if unit in self.units:
+                unit_data = self._data[unit]
+
+                if key in unit_data:
+                    return unit_data[key]
+
+        return None
+
+    def respond(self, unit: Unit, url: str):
+        """Send URL back for the given unit.
+
+        Note: only the leader can send URLs.
+        """
+        # Can't use `unit.name` because with CMR it's a UUID.
+        remote_unit_name = self.get_unit_name(unit)
+        ingress = self._data[self._provider.charm.app].setdefault("ingress", {})
+        ingress.setdefault(remote_unit_name, {})["url"] = url
+        self._provider.wrap(self._relation, self._data)
+
+
+class RelationDataMismatchError(RelationDataError):
+    """Data from different units do not match where they should."""
 
 
 class IngressPerUnitConfigurationChangeEvent(RelationEvent):
     """Event representing a change in the data sent by the ingress."""
 
 
-class IngressPerUnitRequirerEvents(IngressPerUnitEvents):
+class IngressPerUnitRequirerEvents(EndpointWrapperEvents):
     """Container for IUP events."""
 
     ingress_changed = EventSource(IngressPerUnitConfigurationChangeEvent)
 
 
-class IngressPerUnitRequirer(_IngressPerUnitBase):
+class IngressPerUnitRequirer(EndpointWrapper):
     """Implementation of the requirer of ingress_per_unit."""
 
     on = IngressPerUnitRequirerEvents()
 
+    ROLE = RelationRole.requires.name
+    INTERFACE = "ingress_per_unit"
+    SCHEMA = INGRESS_SCHEMA
+    LIMIT = 1
+
     def __init__(
         self,
         charm: CharmBase,
-        relation_name: str = DEFAULT_RELATION_NAME,
+        endpoint: str = None,
         *,
         host: str = None,
         port: int = None,
@@ -585,100 +340,28 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
 
         Args:
             charm: the charm that is instantiating the library.
-            relation_name: the name of the relation name to bind to
-                (defaults to "ingress-per-unit"; relation must be of interface
-                type "ingress_per_unit" and have "limit: 1")
-            host: Hostname to be used by the ingress provider to address the
-            requirer unit; if unspecified, the pod ip of the unit will be used
-            instead
+            endpoint: the name of the relation endpoint to bind to
+                (defaults to "ingress-per-unit"; relation must be of interface type
+                "ingress_per_unit" and have "limit: 1")
+            host: Hostname to be used by the ingress provider to address the requirer
+                unit; if unspecified, the pod ip of the unit will be used instead
         Request Args:
             port: the port of the service
         """
-        super().__init__(charm, relation_name)
-
-        # if instantiated with a port, and we are related, then
-        # we immediately publish our ingress data  to speed up the process.
+        super().__init__(charm, endpoint)
         if port:
-            self._auto_data = host, port
-        else:
-            self._auto_data = None
+            self.auto_data = self._complete_request(host or "", port)
 
         # Workaround for SDI not marking the EndpointWrapper as not
         # ready upon a relation broken event
         self.is_relation_broken = False
 
         self.framework.observe(
-            self.charm.on[self.relation_name].relation_changed, self._emit_ingress_change_event
+            self.charm.on[self.endpoint].relation_changed, self._emit_ingress_change_event
         )
         self.framework.observe(
-            self.charm.on[self.relation_name].relation_broken, self._emit_ingress_change_event
+            self.charm.on[self.endpoint].relation_broken, self._emit_ingress_change_event
         )
-
-    def _handle_relation(self, event):
-        super()._handle_relation(event)
-        self._publish_auto_data(event.relation)
-
-    def _handle_upgrade_or_leader(self, event):
-        for relation in self.relations:
-            self._publish_auto_data(relation)
-
-    def _publish_auto_data(self, relation: Relation):
-        if self._auto_data and self.is_available(relation):
-            host, port = self._auto_data
-            self.provide_ingress_requirements(host=host, port=port)
-
-    @property
-    def relation(self) -> Optional[Relation]:
-        """The established Relation instance, or None if still unrelated."""
-        return self.relations[0] if self.relations else None
-
-    def is_ready(self, relation: Relation = None) -> bool:
-        """Checks whether the given relation is ready.
-
-        Or any relation if not specified.
-        A given relation is ready if the remote side has sent valid data.
-        """
-        if super().is_ready(relation) is False:
-            return False
-
-        return bool(self.url)
-
-    def is_failed(self, relation: Relation = None) -> bool:
-        """Checks whether the given relation is failed.
-
-        Or any relation if not specified.
-        """
-        if not self.relations:  # can't fail if you can't try
-            return False
-
-        if relation is None:
-            return any(map(self.is_failed, self.relations))
-
-        if not relation.app.name:  # type: ignore
-            # Juju doesn't provide JUJU_REMOTE_APP during relation-broken
-            # hooks. See https://github.com/canonical/operator/issues/693
-            return False
-
-        if not relation.units:
-            return False
-
-        try:
-            # grab the data and validate it; might raise
-            raw = self.relation.data[self.unit].get("data")
-        except Exception:
-            log.exception("Error accessing relation databag")
-            return True
-
-        if raw:
-            # validate data
-            data = yaml.safe_load(raw)
-            try:
-                _validate_data(data, INGRESS_REQUIRES_UNIT_SCHEMA)
-            except DataValidationError:
-                log.exception("Error validating relation data")
-                return True
-
-        return False
 
     def _emit_ingress_change_event(self, event):
         if isinstance(event, RelationBrokenEvent):
@@ -687,55 +370,49 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         # TODO Avoid spurious events, emit only when URL changes
         self.on.ingress_changed.emit(self.relation)
 
-    def provide_ingress_requirements(self, *, host: str = None, port: int):
-        """Publishes the data that Traefik needs to provide ingress.
-
-        Args:
-            host: Hostname to be used by the ingress provider to address the
-             requirer unit; if unspecified, the pod ip of the unit will be used
-             instead
-            port: the port of the service (required)
-        """
+    def _complete_request(self, host: Optional[str], port: int):
         if not host:
-            binding = self.charm.model.get_binding(self.relation_name)
+            binding = self.charm.model.get_binding(self.endpoint)
             host = str(binding.network.bind_address)
 
-        data = {
-            "model": self.model.name,
-            "name": self.unit.name,
-            "host": host,
-            "port": port,
+        return {
+            self.charm.unit: {
+                "model": self.model.name,
+                "name": self.charm.unit.name,
+                "host": host,
+                "port": port,
+            },
         }
-        _validate_data(data, INGRESS_REQUIRES_UNIT_SCHEMA)
-        self.relation.data[self.unit]["data"] = yaml.safe_dump(data)
+
+    def request(self, *, host: str = None, port: int):
+        """Request ingress to this unit.
+
+        Args:
+            host: Hostname to be used by the ingress provider to address the requirer
+                unit; if unspecified, the pod ip of the unit will be used instead
+            port: the port of the service (required)
+        """
+        self.wrap(self.relation, self._complete_request(host, port))
 
     @property
-    def urls(self) -> dict:
+    def relation(self):
+        """The established Relation instance, or None."""
+        return self.relations[0] if self.relations else None
+
+    @property
+    def urls(self):
         """The full ingress URLs to reach every unit.
 
         May return an empty dict if the URLs aren't available yet.
         """
-        relation = self.relation
-        if not relation or self.is_relation_broken:
+        if self.is_relation_broken or not self.is_ready():
             return {}
-
-        raw = None
-        if relation.app.name:  # type: ignore
-            # FIXME Workaround for https://github.com/canonical/operator/issues/693
-            # We must be in a relation_broken hook
-            raw = relation.data.get(relation.app, {}).get("data")
-
-        if not raw:
-            return {}
-
-        data = yaml.safe_load(raw)
-        _validate_data(data, INGRESS_PROVIDES_APP_SCHEMA)
-
-        ingress = data.get("ingress", {})
+        data = self.unwrap(self.relation)
+        ingress = data[self.relation.app].get("ingress", {})
         return {unit_name: unit_data["url"] for unit_name, unit_data in ingress.items()}
 
     @property
-    def url(self) -> Optional[str]:
+    def url(self):
         """The full ingress URL to reach the current unit.
 
         May return None if the URL isn't available yet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,9 @@ allow_redefinition = true
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]
-module = ["ops.*", "pytest.*", "pytest_operator.*", "prometheus_api_client.*", "deepdiff.*", "serialized_data_interface.*", "bitmath.*"]
+module = ["ops.*", "pytest.*", "pytest_operator.*", "prometheus_api_client.*", "deepdiff.*", "jsonschema.*", "bitmath.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["charms.traefik_k8s.*"]
+follow_imports = "silent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,5 @@ allow_redefinition = true
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]
-module = ["ops.*", "pytest.*", "pytest_operator.*", "prometheus_api_client.*", "deepdiff.*", "serialized_data_interface.*"]
+module = ["ops.*", "pytest.*", "pytest_operator.*", "prometheus_api_client.*", "deepdiff.*", "serialized_data_interface.*", "bitmath.*"]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,5 @@ allow_redefinition = true
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]
-module = ["ops.*", "pytest.*", "pytest_operator.*", "prometheus_api_client.*", "deepdiff.*", "jsonschema.*", "bitmath.*"]
+module = ["ops.*", "pytest.*", "pytest_operator.*", "prometheus_api_client.*", "deepdiff.*", "serialized_data_interface.*", "bitmath.*"]
 ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = ["charms.traefik_k8s.*"]
-follow_imports = "silent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,7 @@ allow_redefinition = true
 [[tool.mypy.overrides]]
 module = ["ops.*", "pytest.*", "pytest_operator.*", "prometheus_api_client.*", "deepdiff.*", "serialized_data_interface.*", "bitmath.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["charms.grafana_k8s.*"]
+follow_imports = "silent"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pyaml
 requests
 lightkube >= 0.8.1
 lightkube-models >= 1.22.0.4
-serialized-data-interface >= 0.4.0
+jsonschema
 bitmath == 1.3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 lightkube >= 0.8.1
 lightkube-models >= 1.22.0.4
 serialized-data-interface >= 0.4.0
+bitmath == 1.3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pyaml
 requests
 lightkube >= 0.8.1
 lightkube-models >= 1.22.0.4
-jsonschema
+serialized-data-interface >= 0.4.0
 bitmath == 1.3.3.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -59,7 +59,7 @@ class PrometheusCharm(CharmBase):
         self.metrics_consumer = MetricsEndpointConsumer(self)
 
         # Manages ingress for this charm
-        self.ingress = IngressPerUnitRequirer(self, endpoint="ingress", port=self._port)
+        self.ingress = IngressPerUnitRequirer(self, relation_name="ingress", port=self._port)
 
         external_url = urlparse(self._external_url)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -303,18 +303,17 @@ class PrometheusCharm(CharmBase):
                 pvc_name = volume.persistentVolumeClaim.claimName
                 break
 
-        if pvc_name:
-            capacity = cast(
-                PersistentVolumeClaim,
-                client.get(PersistentVolumeClaim, name=pvc_name, namespace=self.model.name),
-            ).status.capacity[
-                "storage"  # Storage name must match metadata.yaml
-            ]
-
-            return capacity
-
-        else:
+        if not pvc_name:
             raise ValueError("No PVC found for pod " + pod_name)
+
+        capacity = cast(
+            PersistentVolumeClaim,
+            client.get(PersistentVolumeClaim, name=pvc_name, namespace=self.model.name),
+        ).status.capacity[
+            "storage"  # Storage name must match metadata.yaml
+        ]
+
+        return capacity
 
     def _is_valid_timespec(self, timeval: str) -> bool:
         """Is a time interval unit and value valid.

--- a/src/charm.py
+++ b/src/charm.py
@@ -59,7 +59,7 @@ class PrometheusCharm(CharmBase):
         self.metrics_consumer = MetricsEndpointConsumer(self)
 
         # Manages ingress for this charm
-        self.ingress = IngressPerUnitRequirer(self, relation_name="ingress", port=self._port)
+        self.ingress = IngressPerUnitRequirer(self, endpoint="ingress", port=self._port)
 
         external_url = urlparse(self._external_url)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,9 +8,10 @@ import logging
 import os
 import re
 import socket
-from typing import Dict
+from typing import Dict, cast
 from urllib.parse import urlparse
 
+import bitmath
 import yaml
 from charms.alertmanager_k8s.v0.alertmanager_dispatch import AlertmanagerConsumer
 from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
@@ -23,6 +24,9 @@ from charms.prometheus_k8s.v0.prometheus_remote_write import (
 )
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 from charms.traefik_k8s.v0.ingress_per_unit import IngressPerUnitRequirer
+from lightkube import Client
+from lightkube.core.exceptions import ApiError as LightkubeApiError
+from lightkube.resources.core_v1 import PersistentVolumeClaim, Pod
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
@@ -236,16 +240,83 @@ class PrometheusCharm(CharmBase):
             args.append("--storage.tsdb.wal-compression")
 
         # Set time series retention time
-        if config.get("metrics_retention_time") and self._is_valid_timespec(
-            config["metrics_retention_time"]
-        ):
-            args.append(f"--storage.tsdb.retention.time={config['metrics_retention_time']}")
+        if self._is_valid_timespec(retention_time := config.get("metrics_retention_time", "")):
+            args.append(f"--storage.tsdb.retention.time={retention_time}")
+
+        # Set time series retention size
+        try:
+            ratio = self._percent_string_to_ratio(config.get("maximum_retention_size", ""))
+
+        except ValueError as e:
+            logger.warning(e)
+            self.unit.status = BlockedStatus(f"Invalid retention size: {e}")
+
+        else:
+            # `storage.tsdb.retention.size` uses the legacy binary format, so "GB" and not "GiB"
+            # https://github.com/prometheus/prometheus/issues/10768
+            # For simplicity, always communicate to prometheus in GiB
+            try:
+                capacity = self._convert_k8s_capacity_to_legacy_binary_gigabytes(
+                    self._get_pvc_capacity(), ratio
+                )
+            except ValueError as e:
+                self.unit.status = BlockedStatus(f"Error calculating retention size: {e}")
+            except LightkubeApiError as e:
+                self.unit.status = BlockedStatus(
+                    f"Error calculating retention size "
+                    f"(try running `juju trust` on this application): {e}"
+                )
+            else:
+                logger.debug("Retention size limit set to %s (%s%%)", capacity, ratio * 100)
+                args.append(f"--storage.tsdb.retention.size={capacity}")
 
         command = ["/bin/prometheus"] + args
 
         return " ".join(command)
 
-    def _is_valid_timespec(self, timeval) -> bool:
+    def _convert_k8s_capacity_to_legacy_binary_gigabytes(self, capacity: str, multiplier) -> str:
+        # Reduce possible ambiguity in unit name by adding a trailing 'B'.
+        # (bitmath doesn't accept e.g. "Gi" because it also supports bits.)
+        if not capacity.endswith("B"):
+            capacity += "B"
+
+        # For simplicity, always communicate to prometheus in GiB
+        storage_value = multiplier * bitmath.parse_string(capacity).to_GiB().value
+        return f"{storage_value}GB"
+
+    def _get_pvc_capacity(self) -> str:
+        # Get PVC capacity from kubernetes
+        client = Client()
+        pod_name = self.unit.name.replace("/", "-", -1)
+
+        # Take the first volume whose name starts with "<app-name>-database-".
+        # The volumes array looks as follows for app "am" and storage "data":
+        # 'volumes': [{'name': 'am-data-d7f6a623',
+        #              'persistentVolumeClaim': {'claimName': 'am-data-d7f6a623-am-0'}}, ...]
+        pvc_name = ""
+        for volume in cast(
+            Pod, client.get(Pod, name=pod_name, namespace=self.model.name)
+        ).spec.volumes:
+            # TODO: How to handle this when the store is not a singleton (i.e. when metadata
+            #  specifies "multiple: range: 1-10")?
+            if volume.persistentVolumeClaim.claimName.startswith(f"{self.app.name}-database-"):
+                pvc_name = volume.persistentVolumeClaim.claimName
+                break
+
+        if pvc_name:
+            capacity = cast(
+                PersistentVolumeClaim,
+                client.get(PersistentVolumeClaim, name=pvc_name, namespace=self.model.name),
+            ).status.capacity[
+                "storage"  # Storage name must match metadata.yaml
+            ]
+
+            return capacity
+
+        else:
+            raise ValueError("No PVC found for pod " + pod_name)
+
+    def _is_valid_timespec(self, timeval: str) -> bool:
         """Is a time interval unit and value valid.
 
         If time interval is not valid unit status is set to blocked.
@@ -268,6 +339,19 @@ class PrometheusCharm(CharmBase):
             self.unit.status = BlockedStatus(f"Invalid time spec : {timeval}")
 
         return bool(matched)
+
+    def _percent_string_to_ratio(self, percentage: str) -> float:
+        """Convert a string representation of percentage of 0-100%, to a 0-1 ratio.
+
+        Raises:
+            ValueError, if the percentage string is invalid or not within range.
+        """
+        if not percentage.endswith("%"):
+            raise ValueError("Percentage string must be a number followed by '%', e.g. '80%'")
+        value = float(percentage[:-1]) / 100.0
+        if value < 0 or value > 1:
+            raise ValueError("Percentage value must be in the range 0-100.")
+        return value
 
     def _prometheus_global_config(self) -> dict:
         """Construct Prometheus global configuration.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -37,6 +37,7 @@ async def test_prometheus_scrape_relation_with_prometheus_tester(
             prometheus_charm,
             resources={"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")},
             application_name=prometheus_app_name,
+            trust=True,  # otherwise errors on ghwf (persistentvolumeclaims ... is forbidden)
         ),
         ops_test.model.deploy(
             prometheus_tester_charm,
@@ -53,7 +54,7 @@ async def test_prometheus_scrape_relation_with_prometheus_tester(
     await ops_test.model.wait_for_idle(apps=app_names, status="active", wait_for_units=1)
 
     assert initial_workload_is_ready(ops_test, app_names)
-    assert check_prometheus_is_ready(ops_test, prometheus_app_name, 0)
+    assert await check_prometheus_is_ready(ops_test, prometheus_app_name, 0)
 
     global initial_config, initial_rules
     initial_config, initial_rules = await asyncio.gather(

--- a/tests/integration/test_cross_model_remote_write.py
+++ b/tests/integration/test_cross_model_remote_write.py
@@ -68,12 +68,13 @@ async def test_offer_and_consume_remote_write(ops_test):
     await consumer.model.consume(f"admin/{offer.model_name}.{prometheus_name}", "prom")
     await consumer.model.relate(agent_name, "prom")
 
+    # Idle period of 60s is not enough - github CI fails for has_metric with idle_period=60.
     await asyncio.gather(
-        offer.model.wait_for_idle(apps=[prometheus_name], status="active", idle_period=60),
-        consumer.model.wait_for_idle(apps=[agent_name], status="active", idle_period=60),
+        offer.model.wait_for_idle(apps=[prometheus_name], status="active", idle_period=90),
+        consumer.model.wait_for_idle(apps=[agent_name], status="active", idle_period=90),
     )
 
-    await has_metric(
+    assert await has_metric(
         ops_test,
         f'up{{juju_model="{consumer.model_name}",juju_application="{agent_name}"}}',
         prometheus_name,
@@ -92,4 +93,4 @@ async def has_metric(ops_test, query: str, app_name: str) -> bool:
         if timeseries.get("metric"):
             return True
 
-    raise Exception
+    return False

--- a/tests/integration/test_cross_model_remote_write.py
+++ b/tests/integration/test_cross_model_remote_write.py
@@ -22,6 +22,7 @@ async def test_create_remote_write_models(ops_test, prometheus_charm):
         prometheus_charm,
         resources={"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")},
         application_name=prometheus_name,
+        trust=True,  # otherwise errors on ghwf (persistentvolumeclaims ... is forbidden)
     )
 
     # pytest_operator keeps a dict[str, ModelState] for internal reference, and they'll
@@ -43,7 +44,7 @@ async def test_create_remote_write_models(ops_test, prometheus_charm):
         consumer.model.wait_for_idle(apps=[agent_name], status="active"),
     )
 
-    assert check_prometheus_is_ready(ops_test, prometheus_name, 0)
+    assert await check_prometheus_is_ready(ops_test, prometheus_name, 0)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_ingress_with_traefik_k8s.py
+++ b/tests/integration/test_ingress_with_traefik_k8s.py
@@ -28,6 +28,7 @@ async def test_ingress_traefik_k8s(ops_test, prometheus_charm):
             prometheus_charm,
             resources={"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")},
             application_name=prometheus_name,
+            trust=True,  # otherwise errors on ghwf (persistentvolumeclaims ... is forbidden)
         ),
         ops_test.model.deploy(
             "traefik-k8s",
@@ -43,7 +44,7 @@ async def test_ingress_traefik_k8s(ops_test, prometheus_charm):
     apps = [prometheus_name, traefik_name]
     await ops_test.model.wait_for_idle(apps=apps, status="active")
     assert initial_workload_is_ready(ops_test, apps)
-    assert check_prometheus_is_ready(ops_test, prometheus_name, 0)
+    assert await check_prometheus_is_ready(ops_test, prometheus_name, 0)
 
     await ops_test.model.add_relation(traefik_name, f"{prometheus_name}:ingress")
 

--- a/tests/integration/test_kubectl_delete.py
+++ b/tests/integration/test_kubectl_delete.py
@@ -24,9 +24,12 @@ async def test_deploy_from_local_path(ops_test, prometheus_charm):
     """Deploy the charm-under-test."""
     logger.debug("deploy local charm")
 
-    await ops_test.model.deploy(prometheus_charm, application_name=app_name, resources=resources)
+    # Need trust = True otherwise errors on ghwf (persistentvolumeclaims ... is forbidden)
+    await ops_test.model.deploy(
+        prometheus_charm, application_name=app_name, resources=resources, trust=True
+    )
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=TIMEOUT)
-    assert check_prometheus_is_ready(ops_test, app_name, 0)
+    assert await check_prometheus_is_ready(ops_test, app_name, 0)
 
 
 @pytest.mark.abort_on_fail
@@ -49,4 +52,4 @@ async def test_kubectl_delete_pod(ops_test, prometheus_charm):
     logger.debug(stdout)
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[app_name].units) > 0)
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=TIMEOUT)
-    assert check_prometheus_is_ready(ops_test, app_name, 0)
+    assert await check_prometheus_is_ready(ops_test, app_name, 0)

--- a/tests/integration/test_prometheus_scrape_multiunit.py
+++ b/tests/integration/test_prometheus_scrape_multiunit.py
@@ -73,6 +73,7 @@ async def test_prometheus_scrape_relation_with_prometheus_tester(
             resources=prometheus_resources,
             application_name=prometheus_app_name,
             num_units=num_units,
+            trust=True,  # otherwise errors on ghwf (persistentvolumeclaims ... is forbidden)
         ),
         ops_test.model.deploy(
             prometheus_tester_charm,

--- a/tests/integration/test_prometheus_scrape_multiunit.py
+++ b/tests/integration/test_prometheus_scrape_multiunit.py
@@ -154,15 +154,17 @@ async def test_prometheus_scrape_relation_with_prometheus_tester(
     )
     for u in range(1, len(rules_by_unit)):
         # Some fields will most likely differ, such as "evaluationTime" and "lastEvaluation".
-        # Also excluding "alerts" because the 'rules' endpoint returns a dict of firing alerts,
-        # which may vary across prometheus units given the share nothing and the units starting up
-        # at different times.
+        # Also excluding:
+        # - "alerts" because the 'rules' endpoint returns a dict of firing alerts,
+        #   which may vary across prometheus units given the share nothing and the units starting
+        #   up at different times.
+        # - "health", which takes time to switch from "unknown" to "ok" and occasionally fails CI.
         assert (
             DeepDiff(
                 rules_by_unit[0],
                 rules_by_unit[u],
                 ignore_order=True,
-                exclude_regex_paths=r"evaluationTime|lastEvaluation|activeAt|alerts",
+                exclude_regex_paths=r"evaluationTime|lastEvaluation|activeAt|alerts|health",
             )
             == {}
         )

--- a/tests/integration/test_remote_write_avalanche.py
+++ b/tests/integration/test_remote_write_avalanche.py
@@ -23,7 +23,12 @@ async def test_charm_successfully_relates_to_avalanche(ops_test: OpsTest, promet
     resources = {"prometheus-image": METADATA["resources"]["prometheus-image"]["upstream-source"]}
 
     # deploy prometheus
-    await ops_test.model.deploy(prometheus_charm, resources=resources, application_name="prom")
+    await ops_test.model.deploy(
+        prometheus_charm,
+        resources=resources,
+        application_name="prom",
+        trust=True,  # otherwise errors on ghwf (persistentvolumeclaims ... is forbidden)
+    )
     await ops_test.model.wait_for_idle(apps=["prom"], status="active")
 
     # deploy avalanche

--- a/tests/integration/test_remote_write_grafana_agent.py
+++ b/tests/integration/test_remote_write_grafana_agent.py
@@ -23,6 +23,7 @@ async def test_remote_write_with_grafana_agent(ops_test, prometheus_charm):
             prometheus_charm,
             resources={"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")},
             application_name=prometheus_name,
+            trust=True,  # otherwise errors on ghwf (persistentvolumeclaims ... is forbidden)
         ),
         ops_test.model.deploy(
             "grafana-agent-k8s",
@@ -32,7 +33,7 @@ async def test_remote_write_with_grafana_agent(ops_test, prometheus_charm):
     )
 
     await ops_test.model.wait_for_idle(apps=apps, status="active", wait_for_units=1)
-    assert check_prometheus_is_ready(ops_test, prometheus_name, 0)
+    assert await check_prometheus_is_ready(ops_test, prometheus_name, 0)
 
     await ops_test.model.add_relation(prometheus_name, agent_name)
 

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -36,7 +36,10 @@ async def test_deploy_from_edge_and_upgrade_from_local_path(ops_test, prometheus
     logger.debug("deploy charm from charmhub")
     await asyncio.gather(
         ops_test.model.deploy(
-            f"ch:{prometheus_app_name}", application_name=prometheus_app_name, channel="edge"
+            f"ch:{prometheus_app_name}",
+            application_name=prometheus_app_name,
+            channel="edge",
+            trust=True,  # otherwise errors on ghwf (persistentvolumeclaims ... is forbidden)
         ),
         ops_test.model.deploy(
             prometheus_tester_charm, resources=tester_resources, application_name=tester_app_name
@@ -62,7 +65,7 @@ async def test_rules_are_retained_after_upgrade(ops_test, prometheus_charm):
     await ops_test.model.wait_for_idle(
         apps=app_names, status="active", timeout=300, idle_period=60
     )
-    assert check_prometheus_is_ready(ops_test, prometheus_app_name, 0)
+    assert await check_prometheus_is_ready(ops_test, prometheus_app_name, 0)
 
     # Check only one alert rule exists
     rules_with_relation = await get_prometheus_rules(ops_test, prometheus_app_name, 0)

--- a/tests/unit/test_charm_status.py
+++ b/tests/unit/test_charm_status.py
@@ -37,6 +37,11 @@ class TestActiveStatus(unittest.TestCase):
         # AND the current unit is a leader
         self.harness.set_leader(True)
 
+        patcher = patch.object(PrometheusCharm, "_get_pvc_capacity")
+        self.mock_capacity = patcher.start()
+        self.mock_capacity.return_value = "1Gi"
+        self.addCleanup(patcher.stop)
+
     @patch_network_get()
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     def test_unit_is_active_if_deployed_without_relations_or_config(self):

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -107,6 +107,12 @@ class TestRemoteWriteConsumer(unittest.TestCase):
         self.harness = Harness(RemoteWriteConsumerCharm, meta=METADATA)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(True)
+
+        patcher = patch.object(PrometheusCharm, "_get_pvc_capacity")
+        self.mock_capacity = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.mock_capacity.return_value = "1Gi"
         self.harness.begin_with_initial_hooks()
 
     def test_address_is_set(self):
@@ -209,6 +215,11 @@ class TestRemoteWriteProvider(unittest.TestCase):
         self.harness = Harness(PrometheusCharm)
         self.harness.set_model_info("lma", "123456")
         self.addCleanup(self.harness.cleanup)
+
+        patcher = patch.object(PrometheusCharm, "_get_pvc_capacity")
+        self.mock_capacity = patcher.start()
+        self.mock_capacity.return_value = "1Gi"
+        self.addCleanup(patcher.stop)
 
     @patch.object(KubernetesServicePatch, "_service_object", new=lambda *args: None)
     @patch.object(Prometheus, "reload_configuration", new=lambda _: True)


### PR DESCRIPTION
## Issue
We currently only set maximum retention time for our timeseries data, meaning we’re likely to run out of disk at some point. COS Lite, being treated as a lightweight appliance with resource constraints, should enforce a reasonable default maximum retention storage size as well. It should default to 80% of the PVC size.

Crossref: [OPENG-231](https://warthogs.atlassian.net/browse/OPENG-231)

## Solution
Add maximum retention size config option.


## Context
NTA.


## Testing Instructions
Run all tests.


## Release Notes
Add maximum retention size config option.