### PR TITLE
Add itests to check for data persistance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,6 @@ allow_redefinition = true
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]
-module = ["ops.*", "pytest.*", "pytest_operator.*", "prometheus_api_client.*", "deepdiff.*", "serialized_data_interface.*"]
+module = ["ops.*", "pytest.*", "pytest_operator.*", "prometheus_api_client.*", "deepdiff.*", "serialized_data_interface.*", "charms.grafana_k8s.*", "charms.alertmanager_k8s.*"]
 ignore_missing_imports = true
+follow_imports = "silent"

--- a/tests/integration/test_remote_write_grafana_agent.py
+++ b/tests/integration/test_remote_write_grafana_agent.py
@@ -9,6 +9,7 @@ import pytest
 from helpers import check_prometheus_is_ready, oci_image, run_promql
 
 logger = logging.getLogger(__name__)
+prometheus_resources = {"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")}
 
 
 @pytest.mark.abort_on_fail
@@ -45,6 +46,60 @@ async def test_remote_write_with_grafana_agent(ops_test, prometheus_charm):
         f'up{{juju_model="{ops_test.model_name}",juju_application="{agent_name}"}}',
         prometheus_name,
     )
+
+
+@pytest.mark.abort_on_fail
+async def test_check_data_persist_on_kubectl_delete_pod(ops_test, prometheus_charm):
+    prometheus_app_name = "prometheus"
+    pod_name = f"{prometheus_app_name}-0"
+    query = "prometheus_tsdb_head_chunks_created_total{}"
+    total0 = await run_promql(ops_test, query, prometheus_app_name)
+    sum0 = int(total0[0]["value"][1])
+
+    cmd = [
+        "sg",
+        "microk8s",
+        "-c",
+        " ".join(["microk8s.kubectl", "delete", "pod", "-n", ops_test.model_name, pod_name]),
+    ]
+
+    logger.debug(
+        "Removing pod '%s' from model '%s' with cmd: %s", pod_name, ops_test.model_name, cmd
+    )
+
+    retcode, stdout, stderr = await ops_test.run(*cmd)
+    assert retcode == 0, f"kubectl failed: {(stderr or stdout).strip()}"
+    logger.debug(stdout)
+    await ops_test.model.block_until(
+        lambda: len(ops_test.model.applications[prometheus_app_name].units) > 0
+    )
+    await ops_test.model.wait_for_idle(apps=[prometheus_app_name], status="active", timeout=60)
+    assert check_prometheus_is_ready(ops_test, prometheus_app_name, 0)
+
+    total1 = await run_promql(ops_test, query, prometheus_app_name)
+    sum1 = int(total1[0]["value"][1])
+    assert sum0 <= sum1
+
+
+@pytest.mark.abort_on_fail
+async def test_check_data_persist_on_charm_upgrade(ops_test, prometheus_charm):
+    prometheus_app_name = "prometheus"
+    agent_name = "grafana-agent"
+    apps = [prometheus_app_name, agent_name]
+    query = "prometheus_tsdb_head_chunks_created_total{}"
+    total0 = await run_promql(ops_test, query, prometheus_app_name)
+    sum0 = int(total0[0]["value"][1])
+
+    logger.debug("upgrade deployed charm with local charm %s", prometheus_charm)
+    await ops_test.model.applications[prometheus_app_name].refresh(
+        path=prometheus_charm, resources=prometheus_resources
+    )
+    await ops_test.model.wait_for_idle(apps=apps, status="active", timeout=300, idle_period=60)
+    assert check_prometheus_is_ready(ops_test, prometheus_app_name, 0)
+
+    total1 = await run_promql(ops_test, query, prometheus_app_name)
+    sum1 = int(total1[0]["value"][1])
+    assert sum0 <= sum1
 
 
 async def has_metric(ops_test, query: str, app_name: str) -> bool:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR add itests to:

* Check if prometheus data persists across unit restarts (pod churns / `kubectl delete pod`)
* Check if prometheus data persists across charm upgrade (`juju refresh`)


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run itests
