### PR TITLE
Add an action to check the prometheus config

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,5 @@
+validate-configuration:
+  description: |
+    Run `promtool` inside the workload to validate the Prometheus configuration file, and
+    return the resulting output. This can be used to troubleshoot a Prometheus instance
+    which will not start due to a bad configuration.

--- a/actions.yaml
+++ b/actions.yaml
@@ -2,4 +2,4 @@ validate-configuration:
   description: |
     Run `promtool` inside the workload to validate the Prometheus configuration file, and
     return the resulting output. This can be used to troubleshoot a Prometheus instance
-    which will not start due to a bad configuration.
+    which will not start, or misbehaves, due to a bad configuration.

--- a/src/charm.py
+++ b/src/charm.py
@@ -27,10 +27,10 @@ from charms.traefik_k8s.v0.ingress_per_unit import IngressPerUnitRequirer
 from lightkube import Client
 from lightkube.core.exceptions import ApiError as LightkubeApiError
 from lightkube.resources.core_v1 import PersistentVolumeClaim, Pod
-from ops.charm import CharmBase
+from ops.charm import ActionEvent, CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
-from ops.pebble import ChangeError, Layer
+from ops.pebble import ChangeError, ExecError, Layer
 
 from prometheus_server import Prometheus
 
@@ -93,6 +93,9 @@ class PrometheusCharm(CharmBase):
         self.framework.observe(self.on.receive_remote_write_relation_broken, self._configure)
         self.framework.observe(self.metrics_consumer.on.targets_changed, self._configure)
         self.framework.observe(self.alertmanager_consumer.on.cluster_changed, self._configure)
+        self.framework.observe(
+            self.on.validate_configuration_action, self._on_validate_configuration
+        )
 
     def _configure(self, _):
         """Reconfigure and either reload or restart Prometheus.
@@ -273,6 +276,27 @@ class PrometheusCharm(CharmBase):
         command = ["/bin/prometheus"] + args
 
         return " ".join(command)
+
+    def _on_validate_configuration(self, event: ActionEvent) -> None:
+        """Runs `promtool check config` inside the workload."""
+        container = self.unit.get_container(self._name)
+
+        if not container.can_connect():
+            event.fail("Could not connect to the Prometheus workload!")
+            return
+
+        proc = container.exec(
+            ["/usr/bin/promtool", "check", "config", "/etc/prometheus/prometheus.yml"]
+        )
+        output = err = ""
+        try:
+            output, err = proc.wait_output()
+        except ExecError as e:
+            output, err = e.stdout, e.stderr
+
+        event.set_results(
+            {"result": output, "error-message": err, "valid": False if err else True}
+        )
 
     def _convert_k8s_capacity_to_legacy_binary_gigabytes(self, capacity: str, multiplier) -> str:
         # Reduce possible ambiguity in unit name by adding a trailing 'B'.

--- a/tests/integration/test_check_config.py
+++ b/tests/integration/test_check_config.py
@@ -59,7 +59,7 @@ async def test_good_config_validates_successfully(
     res = (await action.wait()).results
 
     assert res == {
-        "result": "Checking /etc/prometheus/prometheus.yml\n  SUCCESS: /etc/prometheus/prometheus.yml is "
+        "result": "Checking /etc/prometheus/prometheus.yml\n SUCCESS: /etc/prometheus/prometheus.yml is "
         + "valid prometheus config file syntax\n\n",
         "error-message": "",
         "valid": "True",

--- a/tests/integration/test_check_config.py
+++ b/tests/integration/test_check_config.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+
+import pytest
+from helpers import check_prometheus_is_ready, oci_image
+
+logger = logging.getLogger(__name__)
+
+prometheus_app_name = "prometheus"
+prometheus_resources = {"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")}
+scrape_tester = "tester"
+bad_scrape_tester = "invalid-tester"
+scrape_tester_resources = {
+    "prometheus-tester-image": oci_image(
+        "./tests/integration/prometheus-tester/metadata.yaml",
+        "prometheus-tester-image",
+    )
+}
+scrape_shim = "prometheus-scrape-config"
+
+
+async def test_setup_env(ops_test):
+    await ops_test.model.set_config({"logging-config": "<root>=WARNING; unit=DEBUG"})
+
+
+@pytest.mark.abort_on_fail
+async def test_good_config_validates_successfully(
+    ops_test, prometheus_charm, prometheus_tester_charm
+):
+    """Deploy Prometheus and a single client with a good configuration."""
+    await asyncio.gather(
+        ops_test.model.deploy(
+            prometheus_charm,
+            resources=prometheus_resources,
+            application_name=prometheus_app_name,
+            trust=True,  # otherwise errors on ghwf (persistentvolumeclaims ... is forbidden)
+        ),
+        ops_test.model.deploy(
+            prometheus_tester_charm,
+            resources=scrape_tester_resources,
+            application_name=scrape_tester,
+        ),
+    )
+    await ops_test.model.wait_for_idle(apps=[prometheus_app_name, scrape_tester], status="active")
+    await check_prometheus_is_ready(ops_test, prometheus_app_name, 0)
+
+    await ops_test.model.add_relation(prometheus_app_name, scrape_tester)
+
+    # set some custom configs to later check they persisted across the test
+    action = (
+        await ops_test.model.applications[prometheus_app_name]
+        .units[0]
+        .run_action("validate-configuration")
+    )
+    res = (await action.wait()).results
+
+    assert res == {
+        "result": "Checking /etc/prometheus/prometheus.yml\n  SUCCESS: 0 rule files found\n\n",
+        "error-message": "",
+        "valid": "True",
+        "Code": "0",
+    }
+
+
+@pytest.mark.abort_on_fail
+async def test_bad_config_sets_action_results(ops_test, prometheus_charm, prometheus_tester_charm):
+    """Deploy Prometheus and a single client with a good configuration."""
+    await asyncio.gather(
+        ops_test.model.deploy(
+            "prometheus-scrape-config-k8s",
+            channel="edge",
+            application_name=scrape_shim,
+            config={"scrape_interval": "NotANumber!!!"},
+        ),
+        ops_test.model.deploy(
+            prometheus_tester_charm,
+            resources=scrape_tester_resources,
+            application_name=bad_scrape_tester,
+        ),
+    )
+    await ops_test.model.wait_for_idle(apps=[scrape_shim, bad_scrape_tester])
+
+    await asyncio.gather(
+        ops_test.model.add_relation(bad_scrape_tester, scrape_shim),
+        ops_test.model.add_relation(prometheus_app_name, scrape_shim),
+    )
+    await ops_test.model.wait_for_idle(apps=[prometheus_app_name, scrape_shim, bad_scrape_tester])
+
+    # set some custom configs to later check they persisted across the test
+    action = (
+        await ops_test.model.applications[prometheus_app_name]
+        .units[0]
+        .run_action("validate-configuration")
+    )
+    res = (await action.wait()).results
+
+    assert res == {
+        "error-message": '  FAILED: parsing YAML file /etc/prometheus/prometheus.yml: not a valid duration string: "NotANumber!!!"\n',
+        "result": "Checking /etc/prometheus/prometheus.yml\n\n",
+        "Code": "0",
+        "valid": "False",
+    }

--- a/tests/integration/test_check_config.py
+++ b/tests/integration/test_check_config.py
@@ -59,7 +59,8 @@ async def test_good_config_validates_successfully(
     res = (await action.wait()).results
 
     assert res == {
-        "result": "Checking /etc/prometheus/prometheus.yml\n  SUCCESS: 0 rule files found\n\n",
+        "result": "Checking /etc/prometheus/prometheus.yml\n  SUCCESS: /etc/prometheus/prometheus.yml is "
+        + "valid prometheys config file syntax\n\n",
         "error-message": "",
         "valid": "True",
         "Code": "0",

--- a/tests/integration/test_check_config.py
+++ b/tests/integration/test_check_config.py
@@ -60,7 +60,7 @@ async def test_good_config_validates_successfully(
 
     assert res == {
         "result": "Checking /etc/prometheus/prometheus.yml\n  SUCCESS: /etc/prometheus/prometheus.yml is "
-        + "valid prometheys config file syntax\n\n",
+        + "valid prometheus config file syntax\n\n",
         "error-message": "",
         "valid": "True",
         "Code": "0",


### PR DESCRIPTION
## Issue
Add an action to run `promtool check config` to tell users what may be wrong with their Prometheus configuration.

Closes #180 

## Solution
Add an action to call `promtool`. This also requires checking `pebble.ExecError` if the returncode is not 0 (in case of failure) to populate the action results.

## Testing Instructions
Run the tests. Or create a bad config and test the action

## Release Notes
Add an action to check the prometheus config