### PR TITLE
fix juju topology template substitution

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -666,7 +666,7 @@ class AlertRules:
                         alert_rule["labels"].update(self.topology.label_matcher_dict)
                         # insert juju topology filters into a prometheus alert rule
                         alert_rule["expr"] = self.tool.inject_label_matchers(
-                            re.sub(r"%%juju_topology%%(,?)", r"\1", alert_rule["expr"]),
+                            re.sub(r"%%juju_topology%%,?", "", alert_rule["expr"]),
                             self.topology.label_matcher_dict,
                         )
 


### PR DESCRIPTION
The current code incorrectly replaces the template with a bare comma instead of actually injecting the topology