### PR TITLE
replace processor call with machine call

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -1022,7 +1022,7 @@ class CosTool:
             return expression
 
     def _get_tool_path(self) -> Optional[Path]:
-        arch = platform.processor()
+        arch = platform.machine()
         arch = "amd64" if arch == "x86_64" else arch
         res = "cos-tool-{}".format(arch)
         try:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -2192,7 +2192,7 @@ class CosTool:
             return expression
 
     def _get_tool_path(self) -> Optional[Path]:
-        arch = platform.processor()
+        arch = platform.machine()
         arch = "amd64" if arch == "x86_64" else arch
         res = "cos-tool-{}".format(arch)
         try:

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -32,20 +32,20 @@ class TestTransform(unittest.TestCase):
         self.harness.begin()
 
     # pylint: disable=protected-access
-    @unittest.mock.patch("platform.processor", lambda: "teakettle")
+    @unittest.mock.patch("platform.machine", lambda: "teakettle")
     def test_disable_on_invalid_arch(self):
         tool = self.harness.charm.tool
         self.assertIsNone(tool.path)
         self.assertTrue(tool._disabled)
 
     # pylint: disable=protected-access
-    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    @unittest.mock.patch("platform.machine", lambda: "x86_64")
     def test_gives_path_on_valid_arch(self):
         """When given a valid arch, it should return the binary path."""
         transformer = self.harness.charm.tool
         self.assertIsInstance(transformer.path, PosixPath)
 
-    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    @unittest.mock.patch("platform.machine", lambda: "x86_64")
     def test_setup_transformer(self):
         """When setup it should know the path to the binary."""
         tool = self.harness.charm.tool
@@ -55,7 +55,7 @@ class TestTransform(unittest.TestCase):
         p = str(tool.path)
         self.assertTrue(p.endswith("cos-tool-amd64"))
 
-    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    @unittest.mock.patch("platform.machine", lambda: "x86_64")
     @unittest.mock.patch("subprocess.run")
     def test_returns_original_expression_when_subprocess_call_errors(self, mocked_run):
         mocked_run.side_effect = subprocess.CalledProcessError(
@@ -87,7 +87,7 @@ class TestTransform(unittest.TestCase):
         )
         self.assertEqual(output["groups"][0]["expr"], "process_cpu_seconds_total > 0.12")
 
-    @unittest.mock.patch("platform.processor", lambda: "invalid")
+    @unittest.mock.patch("platform.machine", lambda: "invalid")
     def test_uses_original_expression_when_binary_missing(self):
         tool = self.harness.charm.tool
         output = tool.apply_label_matchers(
@@ -114,20 +114,20 @@ class TestTransform(unittest.TestCase):
         )
         self.assertEqual(output["groups"][0]["expr"], "process_cpu_seconds_total > 0.12")
 
-    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    @unittest.mock.patch("platform.machine", lambda: "x86_64")
     def test_fetches_the_correct_expression(self):
         tool = self.harness.charm.tool
 
         output = tool.inject_label_matchers("up", {"juju_model": "some_juju_model"})
         assert output == 'up{juju_model="some_juju_model"}'
 
-    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    @unittest.mock.patch("platform.machine", lambda: "x86_64")
     def test_handles_comparisons(self):
         tool = self.harness.charm.tool
         output = tool.inject_label_matchers("up > 1", {"juju_model": "some_juju_model"})
         assert output == 'up{juju_model="some_juju_model"} > 1'
 
-    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    @unittest.mock.patch("platform.machine", lambda: "x86_64")
     def test_handles_multiple_labels(self):
         tool = self.harness.charm.tool
         output = tool.inject_label_matchers(
@@ -155,7 +155,7 @@ class TestValidateAlerts(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
-    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    @unittest.mock.patch("platform.machine", lambda: "x86_64")
     def test_returns_errors_on_bad_rule_file(self):
         tool = self.harness.charm.tool
         valid, errs = tool.validate_alert_rules(
@@ -171,7 +171,7 @@ class TestValidateAlerts(unittest.TestCase):
         self.assertEqual(valid, False)
         self.assertIn(errs, "error validating:")
 
-    @unittest.mock.patch("platform.processor", lambda: "x86_64")
+    @unittest.mock.patch("platform.machine", lambda: "x86_64")
     def test_successfully_validates_good_alert_rules(self):
         tool = self.harness.charm.tool
         valid, errs = tool.validate_alert_rules(


### PR DESCRIPTION
the current call to `platform.processor` is not reliable and quite frequently returns `"unknown"`, for instance in the CI, or on arch linux. this patch replaces all occurrences with calls to `platform.machine` which should be way more reliable. 