### PR TITLE
test that prometheus doesn't fail with the same charm related twice.

### DIFF
--- a/tests/integration/test_deduplication.py
+++ b/tests/integration/test_deduplication.py
@@ -64,7 +64,7 @@ async def test_same_app_related_two_ways(
 ):
     """Test that the deduplication works when the same app is related twice."""
     await asyncio.gather(
-        ops_test.model.applications[tester_app_name].set_config({"scrape_jobs": "[]"}),
+        ops_test.model.applications[tester_app_name].reset_config(["scrape_jobs"]),
         ops_test.model.deploy(
             "prometheus-scrape-config-k8s", channel="edge", application_name="scrape-config"
         ),

--- a/tests/integration/test_deduplication.py
+++ b/tests/integration/test_deduplication.py
@@ -70,7 +70,7 @@ async def test_same_app_related_two_ways(
         ),
     )
     await asyncio.gather(
-        ops_test.model.add_relation(prometheus_app_name, "scrape-config"),
+        ops_test.model.add_relation(prometheus_app_name, "scrape-config:metrics-endpoint"),
         ops_test.model.add_relation("scrape-config", tester_app_name),
     )
     await ops_test.model.wait_for_idle(status="active")


### PR DESCRIPTION
## Issue
closes #257 


## Solution
This was previously fixed so I just added an integration test.


## Testing Instructions
relate prometheus to an app then to the same app through prometheus-crape-config-k8s. Make sure it has not crashed.


## Release Notes
Prometheus no longer fails when related to the same application twice.
