### PR TITLE
Metrics Provider uses bind address by default

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1553,7 +1553,14 @@ class MetricsEndpointProvider(Object):
         event is actually needed.
         """
         for relation in self._charm.model.relations[self._relation_name]:
-            relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = socket.getfqdn()
+            unit_ip = str(self._charm.model.get_binding(relation).network.bind_address)
+            if self._is_valid_unit_address(unit_ip):
+                relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = unit_ip
+            else:
+                relation.data[self._charm.unit][
+                    "prometheus_scrape_unit_address"
+                ] = socket.getfqdn()
+
             relation.data[self._charm.unit]["prometheus_scrape_unit_name"] = str(
                 self._charm.model.unit.name
             )

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1554,12 +1554,9 @@ class MetricsEndpointProvider(Object):
         """
         for relation in self._charm.model.relations[self._relation_name]:
             unit_ip = str(self._charm.model.get_binding(relation).network.bind_address)
-            if self._is_valid_unit_address(unit_ip):
-                relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = unit_ip
-            else:
-                relation.data[self._charm.unit][
-                    "prometheus_scrape_unit_address"
-                ] = socket.getfqdn()
+            relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = (
+                unit_ip if self._is_valid_unit_address(unit_ip) else socket.getfqdn()
+            )
 
             relation.data[self._charm.unit]["prometheus_scrape_unit_name"] = str(
                 self._charm.model.unit.name


### PR DESCRIPTION
This commit ensures MetricsEndpointProvider uses bind_address
rather than socket.fqdn() by default and only falls back to
fqdn() if bind address is not valid. This change was made because
it was found that in some cases fqdn() did not return resolvable
addresses for example if MetricsEndpointProvider charm was in
a LXD could on localhost and MetricsEndpointProvider was on
a Microk8s cloud on the same host.

closes #329 

## Issue
Sometimes `socket.fqdn()` does not return resolvable host names.


## Solution
Use `bind_address` by default and fallback to `fqdn()` if `bind_address` is invalid.


## Context
Relating MetricsEndpointProvider charm to MetricsEndpointConsumer charm cross LXD and Microk8s clouds on localhost fails.


## Testing Instructions
- Deploy a MetricsEndpointProvider charm in a LXD cloud on a host (say localhost0
- Deploy the Prometheus charm on a Microk8s cloud on the *same* host
- Relate the two charms and check it works (metrics are scrapped).


## Release Notes
- Metrics Endpoint Provider uses bind_address by default and falls back to fqdn
