### PR TITLE
Allow static scrape targets without a port set

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1128,7 +1128,7 @@ class MetricsEndpointConsumer(Object):
             ports = []
             unitless_targets = []
             for target in all_targets:
-                host, port = target.split(":")
+                host, port = self._target_parts(target)
                 if host.strip() == "*":
                     ports.append(port.strip())
                 else:
@@ -1156,6 +1156,26 @@ class MetricsEndpointConsumer(Object):
         labeled_job["relabel_configs"] = relabel_configs
 
         return labeled_job
+
+    def _target_parts(self, target) -> list:
+        """Extract host and port from a wildcard target.
+
+        Args:
+            target: a string specifying a scrape target. A
+              scrape target is expected to have the format
+              "host:port". The host part may be a wildcard
+              "*" and the port part can be missing (along
+              with ":") in which case port is set to 80.
+
+        Returns:
+            a list with target host and port as in [host, port]
+        """
+        if ":" in target:
+            parts = target.split(":")
+        else:
+            parts = [target, "80"]
+
+        return parts
 
     def _set_juju_labels(self, labels, scrape_metadata) -> dict:
         """Create a copy of metric labels with Juju topology information.


### PR DESCRIPTION
This commit ensures that Metrics Endpoint Consumer accepts
static scrape targets that do not have a port set.

closes #327

## Issue
If a client charm does not set a port in the specification of a static scrape target it leads to an error because targets were hitherto expected to have the format `host:port`


## Solution
Accept targets without port set in which case port is set to 80.


## Context
NA


## Testing Instructions
- Deploy and relate a charm which does not specify port.


## Release Notes
- Scrape targets need not specify port
