### PR TITLE
Report Prometheus version correctly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,8 @@ description = Check code against coding style standards
 deps =
     black
     codespell
-    flake8
+    # Pinned until pyproject-flake8 supports flake8 >= 5
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
## Issue
The operator does not report the running version of Prometheus to Juju


## Solution
Report version during the `_configure` hook, and also add an `update-status` handler to report the version on each `update-status` event