### PR TITLE
Fix validation logic

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -1011,7 +1011,7 @@ class CosTool:
                 return False, ", ".join(
                     [
                         line
-                        for line in e.output.decode("utf8").strip().split("\n")
+                        for line in e.output.decode("utf8").splitlines()
                         if "error validating" in line
                     ]
                 )

--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -18,7 +18,6 @@ import re
 import socket
 import subprocess
 import tempfile
-import uuid
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -993,28 +992,13 @@ class CosTool:
         return rules
 
     def validate_alert_rules(self, rules: dict) -> Tuple[bool, str]:
-        """Will validate correctness alert rules, returning a boolean and any errors."""
+        """Will validate correctness of alert rules, returning a boolean and any errors."""
         if not self.path:
             logger.debug("`cos-tool` unavailable. Not validating alert correctness.")
             return True, ""
 
         with tempfile.TemporaryDirectory() as tmpdir:
             rule_path = Path(tmpdir + "/validate_rule.yaml")
-
-            # Smash "our" rules format into what upstream actually uses, which is more like:
-            #
-            # groups:
-            #   - name: foo
-            #     rules:
-            #       - alert: SomeAlert
-            #         expr: up
-            #       - alert: OtherAlert
-            #         expr: up
-            transformed_rules = {"groups": []}  # type: ignore
-            for rule in rules["groups"]:
-                transformed = {"name": str(uuid.uuid4()), "rules": [rule]}
-                transformed_rules["groups"].append(transformed)
-
             rule_path.write_text(yaml.dump(rules))
 
             args = [str(self.path), "validate", str(rule_path)]
@@ -1024,9 +1008,15 @@ class CosTool:
                 return True, ""
             except subprocess.CalledProcessError as e:
                 logger.debug("Validating the rules failed: %s", e.output)
-                return False, ", ".join([line for line in e.output if "error validating" in line])
+                return False, ", ".join(
+                    [
+                        line
+                        for line in e.output.decode("utf8").strip().split("\n")
+                        if "error validating" in line
+                    ]
+                )
 
-    def inject_label_matchers(self, expression, topology):
+    def inject_label_matchers(self, expression, topology) -> str:
         """Add label matchers to an expression."""
         if not topology:
             return expression
@@ -1042,7 +1032,7 @@ class CosTool:
         # noinspection PyBroadException
         try:
             return self._exec(args)
-        except Exception as e:
+        except subprocess.CalledProcessError as e:
             logger.debug('Applying the expression failed: "%s", falling back to the original', e)
             return expression
 
@@ -1060,7 +1050,6 @@ class CosTool:
             logger.debug('Could not locate cos-tool at: "{}"'.format(res))
         return None
 
-    def _exec(self, cmd):
-        result = subprocess.run(cmd, check=False, stdout=subprocess.PIPE)
-        output = result.stdout.decode("utf-8").strip()
-        return output
+    def _exec(self, cmd) -> str:
+        result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        return result.stdout.decode("utf-8").strip()

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -322,7 +322,6 @@ import re
 import socket
 import subprocess
 import tempfile
-import uuid
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -2224,22 +2223,7 @@ class CosTool:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             rule_path = Path(tmpdir + "/validate_rule.yaml")
-
-            # Smash "our" rules format into what upstream actually uses, which is more like:
-            #
-            # groups:
-            #   - name: foo
-            #     rules:
-            #       - alert: SomeAlert
-            #         expr: up
-            #       - alert: OtherAlert
-            #         expr: up
-            transformed_rules = {"groups": []}  # type: ignore
-            for rule in rules["groups"]:
-                transformed = {"name": str(uuid.uuid4()), "rules": [rule]}
-                transformed_rules["groups"].append(transformed)
-
-            rule_path.write_text(yaml.dump(transformed_rules))
+            rule_path.write_text(yaml.dump(rules))
 
             args = [str(self.path), "validate", str(rule_path)]
             # noinspection PyBroadException
@@ -2248,7 +2232,13 @@ class CosTool:
                 return True, ""
             except subprocess.CalledProcessError as e:
                 logger.debug("Validating the rules failed: %s", e.output)
-                return False, ", ".join([line for line in e.output if "error validating" in line])
+                return False, ", ".join(
+                    [
+                        line
+                        for line in e.output.decode("utf8").strip().split("\n")
+                        if "error validating" in line
+                    ]
+                )
 
     def inject_label_matchers(self, expression, topology) -> str:
         """Add label matchers to an expression."""
@@ -2285,6 +2275,5 @@ class CosTool:
         return None
 
     def _exec(self, cmd) -> str:
-        result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE)
-        output = result.stdout.decode("utf-8").strip()
-        return output
+        result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        return result.stdout.decode("utf-8").strip()

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -2235,7 +2235,7 @@ class CosTool:
                 return False, ", ".join(
                     [
                         line
-                        for line in e.output.decode("utf8").strip().split("\n")
+                        for line in e.output.decode("utf8").splitlines()
                         if "error validating" in line
                     ]
                 )

--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -63,8 +63,15 @@ import typing
 from typing import Any, Dict, Optional, Tuple, Union
 
 import yaml
-from ops.charm import CharmBase, RelationEvent
-from ops.framework import EventSource, Object, ObjectEvents, StoredState
+from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
+from ops.framework import (
+    EventSource,
+    Object,
+    ObjectEvents,
+    StoredDict,
+    StoredList,
+    StoredState,
+)
 from ops.model import Application, ModelError, Relation, Unit
 
 # The unique Charmhub library identifier, never change it
@@ -75,7 +82,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 log = logging.getLogger(__name__)
 
@@ -151,6 +158,19 @@ RequirerData = TypedDict(
 RequirerUnitData = Dict[Unit, "RequirerData"]
 KeyValueMapping = Dict[str, str]
 ProviderApplicationData = Dict[str, KeyValueMapping]
+
+
+def _type_convert_stored(obj):
+    """Convert Stored* to their appropriate types, recursively."""
+    if isinstance(obj, StoredList):
+        return list(map(_type_convert_stored, obj))
+    elif isinstance(obj, StoredDict):
+        rdict = {}  # type: Dict[Any, Any]
+        for k in obj.keys():
+            rdict[k] = _type_convert_stored(obj[k])
+        return rdict
+    else:
+        return obj
 
 
 def _validate_data(data, schema):
@@ -411,6 +431,15 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
         Assumes that this unit is leader.
         """
         assert self.unit.is_leader(), "only leaders can do this"
+        try:
+            relation.data
+        except ModelError as e:
+            log.warning(
+                "error {} accessing relation data for {!r}. "
+                "Probably a ghost of a dead relation is still "
+                "lingering around.".format(e, relation.name)
+            )
+            return
         del relation.data[self.app]["ingress"]
 
     def _requirer_units_data(self, relation: Relation) -> RequirerUnitData:
@@ -431,9 +460,9 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
                 # this remote unit didn't share data yet
                 log.warning("Remote unit {} not ready.".format(remote_unit.name))
                 continue
-            except DataValidationError:
+            except DataValidationError as e:
                 # this remote unit sent invalid data.
-                log.error("Remote unit {} sent invalid data.".format(remote_unit.name))
+                log.error("Remote unit {} sent invalid data ({}).".format(remote_unit.name, e))
                 continue
 
             remote_data["port"] = int(remote_data["port"])
@@ -673,7 +702,10 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         # we calculate the diff between the urls we were aware of
         # before and those we know now
         previous_urls = self._stored.current_urls or {}  # type: ignore
-        current_urls = self.urls or {}
+        current_urls = (
+            {} if isinstance(event, RelationBrokenEvent) else self._get_urls_from_relation_data
+        )
+        self._stored.current_urls = current_urls  # type: ignore
 
         removed = previous_urls.keys() - current_urls.keys()  # type: ignore
         changed = {a for a in current_urls if current_urls[a] != previous_urls.get(a)}  # type: ignore
@@ -696,8 +728,6 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
 
             for unit_name in removed:
                 self.on.revoked.emit(self.relation, unit_name)  # type: ignore
-
-        self._stored.current_urls = current_urls  # type: ignore
 
         # todo remove cast when ops.charm is typed
         self._publish_auto_data(typing.cast(Relation, event.relation))
@@ -751,7 +781,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         self.relation.data[self.unit].update(data)
 
     @property
-    def urls(self) -> Dict[str, str]:
+    def _get_urls_from_relation_data(self) -> Dict[str, str]:
         """The full ingress URLs to reach every unit.
 
         May return an empty dict if the URLs aren't available yet.
@@ -783,6 +813,16 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         _validate_data({"ingress": data}, INGRESS_PROVIDES_APP_SCHEMA)
 
         return {unit_name: unit_data["url"] for unit_name, unit_data in data.items()}
+
+    @property
+    def urls(self) -> Dict[str, str]:
+        """The full ingress URLs to reach every unit.
+
+        May return an empty dict if the URLs aren't available yet.
+        """
+        data = _type_convert_stored(self._stored.current_urls or {})  # type: ignore
+        assert isinstance(data, dict)  # for static checker
+        return data
 
     @property
     def url(self) -> Optional[str]:

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -51,7 +51,7 @@ class Prometheus:
         self.api_timeout = api_timeout
 
     def reload_configuration(self) -> bool:
-        """Send a POST request to to hot-reload the config.
+        """Send a POST request to hot-reload the config.
 
         This reduces down-time compared to restarting the service.
 

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -109,7 +109,7 @@ UNLABELED_ALERT_RULES = {
             "rules": [
                 {
                     "alert": "CPUOverUse",
-                    "expr": 'process_cpu_seconds_total{juju_model="None"',
+                    "expr": 'process_cpu_seconds_total{juju_model="None"}',
                     "for": "0m",
                     "labels": {
                         "severity": "Low",

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -169,7 +169,7 @@ class TestValidateAlerts(unittest.TestCase):
             }
         )
         self.assertEqual(valid, False)
-        self.assertIn(errs, "error validating:")
+        self.assertIn("error validating:", errs)
 
     @unittest.mock.patch("platform.machine", lambda: "x86_64")
     def test_successfully_validates_good_alert_rules(self):
@@ -178,20 +178,25 @@ class TestValidateAlerts(unittest.TestCase):
             {
                 "groups": [
                     {
-                        "alert": "CPUOverUse",
-                        "expr": "process_cpu_seconds_total > 0.12",
-                        "for": "0m",
-                        "labels": {
-                            "severity": "Low",
-                            "juju_model": "None",
-                            "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
-                            "juju_application": "consumer-tester",
-                        },
-                        "annotations": {
-                            "summary": "Instance {{ $labels.instance }} CPU over use",
-                            "description": "{{ $labels.instance }} of job "
-                            "{{ $labels.job }} has used too much CPU.",
-                        },
+                        "name": "group_name",
+                        "rules": [
+                            {
+                                "alert": "CPUOverUse",
+                                "expr": "process_cpu_seconds_total > 0.12",
+                                "for": "0m",
+                                "labels": {
+                                    "severity": "Low",
+                                    "juju_model": "None",
+                                    "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                                    "juju_application": "consumer-tester",
+                                },
+                                "annotations": {
+                                    "summary": "Instance {{ $labels.instance }} CPU over use",
+                                    "description": "{{ $labels.instance }} of job "
+                                    "{{ $labels.job }} has used too much CPU.",
+                                },
+                            }
+                        ],
                     }
                 ]
             }


### PR DESCRIPTION
(This PR was split out of #340.)

## Issue
When the bundle is deployed, prometheus is in blocked status (loading config failed) because:
```
error validating: yaml: unmarshal errors:
  line 4: field name not found in type rulefmt.RuleNode
  line 5: field rules not found in type rulefmt.RuleNode
...
```

Apparently, when cos tool validation synthesized a tempfile to disk, it created incorrect nesting:

```yaml
groups:
- name: 5b372040-794c-4e2c-b040-16468d10039d
  rules:
  - name: cos-lite-load-test_7acf3bc5_loki_loki_request_errors_alerts
    rules:
    - alert: LokiRequestErrors
```

Note the double use of `name` and `rules`.

## Solution
- return stdout as part of `_exec`, so that `.output` includes errors content
- add utest for validating baked-in alerts, as they appear in relation data

Using these changes is demonstrated in https://github.com/canonical/cos-configuration-k8s-operator/pull/24.

## Context
Load test failed to start after latest releases.


## Testing Instructions
Deploy the bundle: `juju deploy --channel=edge cos-lite`


## Release Notes
Fix alert rule validation logic