### PR TITLE
Fix ingress usage

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -89,25 +89,31 @@ class PrometheusCharm(CharmBase):
             resource_reqs_func=self._resource_reqs_from_config,
         )
 
+        self.ingress = IngressPerUnitRequirer(self, relation_name="ingress", port=self._port)
+
         self._topology = JujuTopology.from_charm(self)
 
+        external_url = urlparse(self.external_url)
+
+        # TODO when https://github.com/canonical/traefik-k8s-operator/issues/78 is fixed, change
+        #  the refresh event to self.ingress.on.ready_for_unit.
         self._scraping = MetricsEndpointProvider(
             self,
             relation_name="self-metrics-endpoint",
             jobs=self.self_scraping_job,
+            external_hostname=external_url.netloc,
+            refresh_event=self.on.update_status,  # needed for ingress
         )
         self.grafana_dashboard_provider = GrafanaDashboardProvider(charm=self)
         self.metrics_consumer = MetricsEndpointConsumer(self)
-        self.ingress = IngressPerUnitRequirer(self, relation_name="ingress", port=self._port)
 
-        external_url = urlparse(self.external_url)
         self._prometheus_server = Prometheus(web_route_prefix=external_url.path)
 
         self.remote_write_provider = PrometheusRemoteWriteProvider(
             charm=self,
             relation_name=DEFAULT_REMOTE_WRITE_RELATION_NAME,
             endpoint_address=external_url.hostname or "",
-            endpoint_port=external_url.port or self._port,
+            endpoint_port=external_url.port or 80,
             endpoint_schema=external_url.scheme,
             endpoint_path=f"{external_url.path}/api/v1/write",
         )
@@ -154,9 +160,27 @@ class PrometheusCharm(CharmBase):
         self.framework.observe(self.on.validate_configuration_action, self._on_validate_config)
 
     @property
+    def metrics_path(self):
+        """The metrics path, adjusted by ingress path (if any)."""
+        return urlparse(self.external_url).path.rstrip("/") + "/metrics"
+
+    @property
     def self_scraping_job(self):
         """The scrape job used by Prometheus to scrape itself during self-monitoring."""
-        return [{"static_configs": [{"targets": [f"*:{self._port}"]}]}]
+        # TODO https://github.com/canonical/prometheus-k8s-operator/issues/360
+        # A single scrape job cannot accommodate more than one unit with ingress-per-unit.
+        # With ingress, each unit is expected to have a different path. This means that each
+        # unit needs to have its own static_config, because `metrics_path` is on the same
+        # hierarchical level as `static_configs` (for this reason, *-notation cannot be used).
+        # However, scrape jobs are placed in app data, so only the leader unit can set it, and the
+        # leader unit must be able to obtain addresses of all units.
+        port = urlparse(self.external_url).port or 80
+        return [
+            {
+                "metrics_path": self.metrics_path,
+                "static_configs": [{"targets": [f"*:{port}"]}],
+            }
+        ]
 
     @property
     def log_level(self):
@@ -180,7 +204,7 @@ class PrometheusCharm(CharmBase):
             "job_name": "prometheus",
             "scrape_interval": "5s",
             "scrape_timeout": "5s",
-            "metrics_path": "/metrics",
+            "metrics_path": self.metrics_path,
             "honor_timestamps": True,
             "scheme": "http",
             "static_configs": [
@@ -410,10 +434,13 @@ class PrometheusCharm(CharmBase):
         return True
 
     def _update_layer(self, container) -> bool:
-        current_services = container.get_plan().services
+        current_planned_services = container.get_plan().services
         new_layer = self._prometheus_layer
 
-        if current_services == new_layer.services:
+        current_services = container.get_services()  # mapping from str to ServiceInfo
+        all_svcs_running = all(svc.is_running() for svc in current_services.values())
+
+        if current_planned_services == new_layer.services and all_svcs_running:
             return False
 
         container.add_layer(self._name, new_layer, combine=True)

--- a/src/charm.py
+++ b/src/charm.py
@@ -95,14 +95,16 @@ class PrometheusCharm(CharmBase):
 
         external_url = urlparse(self.external_url)
 
-        # TODO when https://github.com/canonical/traefik-k8s-operator/issues/78 is fixed, change
-        #  the refresh event to self.ingress.on.ready_for_unit.
         self._scraping = MetricsEndpointProvider(
             self,
             relation_name="self-metrics-endpoint",
             jobs=self.self_scraping_job,
             external_url=self.external_url,
-            refresh_event=self.on.update_status,  # needed for ingress
+            refresh_event=[  # needed for ingress
+                self.ingress.on.ready_for_unit,
+                self.ingress.on.revoked_for_unit,
+                self.on.update_status,
+            ],
         )
         self.grafana_dashboard_provider = GrafanaDashboardProvider(charm=self)
         self.metrics_consumer = MetricsEndpointConsumer(self)

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -32,23 +32,11 @@ class Prometheus:
               when we relate to an ingress.
             api_timeout: Optional; timeout (in seconds) to observe when interacting with the API.
         """
-        if web_route_prefix and not web_route_prefix.endswith("/"):
-            # If we do not add the '/' and the end, we will lose the last
-            # bit of the path:
-            #
-            # BAD:
-            #
-            # >>> urljoin('http://some/more', 'thing')
-            #   'http://some/thing'
-            #
-            # GOOD:
-            #
-            # >>> urljoin('http://some/more/', 'thing')
-            #   'http://some/more/thing'
-            #
-            web_route_prefix = f"{web_route_prefix}/"
+        web_route_prefix = web_route_prefix.lstrip("/").rstrip("/")
+        self.base_url = f"http://{host.rstrip('/')}:{port}/" + web_route_prefix
+        if not self.base_url.endswith("/"):
+            self.base_url += "/"
 
-        self.base_url = urljoin(f"http://{host}:{port}", web_route_prefix)
         self.api_timeout = api_timeout
 
     def reload_configuration(self) -> Union[bool, str]:

--- a/tests/integration/test_external_url.py
+++ b/tests/integration/test_external_url.py
@@ -19,7 +19,6 @@ import pytest
 from helpers import oci_image, unit_address
 from pytest_operator.plugin import OpsTest
 
-pytestmark = pytest.mark.skip("https://github.com/canonical/prometheus-k8s-operator/issues/360")
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_external_url.py
+++ b/tests/integration/test_external_url.py
@@ -19,7 +19,6 @@ import pytest
 from helpers import oci_image, unit_address
 from pytest_operator.plugin import OpsTest
 
-
 logger = logging.getLogger(__name__)
 
 prometheus_app_name = "prometheus"

--- a/tests/integration/test_external_url.py
+++ b/tests/integration/test_external_url.py
@@ -145,7 +145,8 @@ async def test_jobs_are_up_via_traefik(ops_test: OpsTest):
         assert '"health":"down"' not in targets
 
     # Workaround to make sure everything is up-to-date: update-status
-    # - wait until ingress is really ready (https://github.com/canonical/traefik-k8s-operator/issues/78)
+    # - wait until ingress is really ready
+    #   (https://github.com/canonical/traefik-k8s-operator/issues/78)
     # - update-status
     async def get_ingressed_endpoints():
         action = (

--- a/tests/integration/test_external_url.py
+++ b/tests/integration/test_external_url.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Test various aspects of `external_url`.
+
+1. When external_url is set (with path prefix) via traefik, default and self-scraping jobs are
+   'up'.
+2. When external_url is set (with path prefix) via config option to a different value,
+   default and self-scraping jobs are 'up'.
+"""
+
+import asyncio
+import logging
+import subprocess
+import urllib.request
+
+import pytest
+from helpers import oci_image, unit_address
+from pytest_operator.plugin import OpsTest
+
+pytestmark = pytest.mark.skip("https://github.com/canonical/prometheus-k8s-operator/issues/360")
+
+logger = logging.getLogger(__name__)
+
+prometheus_app_name = "prometheus"
+prometheus_resources = {"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")}
+external_prom_name = "external-prometheus"
+
+# Two prometheus units are sufficient to test potential interactions between multi-unit
+# deployments and external_url
+num_units = 2
+
+# The period of time required to be idle before `wait_for_idle` returns is set to 90 sec because
+# the default scrape_interval in prometheus is 1m.
+idle_period = 90
+
+
+async def test_setup_env(ops_test: OpsTest):
+    await ops_test.model.set_config(
+        {"logging-config": "<root>=WARNING; unit=DEBUG", "update-status-hook-interval": "60m"}
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy(ops_test: OpsTest, prometheus_charm):
+    await asyncio.gather(
+        ops_test.model.deploy(
+            prometheus_charm,
+            resources=prometheus_resources,
+            application_name=prometheus_app_name,
+            num_units=num_units,
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            prometheus_charm,
+            resources=prometheus_resources,
+            application_name=external_prom_name,  # to scrape the main prom
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            "ch:traefik-k8s",
+            application_name="traefik",
+            channel="edge",
+        ),
+    )
+
+    await asyncio.gather(
+        ops_test.model.add_relation(
+            f"{prometheus_app_name}:self-metrics-endpoint", external_prom_name
+        ),
+        ops_test.model.wait_for_idle(
+            apps=[prometheus_app_name],
+            status="active",
+            wait_for_units=num_units,
+            timeout=300,
+        ),
+        ops_test.model.wait_for_idle(
+            apps=["traefik", external_prom_name],
+            wait_for_units=1,
+            timeout=300,
+        ),
+    )
+
+
+async def test_jobs_are_up_via_traefik(ops_test: OpsTest):
+    # Set up microk8s metallb addon, needed by traefik
+    logger.info("(Re)-enabling metallb")
+    cmd = [
+        "sh",
+        "-c",
+        "ip -4 -j route | jq -r '.[] | select(.dst | contains(\"default\")) | .prefsrc'",
+    ]
+    result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    ip = result.stdout.decode("utf-8").strip()
+
+    logger.info("First, disable metallb, just in case")
+    try:
+        cmd = ["sg", "microk8s", "-c", "microk8s disable metallb"]
+        subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    except Exception as e:
+        print(e)
+        raise
+
+    await asyncio.sleep(30)  # why? just because, for now
+
+    logger.info("Now enable metallb")
+    try:
+        cmd = ["sg", "microk8s", "-c", f"microk8s enable metallb:{ip}-{ip}"]
+        subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    except Exception as e:
+        print(e)
+        raise
+
+    # GIVEN metallb is ready
+    await asyncio.sleep(30)  # why? just because, for now
+
+    # WHEN prometheus is related to traefik
+    await ops_test.model.add_relation(f"{prometheus_app_name}:ingress", "traefik")
+
+    # Workaround to make sure everything is up-to-date: update-status
+    await ops_test.model.set_config({"update-status-hook-interval": "10s"})
+    await asyncio.sleep(11)
+    await ops_test.model.set_config({"update-status-hook-interval": "60m"})
+
+    logger.info("At this point, after re-enabling metallb, traefik should become active")
+    await ops_test.model.wait_for_idle(
+        apps=[prometheus_app_name, "traefik", external_prom_name],
+        status="active",
+        timeout=600,
+        idle_period=idle_period,
+    )
+
+    # THEN the prometheus API is served on metallb's IP and the model-app-unit path
+    def prom_url(unit: int) -> str:
+        return f"http://{ip}/{ops_test.model_name}-{prometheus_app_name}-{unit}"
+
+    # AND the default job is healthy (its scrape url must have the path for this to work)
+    prom_urls = [prom_url(i) + "/api/v1/targets" for i in range(num_units)]
+    for url in prom_urls:
+        logger.info("Attmpting to fetch targets from url: %s", url)
+        targets = urllib.request.urlopen(url, None, timeout=2).read().decode("utf8")
+        logger.info("Response: %s", targets)
+        assert '"health":"up"' in targets
+        assert '"health":"down"' not in targets
+
+    # AND the self-scrape jobs are healthy (their scrape url must have the entire web_external_url
+    # for this to work).
+    external_prom_url = f"http://{await unit_address(ops_test, external_prom_name, 0)}:9090"
+    url = external_prom_url + "/api/v1/targets"
+    logger.info("Attmpting to fetch targets from url: %s", external_prom_url)
+    targets = urllib.request.urlopen(url, None, timeout=2).read().decode("utf8")
+    logger.info("Response: %s", targets)
+    assert '"health":"up"' in targets
+    assert '"health":"down"' not in targets
+
+
+async def test_jobs_are_up_with_config_option_overriding_traefik(ops_test: OpsTest):
+    # GIVEN traefik ingress for prom
+    # (from previous test)
+
+    # WHEN the `web_external_url` config option is set
+    await ops_test.model.applications[prometheus_app_name].set_config(
+        {"web_external_url": "http://foo.bar/baz"},
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[prometheus_app_name],
+        status="active",
+        timeout=300,
+    )
+
+    # THEN the prometheus api is served on the unit's IP and web_external_url's path
+    async def prom_url(unit: int) -> str:
+        return f"http://{await unit_address(ops_test, prometheus_app_name, unit)}:9090/baz"
+
+    # AND the default job is healthy (its scrape url must have the path for this to work)
+    prom_urls = [await prom_url(i) + "/api/v1/targets" for i in range(num_units)]
+    for url in prom_urls:
+        logger.info("Attmpting to fetch targets from url: %s", url)
+        targets = urllib.request.urlopen(url, None, timeout=2).read().decode("utf8")
+        logger.info("Response: %s", targets)
+        assert '"health":"up"' in targets
+        assert '"health":"down"' not in targets

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -80,6 +80,18 @@ def patch_cos_tool_path(func) -> Callable:
     return wrapper_decorator
 
 
+def cli_arg(plan, cli_opt):
+    plan_dict = plan.to_dict()
+    args = plan_dict["services"]["prometheus"]["command"].split()
+    for arg in args:
+        opt_list = arg.split("=")
+        if len(opt_list) == 2 and opt_list[0] == cli_opt:
+            return opt_list[1]
+        if len(opt_list) == 1 and opt_list[0] == cli_opt:
+            return opt_list[0]
+    return None
+
+
 k8s_resource_multipatch = patch.multiple(
     "charm.KubernetesComputeResourcesPatch",
     _namespace="test-namespace",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import ops
 import yaml
-from helpers import k8s_resource_multipatch, prom_multipatch
+from helpers import cli_arg, k8s_resource_multipatch, prom_multipatch
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
 
@@ -281,18 +281,6 @@ def scrape_config(config_yaml, job_name):
     for config in scrape_configs:
         if config["job_name"] == job_name:
             return config
-    return None
-
-
-def cli_arg(plan, cli_opt):
-    plan_dict = plan.to_dict()
-    args = plan_dict["services"]["prometheus"]["command"].split()
-    for arg in args:
-        opt_list = arg.split("=")
-        if len(opt_list) == 2 and opt_list[0] == cli_opt:
-            return opt_list[1]
-        if len(opt_list) == 1 and opt_list[0] == cli_opt:
-            return opt_list[0]
     return None
 
 

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -2,7 +2,9 @@
 # See LICENSE file for licensing details.
 
 import json
+import logging
 import unittest
+from string import Template
 
 from charms.prometheus_k8s.v0.prometheus_scrape import (
     ALLOWED_KEYS,
@@ -13,6 +15,8 @@ from ops.framework import StoredState
 from ops.testing import Harness
 
 from tests.unit.helpers import PROJECT_DIR
+
+logger = logging.getLogger(__name__)
 
 RELATION_NAME = "metrics-endpoint"
 DEFAULT_JOBS = [{"metrics_path": "/metrics"}]
@@ -586,3 +590,146 @@ def wildcard_targets(jobs, wildcard_ports):
                     if target.endswith(port):
                         targets.append(target)
     return targets
+
+
+class TestWildcardTargetsWithMutliunitProvider(unittest.TestCase):
+    """Test how scrape jobs of multiunit providers with wildcard-hosts get rendered to disk."""
+
+    def set_relation_data(self, metrics_path: str = None, external_url_path: Template = None):
+        job = {
+            "job_name": "job",
+            "static_configs": [{"targets": ["*:1234"]}],
+        }
+        if metrics_path:
+            job.update({"metrics_path": metrics_path})
+
+        self.harness.update_relation_data(
+            self.rel_id,
+            "remote-app",
+            {
+                "scrape_metadata": json.dumps(
+                    {
+                        "model": self.__class__.__name__,
+                        "model_uuid": "00000000-0000-0000-a000-000000000000",
+                        "application": "remote-app",
+                        "charm_name": "some-provider",
+                    }
+                ),
+                "scrape_jobs": json.dumps([job]),
+            },
+        )
+
+        external_url_path = external_url_path or Template("")
+        self.harness.update_relation_data(
+            self.rel_id,
+            "remote-app/0",
+            {
+                "prometheus_scrape_unit_address": "10.10.10.10",
+                # "prometheus_scrape_unit_path": external_url_path.substitute(unit=0),
+                "prometheus_scrape_unit_name": "remote-app/0",
+            },
+        )
+
+        self.harness.update_relation_data(
+            self.rel_id,
+            "remote-app/1",
+            {
+                "prometheus_scrape_unit_address": "11.11.11.11",
+                # "prometheus_scrape_unit_path": external_url_path.substitute(unit=1),
+                "prometheus_scrape_unit_name": "remote-app/1",
+            },
+        )
+
+    def setUp(self):
+        metadata_file = open("metadata.yaml")
+        self.harness = Harness(EndpointConsumerCharm, meta=metadata_file)
+
+        self.rel_id = self.harness.add_relation(RELATION_NAME, "remote-app")
+        self.harness.add_relation_unit(self.rel_id, "remote-app/0")
+        self.harness.add_relation_unit(self.rel_id, "remote-app/1")
+
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+    def test_bare_job(self):
+        # WHEN the the provider forwards a nice and simple scrape job
+        self.set_relation_data(metrics_path=None, external_url_path=None)
+
+        # THEN the consumer side sees one job, two static_configs and one target per static_config
+        jobs = self.harness.charm.prometheus_consumer.jobs()
+        self.assertEqual(len(jobs), 1)  # one job
+        self.assertEqual(len(jobs[0]["static_configs"]), 2)  # one static_config per unit
+
+        # one target per static_config
+        self.assertEqual(len(targets_unit_0 := jobs[0]["static_configs"][0]["targets"]), 1)
+        self.assertEqual(len(targets_unit_1 := jobs[0]["static_configs"][1]["targets"]), 1)
+
+        # AND the consumer side expands it to unit addresses
+        unit_netlocs = sorted([targets_unit_0[0], targets_unit_1[0]])
+        self.assertEqual(unit_netlocs, ["10.10.10.10:1234", "11.11.11.11:1234"])
+
+        # AND adds the default metrics_path key
+        self.assertEqual(jobs[0]["metrics_path"], "/metrics")
+
+    def test_job_with_metrics_path(self):
+        # WHEN the provider specifies a metrics_path
+        self.set_relation_data(metrics_path="/custom_path", external_url_path=None)
+
+        # THEN the consumer uses it
+        jobs = self.harness.charm.prometheus_consumer.jobs()
+        self.assertEqual(jobs[0]["metrics_path"], "/custom_path")
+
+    @unittest.skip("Not yet impl'd")
+    def test_job_with_same_path_prefix(self):
+        # WHEN the provider sets unit addresses with the same path in both units
+        self.set_relation_data(metrics_path=None, external_url_path=Template("/foo"))
+
+        # THEN the consumer side sees one job, two static_configs and one target per static_config
+        jobs = self.harness.charm.prometheus_consumer.jobs()
+        self.assertEqual(len(jobs), 1)  # one job
+        self.assertEqual(len(jobs[0]["static_configs"]), 2)  # one static_config per unit
+
+        # one target per static_config
+        self.assertEqual(len(targets_unit_0 := jobs[0]["static_configs"][0]["targets"]), 1)
+        self.assertEqual(len(targets_unit_1 := jobs[0]["static_configs"][1]["targets"]), 1)
+
+        # AND the consumer side expands it to unit addresses
+        unit_netlocs = sorted([targets_unit_0[0], targets_unit_1[0]])
+        self.assertEqual(unit_netlocs, ["10.10.10.10:1234", "11.11.11.11:1234"])
+
+        # AND prefixes the default metrics_path with the unit's path
+        self.assertEqual(jobs[0]["metrics_path"], "/foo/metrics")
+
+    @unittest.skip("Not yet impl'd")
+    def test_job_with_different_path_prefix(self):
+        # WHEN the provider sets unit addresses with a path
+        self.set_relation_data(metrics_path=None, external_url_path=Template("/model-app-$unit"))
+
+        # THEN the consumer side sees one job per unit
+        jobs = self.harness.charm.prometheus_consumer.jobs()
+        self.assertEqual(len(jobs), 2)  # one job per unit, so 2 in total
+        self.assertEqual(len(jobs[0]["static_configs"]), 1)
+
+        # one target per static_config
+        self.assertEqual(len(targets_unit_0 := jobs[0]["static_configs"][0]["targets"]), 1)
+        self.assertEqual(len(targets_unit_1 := jobs[1]["static_configs"][0]["targets"]), 1)
+
+        # AND the consumer side expands it to unit addresses
+        unit_netlocs = sorted([targets_unit_0[0], targets_unit_1[0]])
+        self.assertEqual(unit_netlocs, ["10.10.10.10:1234", "11.11.11.11:1234"])
+
+        # AND prefixes the default metrics_path with the unit's path
+        self.assertEqual(jobs[0]["metrics_path"], "/model-app-0/metrics")
+        self.assertEqual(jobs[1]["metrics_path"], "/model-app-1/metrics")
+
+    @unittest.skip("Not yet impl'd")
+    def test_job_with_port_and_path_prefix(self):
+        # WHEN the provider sets unit addresses with a path and also specifies metrics_path
+        self.set_relation_data(
+            metrics_path="/custom-path", external_url_path=Template("/model-app-$unit")
+        )
+
+        # THEN the provider's metrics_path appended to the unit's path instead of the default
+        jobs = self.harness.charm.prometheus_consumer.jobs()
+        self.assertEqual(jobs[0]["metrics_path"], "/model-app-0/custom-path")
+        self.assertEqual(jobs[1]["metrics_path"], "/model-app-1/custom-path")

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -9,6 +9,17 @@ from prometheus_server import Prometheus
 
 
 class TestServerPrefix(unittest.TestCase):
+    def test_address_glueing(self):
+        # WHEN no args are provided THEN use localhost:9090
+        p = Prometheus()
+        self.assertEqual(p.base_url, "http://localhost:9090/")
+
+        # WHEN path is provided THEN it is appended to localhost:9090 and '/'-terminated
+        for path in ["foo", "/foo", "foo/", "/foo/"]:
+            with self.subTest(path=path):
+                p = Prometheus(web_route_prefix=path)
+                self.assertEqual(p.base_url, "http://localhost:9090/foo/")
+
     @responses.activate
     def test_prometheus_server_without_route_prefix_returns_valid_data(self):
         self.prometheus = Prometheus("localhost", 9090)

--- a/tests/unit/test_web_external_url.py
+++ b/tests/unit/test_web_external_url.py
@@ -1,0 +1,270 @@
+# Copyright 2020 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import logging
+import unittest
+from unittest.mock import patch
+
+import ops
+import yaml
+from helpers import cli_arg, k8s_resource_multipatch, patch_network_get, prom_multipatch
+from ops.testing import Harness
+
+from charm import PROMETHEUS_CONFIG, PrometheusCharm
+
+ops.testing.SIMULATE_CAN_CONNECT = True
+logger = logging.getLogger(__name__)
+
+
+@unittest.skip("https://github.com/canonical/prometheus-k8s-operator/issues/360")
+class TestWebExternalUrlForCharm(unittest.TestCase):
+    """Test that the web_external_url config option is rendered correctly for the charm.
+
+    This entails:
+    - default job config (the same prom scraping itself via localhost:9090)
+    - self-scrape job (the requirer side of the prometheus_scrape relation data)
+    - remote-write url (relation data for the provider side, i.e. receive-remote-write)
+    """
+
+    def setUp(self, *unused):
+        self.harness = Harness(PrometheusCharm)
+        self.addCleanup(self.harness.cleanup)
+
+        pvc_patcher = patch.object(PrometheusCharm, "_get_pvc_capacity")
+        self.pvc_mock = pvc_patcher.start()
+        self.addCleanup(pvc_patcher.stop)
+        self.harness.set_model_name("prometheus_model")
+        self.pvc_mock.return_value = "1Gi"
+
+        for p in [
+            k8s_resource_multipatch,
+            patch_network_get(),
+            patch("socket.getfqdn", new=lambda *args: "fqdn"),
+            patch("charm.KubernetesServicePatch", lambda x, y: None),
+            patch("lightkube.core.client.GenericSyncClient"),
+            prom_multipatch,
+        ]:
+            p.start()
+            self.addCleanup(p.stop)
+
+        self.harness.set_leader(True)
+
+        self.rel_id_self_metrics = self.harness.add_relation(
+            "self-metrics-endpoint", "remote-scraper-app"
+        )
+        self.harness.add_relation_unit(self.rel_id_self_metrics, "remote-scraper-app/0")
+
+        self.rel_id_remote_write = self.harness.add_relation(
+            "receive-remote-write", "remote-write-app"
+        )
+        self.harness.add_relation_unit(self.rel_id_remote_write, "remote-write-app/0")
+
+    def app_data(self, rel_name: str):
+        relation = self.harness.charm.model.get_relation(rel_name)
+        return relation.data[self.harness.charm.app]
+
+    def unit_data(self, rel_name: str):
+        relation = self.harness.charm.model.get_relation(rel_name)
+        return relation.data[self.harness.charm.unit]
+
+    @property
+    def container_name(self):
+        return self.harness.charm._name
+
+    @property
+    def plan(self):
+        return self.harness.get_container_pebble_plan(self.container_name)
+
+    @property
+    def config_file(self) -> dict:
+        return yaml.safe_load(self.container.pull(PROMETHEUS_CONFIG).read())
+
+    def test_web_external_url_not_set(self, *unused):
+        # GIVEN an initialized charm
+        # Note: harness does not re-init the charm on core events such as config-changed.
+        # https://github.com/canonical/operator/issues/736
+        # For this reason, repeating the begin_with_initial_hooks() in every test method.
+        # When operator/736 is implemented, these lines can be moved to setUp().
+        self.harness.update_config(unset=["web_external_url"])
+        self.harness.begin_with_initial_hooks()
+        self.harness.container_pebble_ready("prometheus")
+        self.container = self.harness.charm.unit.get_container(self.container_name)
+
+        # WHEN web_external_url is not set
+        # (This had to be done above, before `begin`, due to operator/736)
+
+        # THEN pebble plan does NOT have the --web.external_url arg set
+        self.assertEqual(cli_arg(self.plan, "--web.external_url"), None)
+
+        # AND default job is the default localhost:9090/metrics
+        scrape_config = self.config_file["scrape_configs"][0]
+        self.assertEqual(scrape_config["static_configs"][0]["targets"], ["localhost:9090"])
+        self.assertEqual(scrape_config["metrics_path"], "/metrics")
+
+        # AND the self-scrape job points to prom's fqdn
+        self.assertEqual(
+            self.app_data("self-metrics-endpoint").get("scrape_jobs"),
+            json.dumps(
+                [{"metrics_path": "/metrics", "static_configs": [{"targets": ["*:9090"]}]}]
+            ),
+        )
+        self.assertEqual(
+            self.unit_data("self-metrics-endpoint").get("prometheus_scrape_unit_address"),
+            "fqdn:9090",
+        )
+
+        # AND the remote-write provider points to prom's fqdn
+        self.assertEqual(
+            self.unit_data("receive-remote-write").get("remote_write"),
+            '{"url": "http://fqdn:9090/api/v1/write"}',
+        )
+
+    def test_web_external_has_hostname_only(self, *unused):
+        # GIVEN an initialized charm
+        self.harness.update_config({"web_external_url": "http://foo.bar"})
+        self.harness.begin_with_initial_hooks()
+        self.harness.container_pebble_ready("prometheus")
+        self.container = self.harness.charm.unit.get_container(self.container_name)
+
+        # WHEN web_external_url is just a hostname
+        # (This had to be done above, before `begin`, due to operator/736)
+
+        # THEN pebble plan has the --web.external_url set to http://foo.bar
+        self.assertEqual(cli_arg(self.plan, "--web.external-url"), "http://foo.bar")
+
+        # AND default job is the default localhost:9090/metrics
+        scrape_config = self.config_file["scrape_configs"][0]
+        self.assertEqual(scrape_config["static_configs"][0]["targets"], ["localhost:9090"])
+        self.assertEqual(scrape_config["metrics_path"], "/metrics")
+
+        # AND the self-scrape job points to the external url
+        self.assertEqual(
+            self.app_data("self-metrics-endpoint").get("scrape_jobs"),
+            json.dumps(
+                [{"metrics_path": "/metrics", "static_configs": [{"targets": ["foo.bar"]}]}]
+            ),
+        )
+        self.assertEqual(
+            self.unit_data("self-metrics-endpoint").get("prometheus_scrape_unit_address"),
+            "foo.bar",
+        )
+
+        # AND the remote-write provider points to prom's fqdn
+        self.assertEqual(
+            self.unit_data("receive-remote-write").get("remote_write"),
+            '{"url": "http://foo.bar:80/api/v1/write"}',
+        )
+
+    def test_web_external_has_hostname_and_port(self, *unused):
+        # GIVEN an initialized charm
+        self.harness.update_config({"web_external_url": "http://foo.bar:1234"})
+        self.harness.begin_with_initial_hooks()
+        self.harness.container_pebble_ready("prometheus")
+        self.container = self.harness.charm.unit.get_container(self.container_name)
+
+        # WHEN web_external_url is a hostname with a port
+        # (This had to be done above, before `begin`, due to operator/736)
+
+        # THEN pebble plan has the --web.external_url set to http://foo.bar:1234
+        self.assertEqual(cli_arg(self.plan, "--web.external-url"), "http://foo.bar:1234")
+
+        # AND default job is the default localhost:9090/metrics
+        scrape_config = self.config_file["scrape_configs"][0]
+        self.assertEqual(scrape_config["static_configs"][0]["targets"], ["localhost:9090"])
+        self.assertEqual(scrape_config["metrics_path"], "/metrics")
+
+        # AND the self-scrape job points to the external url
+        self.assertEqual(
+            self.app_data("self-metrics-endpoint").get("scrape_jobs"),
+            json.dumps(
+                [{"metrics_path": "/metrics", "static_configs": [{"targets": ["foo.bar:1234"]}]}]
+            ),
+        )
+        self.assertEqual(
+            self.unit_data("self-metrics-endpoint").get("prometheus_scrape_unit_address"),
+            "foo.bar:1234",
+        )
+
+        # AND the remote-write provider points to prom's fqdn
+        self.assertEqual(
+            self.unit_data("receive-remote-write").get("remote_write"),
+            '{"url": "http://foo.bar:1234/api/v1/write"}',
+        )
+
+    def test_web_external_has_hostname_and_path(self, *unused):
+        # GIVEN an initialized charm
+        self.harness.update_config({"web_external_url": "http://foo.bar/baz"})
+        self.harness.begin_with_initial_hooks()
+        self.harness.container_pebble_ready("prometheus")
+        self.container = self.harness.charm.unit.get_container(self.container_name)
+
+        # WHEN web_external_url includes a path
+        # (This had to be done above, before `begin`, due to operator/736)
+
+        # THEN pebble plan has the --web.external_url set to http://foo.bar/baz
+        self.assertEqual(cli_arg(self.plan, "--web.external-url"), "http://foo.bar/baz")
+
+        # AND default job is the default localhost:9090/baz/metrics
+        scrape_config = self.config_file["scrape_configs"][0]
+        self.assertEqual(scrape_config["static_configs"][0]["targets"], ["localhost:9090"])
+        self.assertEqual(scrape_config["metrics_path"], "/baz/metrics")
+
+        # AND the self-scrape job points to the external url
+        self.assertEqual(
+            self.app_data("self-metrics-endpoint").get("scrape_jobs"),
+            json.dumps(
+                [{"metrics_path": "/baz/metrics", "static_configs": [{"targets": ["foo.bar"]}]}]
+            ),
+        )
+        self.assertEqual(
+            self.unit_data("self-metrics-endpoint").get("prometheus_scrape_unit_address"),
+            "foo.bar",
+        )
+
+        # AND the remote-write provider points to prom's fqdn
+        self.assertEqual(
+            self.unit_data("receive-remote-write").get("remote_write"),
+            '{"url": "http://foo.bar:80/baz/api/v1/write"}',
+        )
+
+    def test_web_external_has_hostname_port_and_path(self, *unused):
+        # GIVEN an initialized charm
+        self.harness.update_config({"web_external_url": "http://foo.bar:1234/baz"})
+        self.harness.begin_with_initial_hooks()
+        self.harness.container_pebble_ready("prometheus")
+        self.container = self.harness.charm.unit.get_container(self.container_name)
+
+        # WHEN web_external_url includes a port and a path
+        # (This had to be done above, before `begin`, due to operator/736)
+
+        # THEN pebble plan has the --web.external_url set to http://foo.bar:1234/baz
+        self.assertEqual(cli_arg(self.plan, "--web.external-url"), "http://foo.bar:1234/baz")
+
+        # AND default job is the default localhost:9090/baz/metrics
+        scrape_config = self.config_file["scrape_configs"][0]
+        self.assertEqual(scrape_config["static_configs"][0]["targets"], ["localhost:9090"])
+        self.assertEqual(scrape_config["metrics_path"], "/baz/metrics")
+
+        # AND the self-scrape job points to the external url
+        self.assertEqual(
+            self.app_data("self-metrics-endpoint").get("scrape_jobs"),
+            json.dumps(
+                [
+                    {
+                        "metrics_path": "/baz/metrics",
+                        "static_configs": [{"targets": ["foo.bar:1234"]}],
+                    }
+                ]
+            ),
+        )
+        self.assertEqual(
+            self.unit_data("self-metrics-endpoint").get("prometheus_scrape_unit_address"),
+            "foo.bar:1234",
+        )
+
+        # AND the remote-write provider points to prom's fqdn
+        self.assertEqual(
+            self.unit_data("receive-remote-write").get("remote_write"),
+            '{"url": "http://foo.bar:1234/baz/api/v1/write"}',
+        )

--- a/tests/unit/test_web_external_url.py
+++ b/tests/unit/test_web_external_url.py
@@ -17,7 +17,6 @@ ops.testing.SIMULATE_CAN_CONNECT = True
 logger = logging.getLogger(__name__)
 
 
-@unittest.skip("https://github.com/canonical/prometheus-k8s-operator/issues/360")
 class TestWebExternalUrlForCharm(unittest.TestCase):
     """Test that the web_external_url config option is rendered correctly for the charm.
 
@@ -111,7 +110,7 @@ class TestWebExternalUrlForCharm(unittest.TestCase):
         )
         self.assertEqual(
             self.unit_data("self-metrics-endpoint").get("prometheus_scrape_unit_address"),
-            "fqdn:9090",
+            "fqdn",
         )
 
         # AND the remote-write provider points to prom's fqdn
@@ -138,12 +137,10 @@ class TestWebExternalUrlForCharm(unittest.TestCase):
         self.assertEqual(scrape_config["static_configs"][0]["targets"], ["localhost:9090"])
         self.assertEqual(scrape_config["metrics_path"], "/metrics")
 
-        # AND the self-scrape job points to the external url
+        # AND the self-scrape job advertises a wildcard target on port 80
         self.assertEqual(
             self.app_data("self-metrics-endpoint").get("scrape_jobs"),
-            json.dumps(
-                [{"metrics_path": "/metrics", "static_configs": [{"targets": ["foo.bar"]}]}]
-            ),
+            json.dumps([{"metrics_path": "/metrics", "static_configs": [{"targets": ["*:80"]}]}]),
         )
         self.assertEqual(
             self.unit_data("self-metrics-endpoint").get("prometheus_scrape_unit_address"),
@@ -174,16 +171,16 @@ class TestWebExternalUrlForCharm(unittest.TestCase):
         self.assertEqual(scrape_config["static_configs"][0]["targets"], ["localhost:9090"])
         self.assertEqual(scrape_config["metrics_path"], "/metrics")
 
-        # AND the self-scrape job points to the external url
+        # AND the self-scrape job advertises a wildcard target on port 1234
         self.assertEqual(
             self.app_data("self-metrics-endpoint").get("scrape_jobs"),
             json.dumps(
-                [{"metrics_path": "/metrics", "static_configs": [{"targets": ["foo.bar:1234"]}]}]
+                [{"metrics_path": "/metrics", "static_configs": [{"targets": ["*:1234"]}]}]
             ),
         )
         self.assertEqual(
             self.unit_data("self-metrics-endpoint").get("prometheus_scrape_unit_address"),
-            "foo.bar:1234",
+            "foo.bar",
         )
 
         # AND the remote-write provider points to prom's fqdn
@@ -210,12 +207,10 @@ class TestWebExternalUrlForCharm(unittest.TestCase):
         self.assertEqual(scrape_config["static_configs"][0]["targets"], ["localhost:9090"])
         self.assertEqual(scrape_config["metrics_path"], "/baz/metrics")
 
-        # AND the self-scrape job points to the external url
+        # AND the self-scrape job advertises a wildcard target on port 80
         self.assertEqual(
             self.app_data("self-metrics-endpoint").get("scrape_jobs"),
-            json.dumps(
-                [{"metrics_path": "/baz/metrics", "static_configs": [{"targets": ["foo.bar"]}]}]
-            ),
+            json.dumps([{"metrics_path": "/metrics", "static_configs": [{"targets": ["*:80"]}]}]),
         )
         self.assertEqual(
             self.unit_data("self-metrics-endpoint").get("prometheus_scrape_unit_address"),
@@ -246,21 +241,21 @@ class TestWebExternalUrlForCharm(unittest.TestCase):
         self.assertEqual(scrape_config["static_configs"][0]["targets"], ["localhost:9090"])
         self.assertEqual(scrape_config["metrics_path"], "/baz/metrics")
 
-        # AND the self-scrape job points to the external url
+        # AND the self-scrape job advertises a wildcard target on port 1234
         self.assertEqual(
             self.app_data("self-metrics-endpoint").get("scrape_jobs"),
             json.dumps(
                 [
                     {
-                        "metrics_path": "/baz/metrics",
-                        "static_configs": [{"targets": ["foo.bar:1234"]}],
+                        "metrics_path": "/metrics",
+                        "static_configs": [{"targets": ["*:1234"]}],
                     }
                 ]
             ),
         )
         self.assertEqual(
             self.unit_data("self-metrics-endpoint").get("prometheus_scrape_unit_address"),
-            "foo.bar:1234",
+            "foo.bar",
         )
 
         # AND the remote-write provider points to prom's fqdn

--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,7 @@ deps =
     charm: httpcore==0.14.7
     unit: {[testenv:unit]deps}
     integration: {[testenv:integration]deps}
+    integration: pytest-operator==1.0.0b1
 commands =
     charm: mypy {[vars]src_path} {posargs}
     lib: mypy --python-version 3.5 {[vars]lib_path} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, static-{charm,lib,unit,integration}, unit
+envlist = lint, static-{charm,lib}, unit
 
 [vars]
 src_path = {toxinidir}/src
@@ -57,7 +57,7 @@ commands =
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
-[testenv:static-{charm,lib}]
+[testenv:static-{charm,lib,unit,integration}]
 description = Run static analysis checks
 setenv =
     unit: MYPYPATH = {[vars]tst_path}/unit
@@ -71,9 +71,13 @@ deps =
     lib: ops
     charm: responses==0.20.0
     charm: httpcore==0.14.7
+    unit: {[testenv:unit]deps}
+    integration: {[testenv:integration]deps}
 commands =
     charm: mypy {[vars]src_path} {posargs}
     lib: mypy --python-version 3.5 {[vars]lib_path} {posargs}
+    unit: mypy {[vars]tst_path}/unit {posargs}
+    integration: mypy {[vars]tst_path}/integration {posargs}
 
 [testenv:unit]
 description = Run unit tests

--- a/tox.ini
+++ b/tox.ini
@@ -59,9 +59,6 @@ commands =
 
 [testenv:static-{charm,lib,unit,integration}]
 description = Run static analysis checks
-setenv =
-    unit: MYPYPATH = {[vars]tst_path}/unit
-    integration: MYPYPATH = {[vars]tst_path}/integration
 deps =
     mypy
     types-dataclasses


### PR DESCRIPTION
(Note: this PR was split out of #340.)

## Issue
The self-scrape job is "down" when prometheus is related to traefik.The external hostname is not passed to prom_scrape constructor for the self-scraping endpoint.

## Solution
Use external_url in constructing the self-scraping job.

Note: the quality of the solution in this PR is affected by https://github.com/canonical/traefik-k8s-operator/issues/78.

## Testing Instructions
Deploy prom and relate to traefik. Then look at prom's `/api/v1/targets`.


## Release Notes
Fix ingress usage.