### PR TITLE
get workload version from the binary rather than the api

### DIFF
--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -33,3 +33,11 @@ k8s_resource_multipatch = patch.multiple(
     _patch=lambda *a, **kw: True,
     is_ready=lambda *a, **kw: True,
 )
+
+
+class FakeProcessVersionCheck:
+    def __init__(self, args):
+        pass
+
+    def wait_output(self):
+        return ("version 0.1.0", "")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -399,6 +399,7 @@ class TestAlertsFilename(unittest.TestCase):
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
     @patch("prometheus_server.Prometheus.reload_configuration", lambda *_: True)
+    @patch.object(Container, "exec", new=FakeProcessVersionCheck)
     def setUp(self, *unused):
         self.harness = Harness(PrometheusCharm)
         self.addCleanup(self.harness.cleanup)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,7 +10,8 @@ from unittest.mock import patch
 
 import ops
 import yaml
-from helpers import k8s_resource_multipatch
+from helpers import FakeProcessVersionCheck, k8s_resource_multipatch
+from ops.model import Container
 from ops.testing import Harness
 
 from charm import PROMETHEUS_CONFIG, PrometheusCharm
@@ -32,6 +33,7 @@ class TestCharm(unittest.TestCase):
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
+    @patch.object(Container, "exec", new=FakeProcessVersionCheck)
     def setUp(self, *unused):
         self.harness = Harness(PrometheusCharm)
         self.addCleanup(self.harness.cleanup)
@@ -229,6 +231,7 @@ class TestCharm(unittest.TestCase):
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
     @patch("prometheus_server.Prometheus.reload_configuration")
+    @patch.object(Container, "exec", new=FakeProcessVersionCheck)
     def test_configuration_reload(self, trigger_configuration_reload, *unused):
         self.harness.container_pebble_ready("prometheus")
 
@@ -284,6 +287,7 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
+    @patch.object(Container, "exec", new=FakeProcessVersionCheck)
     def test_default_maximum_retention_size_is_80_percent(self, *unused):
         """This test is here to guarantee backwards compatibility.
 
@@ -305,6 +309,7 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
+    @patch.object(Container, "exec", new=FakeProcessVersionCheck)
     def test_multiplication_factor_applied_to_pvc_capacity(self, *unused):
         """The `--storage.tsdb.retention.size` arg must be multiplied by maximum_retention_size."""
         # GIVEN a capacity limit in binary notation (k8s notation)

--- a/tests/unit/test_charm_status.py
+++ b/tests/unit/test_charm_status.py
@@ -71,6 +71,7 @@ class TestActiveStatus(unittest.TestCase):
     @patch_network_get()
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
+    @patch.object(Container, "exec", new=FakeProcessVersionCheck)
     def test_unit_is_blocked_if_reload_configuration_fails(self, *unused):
         """Scenario: Unit is deployed but reload configuration fails."""
         # GIVEN reload configuration fails

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -235,6 +235,7 @@ class TestRemoteWriteProvider(unittest.TestCase):
     @patch.object(Prometheus, "reload_configuration", new=lambda _: True)
     @patch("socket.getfqdn", new=lambda *args: "fqdn")
     @patch_network_get()
+    @patch.object(Container, "exec", new=FakeProcessVersionCheck)
     def test_port_is_set(self, *unused):
         self.harness.begin_with_initial_hooks()
         self.harness.container_pebble_ready("prometheus")

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -15,10 +15,10 @@ from charms.prometheus_k8s.v0.prometheus_remote_write import (
 from charms.prometheus_k8s.v0.prometheus_remote_write import (
     PrometheusRemoteWriteConsumer,
 )
-from helpers import k8s_resource_multipatch, patch_network_get
+from helpers import FakeProcessVersionCheck, k8s_resource_multipatch, patch_network_get
 from ops import framework
 from ops.charm import CharmBase
-from ops.model import ActiveStatus
+from ops.model import ActiveStatus, Container
 from ops.testing import Harness
 
 from charm import Prometheus, PrometheusCharm
@@ -274,6 +274,7 @@ class TestRemoteWriteProvider(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient")
     @patch.object(Prometheus, "reload_configuration", new=lambda _: True)
     @patch_network_get()
+    @patch.object(Container, "exec", new=FakeProcessVersionCheck)
     def test_address_is_updated_on_upgrade(self, *unused):
         rel_id = self.harness.add_relation(RELATION_NAME, "consumer")
         self.harness.add_relation_unit(rel_id, "consumer/0")


### PR DESCRIPTION
## Issue
When using the api to get workload version we rely on `update_status`.

## Solution
Use `/bin/prometheus --version`.

## Testing Instructions
Deploy and check version is set without errors.

## Release Notes
prometheus-k8s no longer relies on update_status to set workload version
