### PR TITLE
Add tls, basic_auth keys to allowlist

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -356,6 +356,9 @@ ALLOWED_KEYS = {
     "label_limit",
     "label_name_length_limit",
     "label_value_length_limit",
+    "scheme",
+    "basic_auth",
+    "tls_config",
 }
 DEFAULT_JOB = {
     "metrics_path": "/metrics",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -222,7 +222,8 @@ class TestCharm(unittest.TestCase):
             },
         )
 
-        prometheus_scrape_config = yaml.safe_load(self.harness.charm._prometheus_config())
+        config, _ = self.harness.charm._prometheus_config()
+        prometheus_scrape_config = yaml.safe_load(config)
         for job in prometheus_scrape_config["scrape_configs"]:
             if job["job_name"] != "prometheus":
                 self.assertIn("honor_labels", job)
@@ -509,3 +510,60 @@ class TestAlertsFilename(unittest.TestCase):
         self.assertEqual(
             {file.path for file in files}, {"/etc/prometheus/rules/juju_ZZZ_group_alerts.rules"}
         )
+
+
+@patch("charms.observability_libs.v0.juju_topology.JujuTopology.is_valid_uuid", lambda *args: True)
+class TestTlsConfig(unittest.TestCase):
+    @patch("charm.KubernetesServicePatch", lambda x, y: None)
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    def setUp(self, *_):
+        self.harness = Harness(PrometheusCharm)
+        self.addCleanup(self.harness.cleanup)
+
+        self.rel_id = self.harness.add_relation(RELATION_NAME, "provider-app")
+        self.harness.add_relation_unit(self.rel_id, "provider-app/0")
+
+        self.harness.begin_with_initial_hooks()
+        self.harness.container_pebble_ready("prometheus")
+
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    @patch("prometheus_server.Prometheus.reload_configuration", lambda *_: True)
+    def test_dummy(self, *_):
+        scrape_jobs = [
+            {
+                "job_name": "job1",
+                "static_configs": [
+                    {"targets": ["*:80"]},
+                ],
+                "tls_config": {"ca_file": "CERT DATA 1"},
+            },
+            {
+                "job_name": "job2",
+                "static_configs": [
+                    {"targets": ["*:80"]},
+                ],
+                "tls_config": {"ca_file": "CERT DATA 2"},
+            },
+        ]
+
+        self.harness.update_relation_data(
+            self.rel_id,
+            "provider-app",
+            {
+                "scrape_jobs": json.dumps(scrape_jobs),
+            },
+        )
+        self.harness.update_relation_data(
+            self.rel_id,
+            "provider-app/0",
+            {
+                "prometheus_scrape_unit_address": "1.1.1.1",
+                "prometheus_scrape_unit_name": "provider-app/0",
+            },
+        )
+
+        container = self.harness.charm.unit.get_container("prometheus")
+        self.assertEqual(container.pull("/etc/prometheus/job1.crt").read(), "CERT DATA 1")
+        self.assertEqual(container.pull("/etc/prometheus/job2.crt").read(), "CERT DATA 2")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -222,7 +222,8 @@ class TestCharm(unittest.TestCase):
             },
         )
 
-        config, _ = self.harness.charm._prometheus_config()
+        container = self.harness.charm.unit.get_container(self.harness.charm._name)
+        config = container.pull(PROMETHEUS_CONFIG)
         prometheus_scrape_config = yaml.safe_load(config)
         for job in prometheus_scrape_config["scrape_configs"]:
             if job["job_name"] != "prometheus":
@@ -517,6 +518,7 @@ class TestTlsConfig(unittest.TestCase):
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
+    @patch.object(Container, "exec", new=FakeProcessVersionCheck)
     def setUp(self, *_):
         self.harness = Harness(PrometheusCharm)
         self.addCleanup(self.harness.cleanup)
@@ -530,6 +532,7 @@ class TestTlsConfig(unittest.TestCase):
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
     @patch("prometheus_server.Prometheus.reload_configuration", lambda *_: True)
+    @patch.object(Container, "exec", new=FakeProcessVersionCheck)
     def test_ca_file(self, *_):
         scrape_jobs = [
             {
@@ -571,6 +574,7 @@ class TestTlsConfig(unittest.TestCase):
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
     @patch("prometheus_server.Prometheus.reload_configuration", lambda *_: True)
+    @patch.object(Container, "exec", new=FakeProcessVersionCheck)
     def test_insecure_skip_verify(self, *_):
         scrape_jobs = [
             {


### PR DESCRIPTION
## Issue
Fixes #347.


## Solution
Add keys to allowlist.


## Context
NTA


## Testing Instructions
Manually deploy and relate this and the matching PR in [scrape-target](https://github.com/canonical/prometheus-scrape-target-k8s-operator/pull/21).

```bash
juju deploy ./prometheus-scrape-target-k8s_ubuntu-20.04-amd64.charm target
juju deploy ./prometheus-k8s_ubuntu-20.04-amd64.charm prom --resource prometheus-image=ubuntu/prometheus:2.33-22.04_beta

TARGET=$(juju controllers --format json | jq -r '.controllers.uk8s."api-endpoints"[0]')
CERT=$(openssl s_client -connect $TARGET -showcerts </dev/null 2>/dev/null | openssl x509 -outform PEM)
juju config target targets=$TARGET scheme=https metrics_path=/introspection/metrics basic_auth=user-prometheus:prom tls_config_insecure_skip_verify=true tls_config_ca_file=$CERT

juju relate prom target

PROM=$(juju status --format=json | jq -r '.applications.prom.units."prom/0".address')
curl $PROM:9090/api/v1/targets | jq '.data.activeTargets[].health'
```

## Release Notes
Add tls, basic_auth keys to allowlist.
