### PR TITLE
Add architecture decision log [do not merge: experiment]

### DIFF
--- a/adl.md
+++ b/adl.md
@@ -1,0 +1,19 @@
+# Architecture decision log
+
+## 2022-09-13 Use stored state for keeping track of config hash
+
+In the context of preventing unnecessary reloads
+([#352](https://github.com/canonical/prometheus-k8s-operator/pull/352)), facing the concerns
+outlined in the table below, we decided for using stored state for keeping track of the config
+hash.
+
+Note that the charm's storage backend is the charm (`use_juju_for_storage` is not set), so files
+will be written if the pod churns (which is good, probably unlike if the storage backend was the
+controller).
+
+
+|                | StoredState            | Pull                                                         |
+|----------------|------------------------|--------------------------------------------------------------|
+| Multiple files | Easy to calculate hash | Need to pull (and sort?) all data (config, certs AND alerts) |
+| Tinkering      | Manual changes persist | Manual changes disappear every _configure                    |
+| Robustness     | Only push              | Pull (multiple files) then push                              |


### PR DESCRIPTION
## Issue
There is currently no centralized place to document architecturally-significant decisions.


## Solution
(Proposal) Use a lean [Y-statements](https://adr.github.io/#sustainable-architectural-decisions)-like format to log the arch. decision records, all in the same file.

In short, the Y-statement is as follows:

> In the context of `<use case/user story u>`, facing `<concern c>` we decided for `<option o>` to achieve `<quality q>`, accepting `<downside d>`.

The long form of it is as follows (extra section “because”):

> In the context of `<use case/user story u>`, facing `<concern c>` we decided for `<option o>` and neglected `<other options>`, to achieve `<system qualities/desired consequences>`, accepting `<downside d/undesired consequences>`, because `<additional rationale>`.


## Release Notes
Add architecture decision log.
