### PR TITLE
Update test_remote_write tests

### DIFF
--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -56,6 +56,7 @@ def cos_tool_path_resolver() -> None:
     cos_path.chmod(0o777)
     _CosTool_remote_write._path = str(cos_path)
 
+
 k8s_resource_multipatch = patch.multiple(
     "charm.KubernetesComputeResourcesPatch",
     _namespace="test-namespace",

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -6,7 +6,8 @@ from typing import Callable
 from unittest.mock import patch
 
 import requests
-from charms.prometheus_k8s.v0.prometheus_remote_write import CosTool
+from charms.prometheus_k8s.v0.prometheus_remote_write import CosTool as _CosTool_remote_write
+from charms.prometheus_k8s.v0.prometheus_scrape import CosTool as _CosTool_scrape
 
 PROJECT_DIR = Path(__file__).resolve().parent.parent.parent
 UNITTEST_DIR = Path(__file__).resolve().parent
@@ -52,7 +53,8 @@ def cos_tool_path_resolver() -> None:
                     f.write(chunk)
 
     cos_path.chmod(0o777)
-    CosTool._path = str(cos_path)
+    _CosTool_remote_write._path = str(cos_path)
+    _CosTool_scrape._path = str(cos_path)
 
 
 k8s_resource_multipatch = patch.multiple(

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -9,7 +9,6 @@ import requests
 from charms.prometheus_k8s.v0.prometheus_remote_write import (
     CosTool as _CosTool_remote_write,
 )
-from charms.prometheus_k8s.v0.prometheus_scrape import CosTool as _CosTool_scrape
 
 PROJECT_DIR = Path(__file__).resolve().parent.parent.parent
 UNITTEST_DIR = Path(__file__).resolve().parent
@@ -56,8 +55,6 @@ def cos_tool_path_resolver() -> None:
 
     cos_path.chmod(0o777)
     _CosTool_remote_write._path = str(cos_path)
-    _CosTool_scrape._path = str(cos_path)
-
 
 k8s_resource_multipatch = patch.multiple(
     "charm.KubernetesComputeResourcesPatch",

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -9,6 +9,8 @@ import requests
 from charms.prometheus_k8s.v0.prometheus_remote_write import CosTool
 
 PROJECT_DIR = Path(__file__).resolve().parent.parent.parent
+UNITTEST_DIR = Path(__file__).resolve().parent
+COS_TOOL_URL = "https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-amd64"
 
 
 def patch_network_get(private_address="10.1.157.116") -> Callable:
@@ -33,7 +35,7 @@ def patch_network_get(private_address="10.1.157.116") -> Callable:
     return patch("ops.testing._TestingModelBackend.network_get", network_get)
 
 
-def cos_tool_path_resolver():
+def cos_tool_path_resolver() -> None:
     """Get cos tool path.
 
     Downloads from GitHub, if it does not exist locally.
@@ -43,8 +45,7 @@ def cos_tool_path_resolver():
     cos_path = PROJECT_DIR / "cos-tool-amd64"
     if not cos_path.exists():
         logging.debug("cos-tool was not found, download it")
-        url = "https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-amd64"
-        with requests.get(url, stream=True) as r:
+        with requests.get(COS_TOOL_URL, stream=True) as r:
             r.raise_for_status()
             with open(cos_path, "wb") as f:
                 for chunk in r.iter_content(chunk_size=1024):

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -6,10 +6,10 @@ from typing import Callable
 from unittest.mock import patch
 
 import requests
-
 from charms.prometheus_k8s.v0.prometheus_remote_write import CosTool
 
 PROJECT_DIR = Path(__file__).resolve().parent.parent.parent
+
 
 def patch_network_get(private_address="10.1.157.116") -> Callable:
     def network_get(*args, **kwargs) -> dict:
@@ -46,15 +46,12 @@ def cos_tool_path_resolver():
         url = "https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-amd64"
         with requests.get(url, stream=True) as r:
             r.raise_for_status()
-            with open(cos_path, 'wb') as f:
+            with open(cos_path, "wb") as f:
                 for chunk in r.iter_content(chunk_size=1024):
                     f.write(chunk)
 
     cos_path.chmod(0o777)
     CosTool._path = str(cos_path)
-
-
-
 
 
 k8s_resource_multipatch = patch.multiple(

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,9 +1,15 @@
 # Copyright 2020 Canonical Ltd.
 # See LICENSE file for licensing details.
-
+import logging
+from pathlib import Path
 from typing import Callable
 from unittest.mock import patch
 
+import requests
+
+from charms.prometheus_k8s.v0.prometheus_remote_write import CosTool
+
+PROJECT_DIR = Path(__file__).resolve().parent.parent.parent
 
 def patch_network_get(private_address="10.1.157.116") -> Callable:
     def network_get(*args, **kwargs) -> dict:
@@ -25,6 +31,30 @@ def patch_network_get(private_address="10.1.157.116") -> Callable:
         }
 
     return patch("ops.testing._TestingModelBackend.network_get", network_get)
+
+
+def cos_tool_path_resolver():
+    """Get cos tool path.
+
+    Downloads from GitHub, if it does not exist locally.
+    Updates CosTool class internal `_path`, otherwise it will always look in CWD
+    (execution directory).
+    """
+    cos_path = PROJECT_DIR / "cos-tool-amd64"
+    if not cos_path.exists():
+        logging.debug("cos-tool was not found, download it")
+        url = "https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-amd64"
+        with requests.get(url, stream=True) as r:
+            r.raise_for_status()
+            with open(cos_path, 'wb') as f:
+                for chunk in r.iter_content(chunk_size=1024):
+                    f.write(chunk)
+
+    cos_path.chmod(0o777)
+    CosTool._path = str(cos_path)
+
+
+
 
 
 k8s_resource_multipatch = patch.multiple(

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -6,7 +6,9 @@ from typing import Callable
 from unittest.mock import patch
 
 import requests
-from charms.prometheus_k8s.v0.prometheus_remote_write import CosTool as _CosTool_remote_write
+from charms.prometheus_k8s.v0.prometheus_remote_write import (
+    CosTool as _CosTool_remote_write,
+)
 from charms.prometheus_k8s.v0.prometheus_scrape import CosTool as _CosTool_scrape
 
 PROJECT_DIR = Path(__file__).resolve().parent.parent.parent

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -9,10 +9,19 @@ from unittest.mock import patch
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
 from charms.prometheus_k8s.v0.prometheus_remote_write import (
     DEFAULT_RELATION_NAME as RELATION_NAME,
+)
+from charms.prometheus_k8s.v0.prometheus_remote_write import (
     RELATION_INTERFACE_NAME as RELATION_INTERFACE,
+)
+from charms.prometheus_k8s.v0.prometheus_remote_write import (
     PrometheusRemoteWriteConsumer,
 )
-from helpers import k8s_resource_multipatch, patch_network_get, prom_multipatch, cos_tool_path_resolver
+from helpers import (
+    cos_tool_path_resolver,
+    k8s_resource_multipatch,
+    patch_network_get,
+    prom_multipatch,
+)
 from ops import framework
 from ops.charm import CharmBase
 from ops.model import ActiveStatus

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -3,19 +3,16 @@
 
 import json
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
 from charms.prometheus_k8s.v0.prometheus_remote_write import (
     DEFAULT_RELATION_NAME as RELATION_NAME,
-)
-from charms.prometheus_k8s.v0.prometheus_remote_write import (
     RELATION_INTERFACE_NAME as RELATION_INTERFACE,
-)
-from charms.prometheus_k8s.v0.prometheus_remote_write import (
     PrometheusRemoteWriteConsumer,
 )
-from helpers import k8s_resource_multipatch, patch_network_get, prom_multipatch
+from helpers import k8s_resource_multipatch, patch_network_get, prom_multipatch, cos_tool_path_resolver
 from ops import framework
 from ops.charm import CharmBase
 from ops.model import ActiveStatus
@@ -23,12 +20,15 @@ from ops.testing import Harness
 
 from charm import Prometheus, PrometheusCharm
 
+UNITTEST_DIR = Path(__file__).resolve().parent
+
+cos_tool_path_resolver()
+
 METADATA = f"""
 name: consumer-tester
 requires:
   {RELATION_NAME}:
     interface: {RELATION_INTERFACE}
-requires:
     ingress-unit:
         interface: ingress-unit
         limit: 1
@@ -90,7 +90,7 @@ class RemoteWriteConsumerCharm(CharmBase):
         self.remote_write_consumer = PrometheusRemoteWriteConsumer(
             self,
             RELATION_NAME,
-            alert_rules_path="./tests/unit/prometheus_alert_rules",
+            alert_rules_path=str(UNITTEST_DIR / "prometheus_alert_rules"),
         )
         self.framework.observe(
             self.remote_write_consumer.on.endpoints_changed,

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -17,8 +17,8 @@ from charms.prometheus_k8s.v0.prometheus_remote_write import (
 )
 from helpers import (
     UNITTEST_DIR,
-    cos_tool_path_resolver,
     k8s_resource_multipatch,
+    patch_cos_tool_path,
     patch_network_get,
     prom_multipatch,
 )
@@ -28,8 +28,6 @@ from ops.model import ActiveStatus
 from ops.testing import Harness
 
 from charm import Prometheus, PrometheusCharm
-
-cos_tool_path_resolver()
 
 METADATA = f"""
 name: consumer-tester
@@ -92,6 +90,7 @@ ALERT_RULES = {
 
 
 class RemoteWriteConsumerCharm(CharmBase):
+    @patch_cos_tool_path
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
         self.remote_write_consumer = PrometheusRemoteWriteConsumer(

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -3,7 +3,6 @@
 
 import json
 import unittest
-from pathlib import Path
 from unittest.mock import patch
 
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
@@ -17,6 +16,7 @@ from charms.prometheus_k8s.v0.prometheus_remote_write import (
     PrometheusRemoteWriteConsumer,
 )
 from helpers import (
+    UNITTEST_DIR,
     cos_tool_path_resolver,
     k8s_resource_multipatch,
     patch_network_get,
@@ -28,8 +28,6 @@ from ops.model import ActiveStatus
 from ops.testing import Harness
 
 from charm import Prometheus, PrometheusCharm
-
-UNITTEST_DIR = Path(__file__).resolve().parent
 
 cos_tool_path_resolver()
 


### PR DESCRIPTION
* add method to automatically fetch` cos-tool` if it does not exist
* make `test_remote_write.py` invokation path independent.
* fix metadata, since two `requires` overlapped which caused overwritting