### PR TITLE
add new landing page integration

### DIFF
--- a/lib/charms/landing_page_k8s/v0/landing_page.py
+++ b/lib/charms/landing_page_k8s/v0/landing_page.py
@@ -1,0 +1,128 @@
+"""Charm for providing landing pages to bundles."""
+
+from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
+from ops.charm import CharmBase
+
+import logging
+
+LIBID = "7e5cd3b1e1264c2689f09f772c9af026"
+LIBAPI = 0
+LIBPATCH = 1
+
+DEFAULT_RELATION_NAME = "landing-page"
+
+logger = logging.getLogger(__name__)
+
+class LandingPageApp:
+    name: str
+    url: str
+    icon: str
+    description: str
+
+    def __init__(self, name, url, icon, description = ""):
+        self.name = name
+        self.url = url
+        self.icon = icon
+        self.description = description
+
+class LandingPageConsumer(Object):
+
+    def __init__(
+        self, 
+        charm,
+        relation_name: str = DEFAULT_RELATION_NAME, 
+        app: LandingPageApp = None
+    ):
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        self._app = app
+
+        events = self._charm.on[self._relation_name]
+        self.framework.observe(events.relation_joined, self._on_relation_changed)
+        self.framework.observe(events.relation_broken, self._on_relation_changed)
+        self.framework.observe(events.relation_changed, self._on_relation_changed)
+        self.framework.observe(events.relation_departed, self._on_relation_changed)
+        self.framework.observe(events.relation_created, self._on_relation_changed)
+
+
+
+    def _on_relation_changed(self, event):
+        if not self._charm.unit.is_leader():
+            return
+        
+        if not self._app:
+            return
+        
+        for relation in self._charm.model.relations[self._relation_name]:
+            relation.data[self._charm.model.app]["name"] = self._app.name
+            relation.data[self._charm.model.app]["description"] = self._app.description
+            relation.data[self._charm.model.app]["url"] = self.unit_address
+            relation.data[self._charm.model.app]["icon"] = self._app.icon
+
+    @property
+    def unit_address(self):
+        if self._app.url:
+            return self._app.url
+        
+        unit_ip = str(self._charm.model.get_binding(relation).network.bind_address)
+        if self._is_valid_unit_address(unit_ip):
+            return unit_ip
+        
+        return socket.getfqdn()
+
+
+class AppsChangedEvent(EventBase):
+    """Event emitted when landing page app entries change."""
+
+    def __init__(self, handle, apps):
+        super().__init__(handle)
+        self.apps  = apps
+
+    def snapshot(self):
+        """Save landing page apps information."""
+        return {"apps": self.apps}
+
+    def restore(self, snapshot):
+        """Restore landing page apps information."""
+        self.apps = snapshot["apps"]
+
+
+class LandingPageEvents(ObjectEvents):
+    """Events raised by `LandingPageConsumer`"""
+
+    apps_changed = EventSource(AppsChangedEvent)
+
+class LandingPageProvider(Object):
+
+    on = LandingPageEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        events = self._charm.on[self._relation_name]
+        self.framework.observe(events.relation_changed, self._on_relation_changed)
+        self.framework.observe(events.relation_joined, self._on_relation_changed)
+        self.framework.observe(events.relation_departed, self._on_relation_changed)
+        self.framework.observe(events.relation_broken, self._on_relation_broken)
+
+    def _on_relation_broken(self, event):
+        self.on.apps_changed.emit(apps=self.apps)
+
+    def _on_relation_changed(self, event):
+        
+        self.on.apps_changed.emit(apps=self.apps)
+
+    @property
+    def apps(self):
+        return [
+            {
+                "name": relation.data[relation.app].get("name", ""),
+                "url": relation.data[relation.app].get("url", ""),
+                "icon": relation.data[relation.app].get("icon", ""), 
+                "description": relation.data[relation.app].get("description", "")
+            }
+            for relation in self._charm.model.relations[self._relation_name]
+            if relation.app and relation.units
+        ]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -47,8 +47,8 @@ requires:
   ingress:
     interface: ingress_per_unit
     limit: 1
-  landing-page:
-    interface: catalog
+  catalogue:
+    interface: catalogue
 
 peers:
   prometheus-peers:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -48,7 +48,7 @@ requires:
     interface: ingress_per_unit
     limit: 1
   landing-page:
-    interface: catalogue
+    interface: catalog
 
 peers:
   prometheus-peers:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -47,6 +47,8 @@ requires:
   ingress:
     interface: ingress_per_unit
     limit: 1
+  landing-page:
+    interface: catalogue
 
 peers:
   prometheus-peers:

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,6 +15,7 @@ import yaml
 from charms.alertmanager_k8s.v0.alertmanager_dispatch import AlertmanagerConsumer
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
+from charms.landing_page_k8s.v0.landing_page import LandingPageApp, LandingPageConsumer
 from charms.observability_libs.v0.juju_topology import JujuTopology
 from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
     K8sResourcePatchFailedEvent,
@@ -116,13 +117,26 @@ class PrometheusCharm(CharmBase):
             source_type="prometheus",
             source_url=self.external_url,
         )
-
         self.alertmanager_consumer = AlertmanagerConsumer(
             charm=self,
             relation_name="alertmanager",
         )
 
-        # Event handlers
+        self.landing_page = LandingPageConsumer(
+            charm=self,
+            app=LandingPageApp(
+                name="Prometheus",
+                icon="chart-line-variant",
+                url=self.external_url,
+                description=(
+                    "Prometheus collects and stores metrics as time series data,"
+                    "i.e. metrics information is stored with the timestamp at which "
+                    "it was recorded, alongside optional key-value pairs called "
+                    "labels."
+                ),
+            ),
+        )
+
         self.framework.observe(self.on.prometheus_pebble_ready, self._on_pebble_ready)
         self.framework.observe(self.on.config_changed, self._configure)
         self.framework.observe(self.on.upgrade_charm, self._configure)

--- a/src/charm.py
+++ b/src/charm.py
@@ -128,15 +128,13 @@ class PrometheusCharm(CharmBase):
                 self.on.prometheus_pebble_ready,
                 self.on["ingress"].relation_joined,
             ],
-            app=CatalogueItem(
+            item=CatalogueItem(
                 name="Prometheus",
                 icon="chart-line-variant",
                 url=self.external_url,
                 description=(
-                    "Prometheus collects and stores metrics as time series data,"
-                    "i.e. metrics information is stored with the timestamp at which "
-                    "it was recorded, alongside optional key-value pairs called "
-                    "labels."
+                    "Prometheus collects, stores and serves metrics as time series data, "
+                    ",alongside optional key-value pairs called labels."
                 ),
             ),
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -134,7 +134,7 @@ class PrometheusCharm(CharmBase):
                 url=self.external_url,
                 description=(
                     "Prometheus collects, stores and serves metrics as time series data, "
-                    ",alongside optional key-value pairs called labels."
+                    "alongside optional key-value pairs called labels."
                 ),
             ),
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,9 +13,9 @@ from urllib.parse import urlparse
 
 import yaml
 from charms.alertmanager_k8s.v0.alertmanager_dispatch import AlertmanagerConsumer
+from charms.catalogue_k8s.v0.catalogue import CatalogueConsumer, CatalogueItem
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
-from charms.catalogue_k8s.v0.catalogue import CatalogueItem, CatalogueConsumer
 from charms.observability_libs.v0.juju_topology import JujuTopology
 from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
     K8sResourcePatchFailedEvent,

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,7 +15,7 @@ import yaml
 from charms.alertmanager_k8s.v0.alertmanager_dispatch import AlertmanagerConsumer
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
-from charms.landing_page_k8s.v0.landing_page import LandingPageApp, LandingPageConsumer
+from charms.catalogue_k8s.v0.catalogue import CatalogueItem, CatalogueConsumer
 from charms.observability_libs.v0.juju_topology import JujuTopology
 from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
     K8sResourcePatchFailedEvent,
@@ -122,9 +122,13 @@ class PrometheusCharm(CharmBase):
             relation_name="alertmanager",
         )
 
-        self.landing_page = LandingPageConsumer(
+        self.catalogue = CatalogueConsumer(
             charm=self,
-            app=LandingPageApp(
+            refresh_event=[
+                self.on.prometheus_pebble_ready,
+                self.on["ingress"].relation_joined,
+            ],
+            app=CatalogueItem(
                 name="Prometheus",
                 icon="chart-line-variant",
                 url=self.external_url,


### PR DESCRIPTION
This PR introduces a new relation interface called `catalog` for connecting Prometheus to a landing page. Over this relation, Prometheus provides an application entry, which then will be used by the landing page to display where users may go.

## Context
See https://github.com/canonical/landing-page-k8s-operator/ for the other end of this relation.

## Testing Instructions
- Build a charm file from this PR branch
- Deploy the build output on Juju
- Deploy `landing-page-k8s` from `edge`
- Relate the two charms together
- Visit the landing page on port 80

## Release Notes
Implement the `catalog` interface to allow for integration with `landing-page-k8s`.