### PR TITLE
Fix: don't crash on empty alert rules file

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -642,7 +642,7 @@ class AlertRules:
                 return []
 
             if not rule_file:
-                logger.warning("Empty rule file: %s", file_path.name)
+                logger.warning("Empty rules file: %s", file_path.name)
                 return []
             if not isinstance(rule_file, dict):
                 logger.error("Invalid rules file (must be a dict): %s", file_path.name)

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -641,10 +641,12 @@ class AlertRules:
                 logger.error("Failed to read alert rules from %s: %s", file_path.name, e)
                 return []
 
-            if not rule_file or not isinstance(rule_file, dict):
-                logger.error("Rule file empty or not a dictionary: %s", file_path.name)
+            if not rule_file:
+                logger.warning("Empty rule file: %s", file_path.name)
                 return []
-
+            if not isinstance(rule_file, dict):
+                logger.error("Invalid rules file (must be a dict): %s", file_path.name)
+                return []
             if _is_official_alert_rule_format(rule_file):
                 alert_groups = rule_file["groups"]
             elif _is_single_alert_rule_format(rule_file):

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -641,6 +641,10 @@ class AlertRules:
                 logger.error("Failed to read alert rules from %s: %s", file_path.name, e)
                 return []
 
+            if not rule_file or not isinstance(rule_file, dict):
+                logger.error("Rule file empty or not a dictionary: %s", file_path.name)
+                return []
+
             if _is_official_alert_rule_format(rule_file):
                 alert_groups = rule_file["groups"]
             elif _is_single_alert_rule_format(rule_file):

--- a/tests/unit/test_prometheus_rules_provider.py
+++ b/tests/unit/test_prometheus_rules_provider.py
@@ -147,3 +147,19 @@ class TestReloadAlertRules(unittest.TestCase):
         alert_rules = json.loads(relation.data[self.harness.charm.app].get("alert_rules"))
         alert_names = [groups["rules"][0]["alert"] for groups in alert_rules["groups"]]
         self.assertEqual(set(alert_names), {"alert.rule", "alert.rules"})
+
+    def test_reload_with_empty_rules(self):
+        """Scenario: The reload method is called with a zero-size alert file."""
+        # GIVEN relation data contains no alerts
+        relation = self.harness.charm.model.get_relation("metrics-endpoint")
+        self.assertEqual(relation.data[self.harness.charm.app].get("alert_rules"), self.NO_ALERTS)
+
+        # WHEN an empty rules file is written
+        self.sandbox.writetext("alert.rule", "")
+
+        # AND the reload method is called
+        self.harness.charm.rules_provider._reinitialize_alert_rules()
+
+        # THEN relation data is not updated
+        relation = self.harness.charm.model.get_relation("metrics-endpoint")
+        self.assertEqual(relation.data[self.harness.charm.app].get("alert_rules"), self.NO_ALERTS)


### PR DESCRIPTION
## Issue
Fixes #364

## Solution
Add defensive check in AlertRules._from_file() 