### PR TITLE
Fix reload

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -126,6 +126,7 @@ class PrometheusCharm(CharmBase):
         self.framework.observe(self.on.prometheus_pebble_ready, self._on_pebble_ready)
         self.framework.observe(self.on.config_changed, self._configure)
         self.framework.observe(self.on.upgrade_charm, self._configure)
+        self.framework.observe(self.on.update_status, self._update_status)
         self.framework.observe(self.ingress.on.ready_for_unit, self._on_ingress_ready)
         self.framework.observe(self.ingress.on.revoked_for_unit, self._on_ingress_revoked)
         self.framework.observe(self.on.receive_remote_write_relation_created, self._configure)
@@ -402,8 +403,6 @@ class PrometheusCharm(CharmBase):
 
     def _update_status(self, event):
         """Fired intermittently by the Juju agent."""
-        self.unit.set_workload_version(self._prometheus_server.version())
-
         # Unit could still be blocked if a reload failed (e.g. during WAL replay or ingress not
         # yet ready). Calling `_configure` to recover.
         if self.unit.status != ActiveStatus():


### PR DESCRIPTION
## Issue
resolves https://github.com/canonical/prometheus-k8s-operator/issues/371


## Solution
Make sure to observe update_status so Prometheus can be cleaned up.


## Testing Instructions
Kill a Prometheus pod and make sure you get a waiting status (or active status) instead of blocked status.


## Release Notes
fixed a bug where prometheus-k8s would go in to blocked status if it took too long to start
