### PR TITLE
Metrics path per unit

### DIFF
--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -74,7 +74,7 @@ class EndpointProviderCharm(CharmBase):
         )
 
 
-class EndpointProviderCharmExternalHostname(CharmBase):
+class EndpointProviderCharmExternalUrl(CharmBase):
     _stored = StoredState()
 
     def __init__(self, *args, **kwargs):
@@ -84,7 +84,7 @@ class EndpointProviderCharmExternalHostname(CharmBase):
             self,
             jobs=JOBS,
             alert_rules_path=str(UNITTEST_DIR / "prometheus_alert_rules"),
-            external_hostname="9.12.20.18",
+            external_url="9.12.20.18",
         )
 
 
@@ -256,8 +256,8 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertIn("prometheus_scrape_unit_name", data)
 
     @patch_network_get()
-    def test_provider_sets_external_hostname(self):
-        harness = Harness(EndpointProviderCharmExternalHostname, meta=PROVIDER_META)
+    def test_provider_sets_external_url(self):
+        harness = Harness(EndpointProviderCharmExternalUrl, meta=PROVIDER_META)
         harness.set_model_name("MyUUID")
         harness.set_leader(True)
         harness.begin()


### PR DESCRIPTION
## Issue
With #370 implemented, now wildcard targets are expanded to individual jobs.
However, the provider's constructor currently takes a hostname rather than a url, and (ingress) path cannot be inferred.


## Solution
Change the provider constructor to take a url. This is a non-breaking change because prometheus_scrape wasn't published since the `external_hostname` arg was introduced.


## Context
Depends on #370.


## Testing Instructions
Afaict, existing utests and itest provide sufficient coverage.


## Release Notes
Add support for a custom metrics path per unit.
