### PR TITLE
Do not static check against ops

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,12 +50,16 @@ allow_redefinition = true
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]
-module = ["ops.*", "pytest.*", "pytest_operator.*", "prometheus_api_client.*", "deepdiff.*"]
+module = ["pytest.*", "pytest_operator.*", "prometheus_api_client.*", "deepdiff.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["charms.grafana_k8s.*", "charms.alertmanager_k8s.*", "charms.traefik_k8s.*"]
 follow_imports = "silent"
+
+[[tool.mypy.overrides]]
+module = ["ops.*"]
+follow_imports = "skip"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Issue
ops 1.5.3 was released yesterday with many important features, but it also causes the static CI to fail.


## Solution
Add ops to mypy's ignorelist, for now.
