### PR TITLE
Correctly render alertmanager config when targets have path prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ venv
 .vscode
 tests/integration/prometheus-tester/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
 cos-tool*
+.hypothesis/*
+

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -548,6 +548,24 @@ class PrometheusConfig:
 
         return modified_scrape_jobs
 
+    @staticmethod
+    def render_alertmanager_static_configs(alertmanagers: List[str]):
+        """Render the alertmanager static_configs section from a list of URLs.
+
+        Each target must be in the hostname:port format, and prefixes are specified in a separate
+        key. Therefore, with ingress in place, would need to extract the path into the
+        `path_prefix` key, which is higher up in the config hierarchy.
+
+        https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alertmanager_config
+
+        Args:
+            alertmanagers: List of alertmanager URLs.
+
+        Returns:
+            A dict representation for the static_configs section.
+        """
+        return {"alertmanagers": [{"static_configs": [{"targets": alertmanagers}]}]}
+
 
 class RelationNotFoundError(Exception):
     """Raised if there is no relation with the given name is found."""

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -341,7 +341,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 22
+LIBPATCH = 23
 
 logger = logging.getLogger(__name__)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,6 +32,7 @@ from charms.prometheus_k8s.v0.prometheus_remote_write import (
 from charms.prometheus_k8s.v0.prometheus_scrape import (
     MetricsEndpointConsumer,
     MetricsEndpointProvider,
+    PrometheusConfig,
 )
 from charms.traefik_k8s.v1.ingress_per_unit import (
     IngressPerUnitReadyForUnitEvent,
@@ -685,15 +686,14 @@ class PrometheusCharm(CharmBase):
         Returns:
             a dictionary consisting of the alerting configuration for Prometheus.
         """
-        alerting_config = {}  # type: Dict[str, list]
-
         alertmanagers = self.alertmanager_consumer.get_cluster_info()
-
         if not alertmanagers:
             logger.debug("No alertmanagers available")
-            return alerting_config
+            return {}
 
-        alerting_config = {"alertmanagers": [{"static_configs": [{"targets": alertmanagers}]}]}
+        alerting_config: Dict[str, list] = PrometheusConfig.render_alertmanager_static_configs(
+            alertmanagers
+        )
         return alerting_config
 
     def _generate_prometheus_config(self, container) -> bool:

--- a/tests/unit/test_prometheus_config.py
+++ b/tests/unit/test_prometheus_config.py
@@ -407,3 +407,85 @@ class TestWildcardExpansionWithPathPrefix(unittest.TestCase):
                 },
             ],
         )
+
+
+class TestAlertmanagerStaticConfigs(unittest.TestCase):
+    def test_ip_address_only(self):
+        # GIVEN a hostname only
+        alertmanagers = ["1.1.1.1", "2.2.2.2"]
+
+        # WHEN rendered
+        static_configs = PrometheusConfig.render_alertmanager_static_configs(alertmanagers)
+
+        # THEN all targets are under the same static_config
+        # AND no path_prefix present
+        self.assertEqual(
+            static_configs,
+            {"alertmanagers": [{"static_configs": [{"targets": ["1.1.1.1", "2.2.2.2"]}]}]},
+        )
+
+    def test_ip_address_and_port(self):
+        # GIVEN a hostname:port
+        alertmanagers = ["1.1.1.1:1111", "2.2.2.2:2222"]
+
+        # WHEN rendered
+        static_configs = PrometheusConfig.render_alertmanager_static_configs(alertmanagers)
+
+        # THEN all targets are under the same static_config
+        # AND port makes part of the target string
+        # AND no path_prefix present
+        self.assertEqual(
+            static_configs,
+            {
+                "alertmanagers": [
+                    {"static_configs": [{"targets": ["1.1.1.1:1111", "2.2.2.2:2222"]}]}
+                ]
+            },
+        )
+
+    def test_ip_address_port_and_same_path_prefix(self):
+        # GIVEN a hostname:port/path, all with the same path
+        alertmanagers = ["1.1.1.1:1111/some/path", "2.2.2.2:2222/some/path"]
+
+        # WHEN rendered
+        static_configs = PrometheusConfig.render_alertmanager_static_configs(alertmanagers)
+
+        # THEN all targets are under the same static_config
+        # AND port makes part of the target string
+        # AND a path_prefix is rendered
+        self.assertEqual(
+            static_configs,
+            {
+                "alertmanagers": [
+                    {
+                        "path_prefix": "/some/path",
+                        "static_configs": [{"targets": ["1.1.1.1:1111", "2.2.2.2:2222"]}],
+                    }
+                ]
+            },
+        )
+    
+    def test_ip_address_port_and_different_path_prefix(self):
+        # GIVEN a hostname:port/path, all with the same path
+        alertmanagers = ["1.1.1.1:1111/some/path", "2.2.2.2:2222/some/other/path"]
+
+        # WHEN rendered
+        static_configs = PrometheusConfig.render_alertmanager_static_configs(alertmanagers)
+
+        # THEN each target is under its own static_config with its own path_prefix
+        # AND port makes part of the target string
+        self.assertEqual(
+            static_configs,
+            {
+                "alertmanagers": [
+                    {
+                        "path_prefix": "/some/path",
+                        "static_configs": [{"targets": ["1.1.1.1:1111"]}],
+                    },
+                    {
+                        "path_prefix": "/some/other/path",
+                        "static_configs": [{"targets": ["2.2.2.2:2222"]}],
+                    },
+                ]
+            },
+        )

--- a/tests/unit/test_prometheus_config.py
+++ b/tests/unit/test_prometheus_config.py
@@ -418,10 +418,14 @@ class TestAlertmanagerStaticConfigs(unittest.TestCase):
         static_configs = PrometheusConfig.render_alertmanager_static_configs(alertmanagers)
 
         # THEN all targets are under the same static_config
-        # AND no path_prefix present
+        # AND the default path_prefix is rendered
         self.assertEqual(
             static_configs,
-            {"alertmanagers": [{"static_configs": [{"targets": ["1.1.1.1", "2.2.2.2"]}]}]},
+            {
+                "alertmanagers": [
+                    {"path_prefix": "/", "static_configs": [{"targets": ["1.1.1.1", "2.2.2.2"]}]},
+                ],
+            },
         )
 
     def test_ip_address_and_port(self):
@@ -433,13 +437,16 @@ class TestAlertmanagerStaticConfigs(unittest.TestCase):
 
         # THEN all targets are under the same static_config
         # AND port makes part of the target string
-        # AND no path_prefix present
+        # AND the default path_prefix is rendered
         self.assertEqual(
             static_configs,
             {
                 "alertmanagers": [
-                    {"static_configs": [{"targets": ["1.1.1.1:1111", "2.2.2.2:2222"]}]}
-                ]
+                    {
+                        "path_prefix": "/",
+                        "static_configs": [{"targets": ["1.1.1.1:1111", "2.2.2.2:2222"]}],
+                    },
+                ],
             },
         )
 
@@ -460,14 +467,14 @@ class TestAlertmanagerStaticConfigs(unittest.TestCase):
                     {
                         "path_prefix": "/some/path",
                         "static_configs": [{"targets": ["1.1.1.1:1111", "2.2.2.2:2222"]}],
-                    }
-                ]
+                    },
+                ],
             },
         )
-    
+
     def test_ip_address_port_and_different_path_prefix(self):
         # GIVEN a hostname:port/path, all with the same path
-        alertmanagers = ["1.1.1.1:1111/some/path", "2.2.2.2:2222/some/other/path"]
+        alertmanagers = ["1.1.1.1:1111/some/path", "2.2.2.2:2222/some/other/path", "3.3.3.3"]
 
         # WHEN rendered
         static_configs = PrometheusConfig.render_alertmanager_static_configs(alertmanagers)
@@ -486,6 +493,10 @@ class TestAlertmanagerStaticConfigs(unittest.TestCase):
                         "path_prefix": "/some/other/path",
                         "static_configs": [{"targets": ["2.2.2.2:2222"]}],
                     },
-                ]
+                    {
+                        "path_prefix": "/",
+                        "static_configs": [{"targets": ["3.3.3.3"]}],
+                    },
+                ],
             },
         )


### PR DESCRIPTION
## Issue
Fixes #377.


## Solution
Extract paths into the `path_prefix` config key.


## Context
Ingress.


## Testing Instructions
- utests
- e2e: relate prom - alertmanager - traefik and make sure config is valid.


## Release Notes
Correctly render alertmanager config when targets have path prefix
