### PR TITLE
Fix brittle test

### DIFF
--- a/tests/integration/test_check_config.py
+++ b/tests/integration/test_check_config.py
@@ -60,9 +60,9 @@ async def test_good_config_validates_successfully(
     )
     res = (await action.wait()).results
 
-    assert res["error-message"] == ""
     assert res["valid"] == "True"
-    assert "SUCCESS" in res["result"]  # NOTE: this is coming from promtool and may change
+    assert res["error-message"] == ""
+    assert "SUCCESS" in res["result"]  # NOTE: this is coming from promtool so may change
 
 
 @pytest.mark.abort_on_fail
@@ -101,9 +101,6 @@ async def test_bad_config_sets_action_results(ops_test, prometheus_charm, promet
     )
     res = (await action.wait()).results
 
-    assert res == {
-        "error-message": '  FAILED: parsing YAML file /etc/prometheus/prometheus.yml: not a valid duration string: "NotANumber!!!"\n',
-        "result": "Checking /etc/prometheus/prometheus.yml\n\n",
-        "Code": "0",
-        "valid": "False",
-    }
+    assert res["valid"] == "False"
+    assert "FAILED" in res["error-message"]  # NOTE: this is coming from promtool so may change
+    assert "SUCCESS" not in res["result"]  # NOTE: this is coming from promtool and may change

--- a/tests/integration/test_check_config.py
+++ b/tests/integration/test_check_config.py
@@ -60,13 +60,9 @@ async def test_good_config_validates_successfully(
     )
     res = (await action.wait()).results
 
-    assert res == {
-        "result": "Checking /etc/prometheus/prometheus.yml\n SUCCESS: /etc/prometheus/prometheus.yml is "
-        + "valid prometheus config file syntax\n\n",
-        "error-message": "",
-        "valid": "True",
-        "Code": "0",
-    }
+    assert res["error-message"] == ""
+    assert res["valid"] == "True"
+    assert "SUCCESS" in res["result"]  # NOTE: this is coming from promtool and may change
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
## Issue
A brittle test [broke](https://github.com/canonical/prometheus-k8s-operator/actions/runs/3199023424/jobs/5224301841#step:5:1516) between merge CI and release CI of #379.

https://github.com/canonical/prometheus-k8s-operator/blob/72dc79c800a5408eb207ef43a7972502e22d4818/tests/integration/test_check_config.py#L63-L69

The key name for the action's return code changed (not sure where/how):
```diff
     {
-    'Code': '0',
     'error-message': '',
     'result': 'Checking /etc/prometheus/prometheus.yml\n'
               ' SUCCESS: /etc/prometheus/prometheus.yml is valid prometheus '
               'config file syntax\n'
               '\n',
+    'return-code': 0,
     'valid': 'True',
    }
```

## Solution
- The return code is not set by charm code, so remove it entirely from the assertions made.
- Modify test to be less dependent on the exact output of promtool.


## Context
NTA.


## Testing Instructions
- Existing itests.


## Release Notes
Fix itest.
