### PR TITLE
add the juju_topology lib requirement to the docs

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1,6 +1,6 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-"""## Overview.
+"""## Overview
 
 This document explains how to integrate with the Prometheus charm
 for the purpose of providing a metrics endpoint to Prometheus. It
@@ -10,6 +10,11 @@ currently integrated charms. Finally this document is the
 authoritative reference on the structure of relation data that is
 shared between Prometheus charms and any other charm that intends to
 provide a scrape target for Prometheus.
+
+## Requirements
+
+Using this library requires to fetch the juju_topology library from the
+[observability-libs]((https://github.com/canonical/observability-libs/blob/main/lib/charms/observability_libs/v0/juju_topology.py).
 
 ## Provider Library Usage
 


### PR DESCRIPTION
## Issue

Implementing a Prometheus relation by using this library also requires the developer to fetch the [charms.observability_libs.v0.juju_topology](https://github.com/canonical/observability-libs/blob/main/lib/charms/observability_libs/v0/juju_topology.py) library.

The library is required [here](https://github.com/canonical/prometheus-k8s-operator/blob/main/lib/charms/prometheus_k8s/v0/prometheus_scrape.py#L331).

## Solution
Documentation update to communicate to the library user the need to fetch that library to be able to use this one.
