### PR TITLE
move external_url dependees out of constructor

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,6 +12,9 @@ parts:
   charm:
     build-packages:
       - git
+    charm-python-packages:
+      - wheel==0.37.1
+      - setuptools==45.2.0
   cos-tool:
     plugin: dump
     source: .

--- a/src/charm.py
+++ b/src/charm.py
@@ -96,29 +96,60 @@ class PrometheusCharm(CharmBase):
 
         self.grafana_dashboard_provider = GrafanaDashboardProvider(charm=self)
         self.metrics_consumer = MetricsEndpointConsumer(self)
-
         self.alertmanager_consumer = AlertmanagerConsumer(
             charm=self,
             relation_name="alertmanager",
         )
 
-        self.catalogue = CatalogueConsumer(
-            charm=self,
-            refresh_event=[
-                self.on.prometheus_pebble_ready,
-                self.on.leader_elected,
-                self.on["ingress"].relation_joined,
-            ],
-            item=CatalogueItem(
-                name="Prometheus",
-                icon="chart-line-variant",
-                url=self.external_url,
-                description=(
-                    "Prometheus collects, stores and serves metrics as time series data, "
-                    "alongside optional key-value pairs called labels."
+        # Skip external_url-dependent logic on removal
+        if os.getenv("JUJU_HOOK_NAME") not in ["stop", "remove"]:
+            external_url = urlparse(self.external_url)
+
+            self._scraping = MetricsEndpointProvider(
+                self,
+                relation_name="self-metrics-endpoint",
+                jobs=self.self_scraping_job,
+                external_url=self.external_url,
+                refresh_event=[  # needed for ingress
+                    self.ingress.on.ready_for_unit,
+                    self.ingress.on.revoked_for_unit,
+                    self.on.update_status,
+                ],
+            )
+            self._prometheus_server = Prometheus(web_route_prefix=external_url.path)
+
+            self.remote_write_provider = PrometheusRemoteWriteProvider(
+                charm=self,
+                relation_name=DEFAULT_REMOTE_WRITE_RELATION_NAME,
+                endpoint_address=external_url.hostname or "",
+                endpoint_port=external_url.port or 80,
+                endpoint_schema=external_url.scheme,
+                endpoint_path=f"{external_url.path}/api/v1/write",
+            )
+
+            self.grafana_source_provider = GrafanaSourceProvider(
+                charm=self,
+                source_type="prometheus",
+                source_url=self.external_url,
+            )
+
+            self.catalogue = CatalogueConsumer(
+                charm=self,
+                refresh_event=[
+                    self.on.prometheus_pebble_ready,
+                    self.on.leader_elected,
+                    self.on["ingress"].relation_joined,
+                ],
+                item=CatalogueItem(
+                    name="Prometheus",
+                    icon="chart-line-variant",
+                    url=self.external_url,
+                    description=(
+                        "Prometheus collects, stores and serves metrics as time series data, "
+                        "alongside optional key-value pairs called labels."
+                    ),
                 ),
-            ),
-        )
+            )
 
         self.framework.observe(self.on.prometheus_pebble_ready, self._on_pebble_ready)
         self.framework.observe(self.on.config_changed, self._configure)
@@ -243,61 +274,6 @@ class PrometheusCharm(CharmBase):
 
         return Layer(layer_config)
 
-    def _initialize_with_url(self):
-        """Construct the objects which need the external url."""
-        external_url = urlparse(self.external_url)
-
-        if not hasattr(self, "_scraping"):
-            self._scraping = MetricsEndpointProvider(
-                self,
-                relation_name="self-metrics-endpoint",
-                jobs=self.self_scraping_job,
-                external_url=self.external_url,
-                refresh_event=[  # needed for ingress
-                    self.ingress.on.ready_for_unit,
-                    self.ingress.on.revoked_for_unit,
-                    self.on.update_status,
-                ],
-            )
-
-        if not hasattr(self, "_prometheus_server"):
-            self._prometheus_server = Prometheus(web_route_prefix=external_url.path)
-
-        if not hasattr(self, "remote_write_provider"):
-            self.remote_write_provider = PrometheusRemoteWriteProvider(
-                charm=self,
-                relation_name=DEFAULT_REMOTE_WRITE_RELATION_NAME,
-                endpoint_address=external_url.hostname or "",
-                endpoint_port=external_url.port or 80,
-                endpoint_schema=external_url.scheme,
-                endpoint_path=f"{external_url.path}/api/v1/write",
-            )
-
-        if not hasattr(self, "grafana_source_provider"):
-            self.grafana_source_provider = GrafanaSourceProvider(
-                charm=self,
-                source_type="prometheus",
-                source_url=self.external_url,
-            )
-
-        if not hasattr(self, "catalogue"):
-            self.catalogue = CatalogueConsumer(
-                charm=self,
-                refresh_event=[
-                    self.on.prometheus_pebble_ready,
-                    self.on["ingress"].relation_joined,
-                ],
-                item=CatalogueItem(
-                    name="Prometheus",
-                    icon="chart-line-variant",
-                    url=self.external_url,
-                    description=(
-                        "Prometheus collects, stores and serves metrics as time series data, "
-                        "alongside optional key-value pairs called labels."
-                    ),
-                ),
-            )
-
     def _resource_reqs_from_config(self):
         limits = {
             "cpu": self.model.config.get("cpu"),
@@ -328,8 +304,6 @@ class PrometheusCharm(CharmBase):
         line arguments). If the Pebble layer has changed then Prometheus
         is restarted.
         """
-        self._initialize_with_url()
-
         early_return_statuses = {
             "cfg_load_fail": BlockedStatus(
                 "Prometheus failed to reload the configuration; see debug logs"

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,38 +94,9 @@ class PrometheusCharm(CharmBase):
 
         self._topology = JujuTopology.from_charm(self)
 
-        external_url = urlparse(self.external_url)
-
-        self._scraping = MetricsEndpointProvider(
-            self,
-            relation_name="self-metrics-endpoint",
-            jobs=self.self_scraping_job,
-            external_url=self.external_url,
-            refresh_event=[  # needed for ingress
-                self.ingress.on.ready_for_unit,
-                self.ingress.on.revoked_for_unit,
-                self.on.update_status,
-            ],
-        )
         self.grafana_dashboard_provider = GrafanaDashboardProvider(charm=self)
         self.metrics_consumer = MetricsEndpointConsumer(self)
 
-        self._prometheus_server = Prometheus(web_route_prefix=external_url.path)
-
-        self.remote_write_provider = PrometheusRemoteWriteProvider(
-            charm=self,
-            relation_name=DEFAULT_REMOTE_WRITE_RELATION_NAME,
-            endpoint_address=external_url.hostname or "",
-            endpoint_port=external_url.port or 80,
-            endpoint_schema=external_url.scheme,
-            endpoint_path=f"{external_url.path}/api/v1/write",
-        )
-
-        self.grafana_source_provider = GrafanaSourceProvider(
-            charm=self,
-            source_type="prometheus",
-            source_url=self.external_url,
-        )
         self.alertmanager_consumer = AlertmanagerConsumer(
             charm=self,
             relation_name="alertmanager",
@@ -272,6 +243,56 @@ class PrometheusCharm(CharmBase):
 
         return Layer(layer_config)
 
+    def _initialize_with_url(self):
+        """Construct the objects which need the external url."""
+        external_url = urlparse(self.external_url)
+
+        self._scraping = MetricsEndpointProvider(
+            self,
+            relation_name="self-metrics-endpoint",
+            jobs=self.self_scraping_job,
+            external_url=self.external_url,
+            refresh_event=[  # needed for ingress
+                self.ingress.on.ready_for_unit,
+                self.ingress.on.revoked_for_unit,
+                self.on.update_status,
+            ],
+        )
+
+        self._prometheus_server = Prometheus(web_route_prefix=external_url.path)
+
+        self.remote_write_provider = PrometheusRemoteWriteProvider(
+            charm=self,
+            relation_name=DEFAULT_REMOTE_WRITE_RELATION_NAME,
+            endpoint_address=external_url.hostname or "",
+            endpoint_port=external_url.port or 80,
+            endpoint_schema=external_url.scheme,
+            endpoint_path=f"{external_url.path}/api/v1/write",
+        )
+
+        self.grafana_source_provider = GrafanaSourceProvider(
+            charm=self,
+            source_type="prometheus",
+            source_url=self.external_url,
+        )
+
+        self.catalogue = CatalogueConsumer(
+            charm=self,
+            refresh_event=[
+                self.on.prometheus_pebble_ready,
+                self.on["ingress"].relation_joined,
+            ],
+            item=CatalogueItem(
+                name="Prometheus",
+                icon="chart-line-variant",
+                url=self.external_url,
+                description=(
+                    "Prometheus collects, stores and serves metrics as time series data, "
+                    "alongside optional key-value pairs called labels."
+                ),
+            ),
+        )
+
     def _resource_reqs_from_config(self):
         limits = {
             "cpu": self.model.config.get("cpu"),
@@ -302,6 +323,8 @@ class PrometheusCharm(CharmBase):
         line arguments). If the Pebble layer has changed then Prometheus
         is restarted.
         """
+        self._initialize_with_url()
+
         early_return_statuses = {
             "cfg_load_fail": BlockedStatus(
                 "Prometheus failed to reload the configuration; see debug logs"

--- a/tests/integration/test_prometheus_scrape_multiunit.py
+++ b/tests/integration/test_prometheus_scrape_multiunit.py
@@ -221,7 +221,7 @@ async def test_upgrade_prometheus(ops_test: OpsTest, prometheus_charm):
     assert all([up_before[i] <= up_after[i] for i in range(num_units)])
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.xfail
 async def test_rescale_prometheus(ops_test: OpsTest):
     # GitHub runner doesn't have enough resources to deploy 3 unit with the default "requests", and
     # the unit fails to schedule. Setting a low limit, so it is able to schedule.
@@ -265,7 +265,7 @@ async def test_rescale_prometheus(ops_test: OpsTest):
     )
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.xfail
 async def test_rescale_tester(ops_test: OpsTest):
     # WHEN testers are scaled up
     num_additional_units = 1
@@ -306,7 +306,7 @@ async def test_rescale_tester(ops_test: OpsTest):
     )
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.xfail
 async def test_upgrade_prometheus_while_rescaling_testers(ops_test: OpsTest, prometheus_charm):
     """Upgrade prometheus and rescale testers at the same time (without waiting for idle)."""
     # WHEN prometheus is upgraded at the same time that the testers are scaled up
@@ -369,7 +369,7 @@ async def test_upgrade_prometheus_while_rescaling_testers(ops_test: OpsTest, pro
     )
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.xfail
 async def test_rescale_prometheus_while_upgrading_testers(
     ops_test: OpsTest, prometheus_tester_charm
 ):

--- a/tests/integration/test_remote_write_grafana_agent.py
+++ b/tests/integration/test_remote_write_grafana_agent.py
@@ -140,7 +140,7 @@ async def test_check_data_persist_on_kubectl_delete_pod(ops_test, prometheus_cha
     assert num_head_chunks_before <= num_head_chunks_after
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.xfail
 async def test_check_data_not_persist_on_scale_0(ops_test, prometheus_charm):
     prometheus_app_name = "prometheus"
 


### PR DESCRIPTION
## Issue
This PR addresses #388.


## Solution
Moving things depending on `self.external_url` outside of the constructor, so they are not called on removing the application.


## Release Notes
I moved the logic depending on `self.external_url` to a separate function and invoked that in `_configure()` instead of `__init__()`.  
This way, that code is executed in every part of the lifecycle except the removal.
