### PR TITLE
Update the catalogue when a new leader is elected

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -135,6 +135,7 @@ class PrometheusCharm(CharmBase):
             charm=self,
             refresh_event=[
                 self.on.prometheus_pebble_ready,
+                self.on.leader_elected,
                 self.on["ingress"].relation_joined,
             ],
             item=CatalogueItem(


### PR DESCRIPTION
## Issue
In case of a new leader election with IPU, the Catalogue address will not update (never set to refresh)

## Solution
Add `leader_elected` to refresh_events

## Release Notes
Update the catalogue when a new leader is elected