### PR TITLE
add new public method update_scrape_job_spec

### DIFF
--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -67,16 +67,15 @@ topology = JujuTopology(
 ```
 
 """
-
-import re
 from collections import OrderedDict
 from typing import Dict, List, Optional
+from uuid import UUID
 
 # The unique Charmhub library identifier, never change it
 LIBID = "bced1658f20f49d28b88f61f83c2d232"
 
 LIBAPI = 0
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 class InvalidUUIDError(Exception):
@@ -126,29 +125,18 @@ class JujuTopology:
         self._unit = unit
 
     def is_valid_uuid(self, uuid):
-        """Validate the supplied UUID against the Juju Model UUID pattern."""
-        # TODO:
-        # Harness is harcoding an UUID that is v1 not v4: f2c1b2a6-e006-11eb-ba80-0242ac130004
-        # See: https://github.com/canonical/operator/issues/779
-        #
-        # >>> uuid.UUID("f2c1b2a6-e006-11eb-ba80-0242ac130004").version
-        # 1
-        #
-        # we changed the validation of the 3ed UUID block: 4[a-f0-9]{3} -> [a-f0-9]{4}
-        # See: https://github.com/canonical/operator/blob/main/ops/testing.py#L1094
-        #
-        # Juju in fact generates a UUID v4: https://github.com/juju/utils/blob/master/uuid.go#L62
-        # but does not validate it is actually v4:
-        # See:
-        # - https://github.com/juju/utils/blob/master/uuid.go#L22
-        # - https://github.com/juju/schema/blob/master/strings.go#L79
-        #
-        # Once Harness fixes this, we should remove this comment and refactor the regex or
-        # the entire method using the uuid module to validate UUIDs
-        regex = re.compile(
-            "^[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}$"
-        )
-        return bool(regex.match(uuid))
+        """Validate the supplied UUID against the Juju Model UUID pattern.
+
+        Args:
+            uuid: string that needs to be checked if it is valid v4 UUID.
+
+        Returns:
+            True if parameter is a valid v4 UUID, False otherwise.
+        """
+        try:
+            return str(UUID(uuid, version=4)) == uuid
+        except (ValueError, TypeError):
+            return False
 
     @classmethod
     def from_charm(cls, charm):

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -449,7 +449,7 @@ class PrometheusConfig:
     def expand_wildcard_targets_into_individual_jobs(
         scrape_jobs: List[dict],
         hosts: Dict[str, Tuple[str, str]],
-        topology: JujuTopology = None,  # type: ignore
+        topology: JujuTopology = None,
     ) -> List[dict]:
         """Extract wildcard hosts from the given scrape_configs list into separate jobs.
 
@@ -1378,7 +1378,7 @@ class MetricsEndpointProvider(Object):
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
         external_url: str = "",
-        lookaside_jobs_callable: Callable = None,  # type: ignore
+        lookaside_jobs_callable: Callable = None,
     ):
         """Construct a metrics provider for a Prometheus charm.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ namespace_packages = true
 explicit_package_bases = true
 check_untyped_defs = true
 allow_redefinition = true
+implicit_optional = true
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ module = ["pytest.*", "pytest_operator.*", "prometheus_api_client.*", "deepdiff.
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = ["charms.grafana_k8s.*", "charms.alertmanager_k8s.*", "charms.traefik_k8s.*"]
+module = ["charms.grafana_k8s.*", "charms.alertmanager_k8s.*", "charms.observability_libs.*", "charms.traefik_k8s.*"]
 follow_imports = "silent"
 
 [[tool.mypy.overrides]]

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -4,6 +4,7 @@
 import json
 import logging
 import unittest
+import uuid
 from string import Template
 
 from charms.prometheus_k8s.v0.prometheus_scrape import (
@@ -610,7 +611,7 @@ class TestWildcardTargetsWithMutliunitProvider(unittest.TestCase):
                 "scrape_metadata": json.dumps(
                     {
                         "model": self.__class__.__name__,
-                        "model_uuid": "00000000-0000-0000-a000-000000000000",
+                        "model_uuid": str(uuid.uuid4()),
                         "application": "remote-app",
                         "charm_name": "some-provider",
                     }

--- a/tests/unit/test_prometheus_config.py
+++ b/tests/unit/test_prometheus_config.py
@@ -3,6 +3,7 @@
 
 import logging
 import unittest
+import uuid
 
 from charms.observability_libs.v0.juju_topology import JujuTopology
 from charms.prometheus_k8s.v0.prometheus_scrape import PrometheusConfig
@@ -270,7 +271,7 @@ class TestWildcardExpansionWithTopology(unittest.TestCase):
         # AND some topology
         topology = JujuTopology(
             model="model",
-            model_uuid="00000000-0000-0000-a000-000000000000",
+            model_uuid=str(uuid.uuid4()),
             application="app",
             charm_name="charm",
         )

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -45,18 +45,18 @@ requires:
 ALERT_RULES = {
     "groups": [
         {
-            "name": "None_f2c1b2a6-e006-11eb-ba80-0242ac130004_consumer-tester_alerts",
+            "name": "None_e674af04-0e76-4c11-92a0-f219fa8b4386_consumer-tester_alerts",
             "rules": [
                 {
                     "alert": "CPUOverUse",
                     "expr": 'process_cpu_seconds_total{juju_application="consumer-tester",'
                     'juju_model="None",'
-                    'juju_model_uuid="f2c1b2a6-e006-11eb-ba80-0242ac130004"} > 0.12',
+                    'juju_model_uuid="e674af04-0e76-4c11-92a0-f219fa8b4386"} > 0.12',
                     "for": "0m",
                     "labels": {
                         "severity": "Low",
                         "juju_model": "None",
-                        "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                        "juju_model_uuid": "e674af04-0e76-4c11-92a0-f219fa8b4386",
                         "juju_application": "consumer-tester",
                     },
                     "annotations": {
@@ -68,12 +68,12 @@ ALERT_RULES = {
                 {
                     "alert": "PrometheusTargetMissing",
                     "expr": 'up{juju_application="consumer-tester",juju_model="None",'
-                    'juju_model_uuid="f2c1b2a6-e006-11eb-ba80-0242ac130004"} == 0',
+                    'juju_model_uuid="e674af04-0e76-4c11-92a0-f219fa8b4386"} == 0',
                     "for": "0m",
                     "labels": {
                         "severity": "critical",
                         "juju_model": "None",
-                        "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                        "juju_model_uuid": "e674af04-0e76-4c11-92a0-f219fa8b4386",
                         "juju_application": "consumer-tester",
                     },
                     "annotations": {


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Our current approach in "MetricEndpointProvider" of building everything with the object constructor is not very handy when the charm that instruments the `prometheus_scrape` library is related to an ingress (Traefik for example). 

Let's say we have this scenario:


```mermaid
flowchart LR
    A[prometheus] ---|metrics-endpoint| B[loki]
    B --- |ingress-per-unit| C[traefik]
    
```

And the following code in the loki charm.py:

```python
    def __init__(self, *args):
        ...
        external_url = urlparse(self._external_url)

        scrape_jobs = [
            {
                "metrics_path": f"{external_url.path}/metrics",
                "static_configs": [{"targets": [f"{external_url.hostname}:{external_url.port}"]}],
            }
        ]
        self.metrics_provider = MetricsEndpointProvider(
            self,
            jobs=self.scrape_jobs,
            refresh_event=[
                self.on.update_status,
                self.ingress_per_unit.on.ready_for_unit,
                self.ingress_per_unit.on.revoked_for_unit,
                self.on.ingress_relation_departed,
            ],
        )

...

    @property
    def _external_url(self) -> str:
        """Return the external hostname to be passed to ingress via the relation."""
        if ingress_url := self.ingress_per_unit.url:
            logger.debug("This unit's ingress URL: %s", ingress_url)
            return ingress_url

        return f"http://{self.hostname}:{self._port}"
```

When the relations between the 3 charms are established, prometheus will have loki's scrape job with the external URL and path traefik provides to loki.

```yaml
- honor_labels: true
  job_name: juju_cos_9ba3b5f2_loki_prometheus_scrape
  metrics_path: /cos-loki-0/metrics
  relabel_configs:
  - regex: (.*)
    separator: _
    source_labels:
    - juju_model
    - juju_model_uuid
    - juju_application
    target_label: instance
  static_configs:
  - labels:
      juju_application: loki
      juju_charm: loki-k8s
      juju_model: cos
      juju_model_uuid: 9ba3b5f2-b859-4544-8455-503ec5e5b815
    targets:
    - 192.168.122.10:80
```


But if we remove the relation between [loki](https://github.com/canonical/loki-k8s-operator) and [traefik](https://github.com/canonical/traefik-k8s-operator), prometheus will not receive the new loki URL (and internal IP or FDQN) since at the moment we instantiate `MetricsEndpointProvider` in `__init__` (when `self.ingress_per_unit.on.revoked_for_unit` event is fired) the `self.ingress_per_unit.url` still returns an external url.    

## Solution
<!-- A summary of the solution addressing the above issue -->

We implemented a public method that let us update scrape jobs.
We are following the same pattern we have in [`LokiPushApiProvider`'s `update_endpoint`](https://github.com/canonical/loki-k8s-operator/blob/main/lib/charms/loki_k8s/v0/loki_push_api.py#L1232) and in [`Grafana`'s `update_source`](https://github.com/canonical/grafana-k8s-operator/blob/main/lib/charms/grafana_k8s/v0/grafana_source.py#L412).

With this implementation, we may have in the charm that uses `MetricsEndpointProvider`:

```python
    def __init__(self, *args):
        ...
        self.framework.observe(self.ingress_per_unit.on.ready_for_unit, self._on_ingress_changed)
        self.framework.observe(self.ingress_per_unit.on.revoked_for_unit, self._on_ingress_changed)

        ...

        self.metrics_provider = MetricsEndpointProvider(
            self,
            jobs=self.scrape_jobs,
            refresh_event=[
                self.on.update_status,
                self.ingress_per_unit.on.ready_for_unit,
                self.ingress_per_unit.on.revoked_for_unit,
                self.on.ingress_relation_departed,
            ],
        )

    def _on_ingress_changed(self, _):
        ...
        self.metrics_provider.update_scrape_job_spec(self.scrape_jobs)

    @property
    def scrape_jobs(self) -> list:
        """Generate scrape jobs."""
        if not self.ingress_per_unit.url:
            return [
                {
                    "static_configs": [{"targets": [f"*:{self._port}"]}],
                }
            ]

        external_url = urlparse(self.ingress_per_unit.url)

        return [
            {
                "metrics_path": f"{external_url.path}/metrics",
                "static_configs": [{"targets": [f"{external_url.hostname}:{external_url.port}"]}],
            }
        ]
```
 

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

See [this Loki issue](https://github.com/canonical/loki-k8s-operator/issues/210)

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

- Deploy prometheus, loki and traefik
- Relate prometheus and loki
  - Check that loki scrape job in prometheus config use internal IP or a FQDN
- Relate loki and traefik
  - Check that loki scrape job in prometheus config use external URL provided by traefik.
- Remove the relation between loki and traefik
  - Check that loki scrape job in prometheus config use internal IP or a FQDN again
