### PR TITLE
Also take yml and yaml rule files

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 logger = logging.getLogger(__name__)
@@ -321,7 +321,9 @@ class AlertRules:
         alert_groups = []  # type: List[dict]
 
         # Gather all alerts into a list of groups
-        for file_path in self._multi_suffix_glob(dir_path, [".rule", ".rules"], recursive):
+        for file_path in self._multi_suffix_glob(
+            dir_path, [".rule", ".rules", ".yml", ".yaml"], recursive
+        ):
             alert_groups_from_file = self._from_file(dir_path, file_path)
             if alert_groups_from_file:
                 logger.debug("Reading alert rule from %s", file_path)

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -255,7 +255,11 @@ is assumed to be in one of two formats:
 - a single rule format, which is a simplified subset of the official format,
 comprising a single alert rule per file, using the same YAML fields.
 
-The file name must have the `.rule` extension.
+The file name must have one of the following extensions:
+- `.rule`
+- `.rules`
+- `.yml`
+- `.yaml`
 
 An example of the contents of such a file in the custom single rule
 format is shown below.
@@ -939,7 +943,9 @@ class AlertRules:
         alert_groups = []  # type: List[dict]
 
         # Gather all alerts into a list of groups
-        for file_path in self._multi_suffix_glob(dir_path, [".rule", ".rules"], recursive):
+        for file_path in self._multi_suffix_glob(
+            dir_path, [".rule", ".rules", ".yml", ".yaml"], recursive
+        ):
             alert_groups_from_file = self._from_file(dir_path, file_path)
             if alert_groups_from_file:
                 logger.debug("Reading alert rule from %s", file_path)

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -354,7 +354,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 26
+LIBPATCH = 25
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_prometheus_rules_provider.py
+++ b/tests/unit/test_prometheus_rules_provider.py
@@ -108,7 +108,17 @@ class TestReloadAlertRules(unittest.TestCase):
     def test_only_files_with_rule_or_rules_suffixes_are_loaded(self):
         """Scenario: User has both short-form rules (*.rule) and long-form rules (*.rules)."""
         # GIVEN various tricky combinations of files present
-        filenames = ["alert.rule", "alert.rules", "alert.ruless", "alertrule", "alertrules"]
+        filenames = [
+            "alert.rule",
+            "alert.rules",
+            "alert.ruless",
+            "alertrule",
+            "alertrules",
+            "alert.yml",
+            "alert.yaml",
+            "alert.txt",
+            "alert.json",
+        ]
         for filename in filenames:
             rule_file = yaml.safe_dump({"alert": filename, "expr": "avg(some_vector[5m]) > 5"})
             self.sandbox.writetext(filename, rule_file)
@@ -120,7 +130,9 @@ class TestReloadAlertRules(unittest.TestCase):
         relation = self.harness.charm.model.get_relation("metrics-endpoint")
         alert_rules = json.loads(relation.data[self.harness.charm.app].get("alert_rules"))
         alert_names = [groups["rules"][0]["alert"] for groups in alert_rules["groups"]]
-        self.assertEqual(set(alert_names), {"alert.rule", "alert.rules"})
+        self.assertEqual(
+            set(alert_names), {"alert.rule", "alert.rules", "alert.yml", "alert.yaml"}
+        )
 
     def test_reload_with_empty_rules(self):
         """Scenario: The reload method is called with a zero-size alert file."""


### PR DESCRIPTION
## Issue
The official docs use yml:
- https://github.com/prometheus/prometheus/blob/main/documentation/examples/prometheus.yml
- https://github.com/prometheus/docs/blob/3fa139d3f3519940881bf535e295e83fe815e13c/content/docs/guides/query-log.md#recording-rules-and-alerts
- https://github.com/prometheus/docs/blob/512f28293efc7dba62c13dc6e9ea5247c39f27d4/content/docs/tutorials/alerting_based_on_metrics.md#alerting-based-on-metrics

And it's always nice that editors automatically pick the correct syntax highlighting.


## Solution
Also take yml and yaml in addition to rule and rules extensions.

Fixes #396.


## Context
Since we no longer need the topology stub, we no longer need to differentiate COS rules from regular rules via extension.


## Testing Instructions
Afaict, the augmented utest provides sufficient coverage.


## Release Notes
Also take yml and yaml rule files.
