### PR TITLE
cancel jobs if new commit is pushed to the same branch

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,5 +1,9 @@
 name: Pull Requests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
currently if you constantly push to the same branch, then CI runs for multiple commits in parallel

that is useless, we do not care about old commits in the same branch. Thus, we can cancel jobs and free up machine resources

we create a unique group that consists of workflow name and a branch name. If new commits are pushed to the same group, previous pipeline is aborted.

We can save hundreds of machine hours 


see:
https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow