### PR TITLE
Test fix: Make sure jobs for all ingressed units are "up"

### DIFF
--- a/tests/integration/test_external_url.py
+++ b/tests/integration/test_external_url.py
@@ -13,6 +13,7 @@
 import asyncio
 import json
 import logging
+import re
 import subprocess
 import urllib.request
 
@@ -183,14 +184,14 @@ async def test_jobs_are_up_via_traefik(ops_test: OpsTest):
     # AND the default job is healthy (its scrape url must have the path for this to work)
     prom_urls = [prom_url(i) + "/api/v1/targets" for i in range(num_units)]
     for url in prom_urls:
-        logger.info("Attmpting to fetch targets from url: %s", url)
+        logger.info("Attempting to fetch targets from url: %s", url)
         targets = urllib.request.urlopen(url, None, timeout=2).read().decode("utf8")
         logger.info("Response: %s", targets)
         assert '"health":"up"' in targets
         assert '"health":"down"' not in targets
 
     # Workaround to make sure everything is up-to-date:
-    # Ingress events are already passed as refresh_event to the MeetricsEndpointProvider.
+    # Ingress events are already passed as refresh_event to the MetricsEndpointProvider.
     # TODO remove these two lines when https://github.com/canonical/traefik-k8s-operator/issues/78
     #  is fixed.
     await wait_for_ingress(ops_test)
@@ -200,11 +201,14 @@ async def test_jobs_are_up_via_traefik(ops_test: OpsTest):
     # for this to work).
     external_prom_url = f"http://{await unit_address(ops_test, external_prom_name, 0)}:9090"
     url = external_prom_url + "/api/v1/targets"
-    logger.info("Attmpting to fetch targets from url: %s", external_prom_url)
+    logger.info("Attempting to fetch targets from url: %s", external_prom_url)
     targets = urllib.request.urlopen(url, None, timeout=2).read().decode("utf8")
     logger.info("Response: %s", targets)
+    for i in range(num_units):
+        assert f"{ops_test.model_name}-{prometheus_app_name}-{i}" in targets
     assert '"health":"up"' in targets
     assert '"health":"down"' not in targets
+    assert len(re.findall(r'"health":"up"', targets)) == 3  # the default self scrape, and the two prom units
 
 
 async def test_jobs_are_up_with_config_option_overriding_traefik(ops_test: OpsTest):
@@ -229,7 +233,7 @@ async def test_jobs_are_up_with_config_option_overriding_traefik(ops_test: OpsTe
     # AND the default job is healthy (its scrape url must have the path for this to work)
     prom_urls = [await prom_url(i) + "/api/v1/targets" for i in range(num_units)]
     for url in prom_urls:
-        logger.info("Attmpting to fetch targets from url: %s", url)
+        logger.info("Attempting to fetch targets from url: %s", url)
         targets = urllib.request.urlopen(url, None, timeout=2).read().decode("utf8")
         logger.info("Response: %s", targets)
         assert '"health":"up"' in targets

--- a/tests/integration/test_external_url.py
+++ b/tests/integration/test_external_url.py
@@ -204,8 +204,12 @@ async def test_jobs_are_up_via_traefik(ops_test: OpsTest):
     logger.info("Attempting to fetch targets from url: %s", external_prom_url)
     targets = urllib.request.urlopen(url, None, timeout=2).read().decode("utf8")
     logger.info("Response: %s", targets)
+
+    # Make sure the ingressed targets, and not the old ones before ingress applied, are the ones being scraped.
+    # (Assuming the default scrape interval of 1 min passed since reldata was updated with the external url.)
     for i in range(num_units):
         assert f"{ops_test.model_name}-{prometheus_app_name}-{i}" in targets
+
     assert '"health":"up"' in targets
     assert '"health":"down"' not in targets
     assert len(re.findall(r'"health":"up"', targets)) == 3  # the default self scrape, and the two prom units

--- a/tests/integration/test_external_url.py
+++ b/tests/integration/test_external_url.py
@@ -205,8 +205,9 @@ async def test_jobs_are_up_via_traefik(ops_test: OpsTest):
     targets = urllib.request.urlopen(url, None, timeout=2).read().decode("utf8")
     logger.info("Response: %s", targets)
 
-    # Make sure the ingressed targets, and not the old ones before ingress applied, are the ones being scraped.
-    # (Assuming the default scrape interval of 1 min passed since reldata was updated with the external url.)
+    # Make sure the ingressed targets, and not the old ones before ingress applied, are the ones
+    # being scraped. (Assuming the default scrape interval of 1 min passed since reldata was
+    # updated with the external url.)
     for i in range(num_units):
         assert f"{ops_test.model_name}-{prometheus_app_name}-{i}" in targets
 

--- a/tests/integration/test_external_url.py
+++ b/tests/integration/test_external_url.py
@@ -212,7 +212,9 @@ async def test_jobs_are_up_via_traefik(ops_test: OpsTest):
 
     assert '"health":"up"' in targets
     assert '"health":"down"' not in targets
-    assert len(re.findall(r'"health":"up"', targets)) == 3  # the default self scrape, and the two prom units
+    assert (
+        len(re.findall(r'"health":"up"', targets)) == 3
+    )  # the default self scrape, and the two prom units
 
 
 async def test_jobs_are_up_with_config_option_overriding_traefik(ops_test: OpsTest):


### PR DESCRIPTION
## Issue
There is no itest that proves #393 is fixed. 


## Solution
Augment existing test to ensure units behind ingress-per-unit are reporting a correct path, resulting in an "up" status for all units. (In fact, we can convince our selves that this is the case from logs from previous PRs, for example [here](https://github.com/canonical/prometheus-k8s-operator/actions/runs/3499728279/jobs/5861612514#step:5:634).)

Fixes #393.

## Context
Afaict, #370 and #373 addressed #393 in full. (Perhaps this issue was encountered before fetch-lib?)


## Testing Instructions
- Afaict, the `test_external_url` itest fully covers the issue.
- Deploy two units of prom, relate them to ingress and then relate them to another prom. Make sure the other prom's targets have the correct ingress-per-unit path, and that both jobs are "up".


## Release Notes
Test fix: Make sure jobs for all ingressed units are "up".
