### PR TITLE
Make sure updated external url propogates to catalogue

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -142,7 +142,8 @@ class PrometheusCharm(CharmBase):
             refresh_event=[
                 self.on.prometheus_pebble_ready,
                 self.on.leader_elected,
-                self.on["ingress"].relation_joined,
+                self.on["ingress"].relation_changed,
+                self.on.config_changed,  # web_external_url; also covers upgrade-charm
             ],
             item=CatalogueItem(
                 name="Prometheus",


### PR DESCRIPTION
## Issue
- Ingress url wasn't propagating to catalogue, unless re-related.
- Setting `web_external_url` wasn't propagating to catalogue, unless re-related.


## Solution
Fix refresh events.

Fixes https://github.com/canonical/catalogue-k8s-operator/issues/3


## Context
NTA.


## Testing Instructions
1. Relate prom to ctlg.
2. Change external url -- either:
  - `juju config prom/0 web_external_url="http://unre.al"`; or
  - relate prom to trfk.
3. `juju ssh --container catalogue ctlg/0 cat /web/config.json | jq` and make sure the correct address is there.


## Release Notes
Make sure updated external url propogates to catalogue.
