### PR TITLE
More refresh events for catalogue

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -145,10 +145,6 @@ class PrometheusCharm(CharmBase):
                 self.ingress.on.ready_for_unit,
                 self.ingress.on.revoked_for_unit,
                 self.on.config_changed,  # web_external_url; also covers upgrade-charm
-                # TODO remove the following after the traefik issue is fixed
-                #  https://github.com/canonical/traefik-k8s-operator/issues/78
-                self.on["ingress"].relation_changed,
-                self.on.update_status,
             ],
             item=CatalogueItem(
                 name="Prometheus",

--- a/src/charm.py
+++ b/src/charm.py
@@ -142,8 +142,13 @@ class PrometheusCharm(CharmBase):
             refresh_event=[
                 self.on.prometheus_pebble_ready,
                 self.on.leader_elected,
-                self.on["ingress"].relation_changed,
+                self.ingress.on.ready_for_unit,
+                self.ingress.on.revoked_for_unit,
                 self.on.config_changed,  # web_external_url; also covers upgrade-charm
+                # TODO remove the following after the traefik issue is fixed
+                #  https://github.com/canonical/traefik-k8s-operator/issues/78
+                self.on["ingress"].relation_changed,
+                self.on.update_status,
             ],
             item=CatalogueItem(
                 name="Prometheus",


### PR DESCRIPTION
## Issue
#404 was confirmed working locally, but only once... In a load test deployment, the link was still wrong even after that fix.


## Solution
Add more refresh events.


## Context
Addresses https://github.com/canonical/catalogue-k8s-operator/issues/3.


## Testing Instructions
1. Deploy the cos-lite bundle.
2. Make sure prom has the correct url.


## Release Notes
Add more refresh events for catalogue.
