### PR TITLE
send-remote-write feature

### DIFF
--- a/INTEGRATING.md
+++ b/INTEGRATING.md
@@ -38,3 +38,42 @@ configuration is generated.
 4. [Traefik Charmed Operator](https://charmhub.io/traefik-k8s), over the `ingress_per_unit` interface, so Prometheus may be reached from outside the Kubernetes cluster it is running on.
 
 5. [Catalogue Charmed Operator](https://charmhub.io/catalogue-k8s), over the `catalogue` interface, so Prometheus can be published in the service catalogue web page.
+
+## Deployment scenarios
+
+### Tier prometheus deployments (local-remote on-call teams)
+
+```mermaid
+graph LR
+subgraph COS1
+  am1[Alertmanager]
+  prom1[Prometheus]
+  am1 --- prom1
+end
+subgraph COS1.2
+  am1.2[Alertmanager]
+  prom1.2[Prometheus]
+  am1.2 --- prom1.2
+end
+subgraph COS2
+  am2[Alertmanager]
+  prom2[Prometheus]
+  am2 --- prom2
+end
+subgraph COS[Main COS]
+  am[Alertmanager]
+  prom[Prometheus]
+  prom --- am
+end
+pd1[PagerDuty] --- am1
+pd2[PagerDuty] --- am2
+am --- pd[PagerDuty]
+prom1 --- |remote write, rules| am1.2
+prom1.2 --- |remote write, rules| prom
+prom2 --- |remote write, rules| prom
+```
+
+Main COS will have a combination of rules COS1+COS2+Main COS to track the health of the entire system.
+Prometheus in COS1 scrapes an application (PagerDuty), sends metrics and alert rules to Prometheus in COS1.2, 
+which sends metrics and alert rules to Prometheus in Main COS. As result Prometheus in Main COS will have alert rules
+defined in the application.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -49,6 +49,8 @@ requires:
     limit: 1
   catalogue:
     interface: catalogue
+  send-remote-write:
+    interface: prometheus_remote_write
 
 peers:
   prometheus-peers:

--- a/src/charm.py
+++ b/src/charm.py
@@ -175,6 +175,9 @@ class PrometheusCharm(CharmBase):
         self.framework.observe(self.ingress.on.revoked_for_unit, self._on_ingress_revoked)
         self.framework.observe(self.on.receive_remote_write_relation_created, self._configure)
         self.framework.observe(self.on.receive_remote_write_relation_changed, self._configure)
+        self.framework.observe(
+            self.on.receive_remote_write_relation_changed, self._push_alerts_to_remote_write
+        )
         self.framework.observe(self.on.receive_remote_write_relation_broken, self._configure)
         self.framework.observe(self.on.send_remote_write_relation_broken, self._configure)
         self.framework.observe(

--- a/tests/integration/test_receive_remote_write.py
+++ b/tests/integration/test_receive_remote_write.py
@@ -21,7 +21,7 @@ avalanche = "avalanche"
 prom_send = "prometheus-sender"
 prom_receiver_sender = "prometheus-receiver-sender"
 prom_receive = "prometheus-receiver"  # prometheus that provides `/api/v1/write` API endpoint
-local_apps = [avalanche, prom_receive, prom_send]
+local_apps = [avalanche, prom_receive, prom_send, prom_receiver_sender]
 
 
 @pytest.mark.abort_on_fail
@@ -81,7 +81,7 @@ async def test_receive_remote_write(ops_test: OpsTest, prometheus_charm):
         ),
     )
 
-    await ops_test.model.wait_for_idle(apps=local_apps, status="active", idle_period=60)
+    await ops_test.model.wait_for_idle(apps=local_apps, status="active", idle_period=90)
 
     # check that both Prometheus have avalanche metrics and both fire avalanche alert
     for app in [prom_send, prom_receiver_sender, prom_receive]:

--- a/tests/integration/test_receive_remote_write.py
+++ b/tests/integration/test_receive_remote_write.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+
+import pytest
+from helpers import (
+    check_prometheus_is_ready,
+    get_prometheus_rules,
+    has_metric,
+    oci_image,
+)
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+avalanche = "avalanche"
+# prometheus that will consume from the app and write to the remote API
+prom_send = "prometheus-sender"
+prom_receiver_sender = "prometheus-receiver-sender"
+prom_receive = "prometheus-receiver"  # prometheus that provides `/api/v1/write` API endpoint
+local_apps = [avalanche, prom_receive, prom_send]
+
+
+@pytest.mark.abort_on_fail
+async def test_receive_remote_write(ops_test: OpsTest, prometheus_charm):
+    """Test chaining via `receive-remote-write` relation.
+
+    When two Prometheuses are related to one another via `receive-remote-write`,
+    then all the alerts from the 1st prometheus should be forwarded to the second.
+
+    Prometheus (prometheus-receiver) that provides `receive-remote-write` relation
+    provides `/api/v1/write` API endpoint that will be consumed by Prometheus (prometheus-sender)
+    that requires `send-remote-write` relation. Later, `prometheus-sender` will write all the data
+    it receives from applications to the provided API endpoint of `prometheus-receiver`.
+
+    """
+    await asyncio.gather(
+        ops_test.model.deploy(
+            prometheus_charm,
+            resources={"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")},
+            application_name=prom_send,
+            trust=True,  # otherwise errors on ghwf (persistentvolumeclaims ... is forbidden)
+            series="focal",
+        ),
+        ops_test.model.deploy(
+            prometheus_charm,
+            resources={"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")},
+            application_name=prom_receive,
+            trust=True,  # otherwise errors on ghwf (persistentvolumeclaims ... is forbidden)
+            series="focal",
+        ),
+        ops_test.model.deploy(
+            prometheus_charm,
+            resources={"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")},
+            application_name=prom_receiver_sender,
+            trust=True,  # otherwise errors on ghwf (persistentvolumeclaims ... is forbidden)
+            series="focal",
+        ),
+        ops_test.model.deploy(
+            "avalanche-k8s", channel="edge", application_name=avalanche, series="focal"
+        ),
+    )
+
+    await ops_test.model.wait_for_idle(status="active", wait_for_units=1, raise_on_error=False)
+    assert await check_prometheus_is_ready(ops_test, prom_send, 0)
+    assert await check_prometheus_is_ready(ops_test, prom_receive, 0)
+    assert await check_prometheus_is_ready(ops_test, prom_receiver_sender, 0)
+
+    await asyncio.gather(
+        ops_test.model.add_relation(
+            f"{avalanche}:metrics-endpoint", f"{prom_send}:metrics-endpoint"
+        ),
+        ops_test.model.add_relation(
+            f"{prom_send}:send-remote-write", f"{prom_receiver_sender}:receive-remote-write"
+        ),
+        ops_test.model.add_relation(
+            f"{prom_receiver_sender}:send-remote-write", f"{prom_receive}:receive-remote-write"
+        ),
+    )
+
+    await ops_test.model.wait_for_idle(apps=local_apps, status="active", idle_period=60)
+
+    # check that both Prometheus have avalanche metrics and both fire avalanche alert
+    for app in [prom_send, prom_receiver_sender, prom_receive]:
+        assert await has_metric(
+            ops_test,
+            f'up{{juju_model="{ops_test.model_name}",juju_application="{avalanche}"}}',
+            app,
+        )
+
+        # Note: the following depends on an avalnche alert coming from the avalanche charm
+        # https://github.com/canonical/avalanche-k8s-operator/blob/main/src/prometheus_alert_rules
+        prom_rules_list = await get_prometheus_rules(ops_test, app, 0)
+        for rules_dict in prom_rules_list:
+            if rules_list := rules_dict.get("rules", []):
+                for rule in rules_list:
+                    if rule["name"] == "AlwaysFiringDueToNumericValue":
+                        assert rule["state"] == "firing"
+                        break
+                else:
+                    # "AlwaysFiringDueToNumericValue" was not found, go to next rules_dict
+                    continue
+                break
+        else:
+            raise AssertionError(
+                f"The 'AlwaysFiringDueToNumericValue' avalanche alert was not found in prometheus '{app}'"
+            )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import ops
 import yaml
+from charms.prometheus_k8s.v0.prometheus_remote_write import DEFAULT_CONSUMER_NAME
 from helpers import cli_arg, k8s_resource_multipatch, prom_multipatch
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
@@ -231,6 +232,28 @@ class TestCharm(unittest.TestCase):
             if job["job_name"] != "prometheus":
                 self.assertIn("honor_labels", job)
                 self.assertTrue(job["honor_labels"])
+
+    @k8s_resource_multipatch
+    def test_send_remote_write_endpoints(self, *unused):
+        rel_id = self.harness.add_relation(DEFAULT_CONSUMER_NAME, "prometheus-receiver")
+        unit_name = "prometheus-receiver/0"
+        self.harness.add_relation_unit(rel_id, unit_name)
+
+        self.harness.update_relation_data(
+            rel_id,
+            unit_name,
+            {"remote_write": json.dumps({"url": "http://1.1.1.1:9090/api/v1/write"})},
+        )
+
+        container = self.harness.charm.unit.get_container(self.harness.charm._name)
+        config = container.pull(PROMETHEUS_CONFIG)
+        prometheus_scrape_config = yaml.safe_load(config)
+
+        self.assertIn("remote_write", prometheus_scrape_config)
+        self.assertEqual(
+            prometheus_scrape_config["remote_write"],
+            [{"url": "http://1.1.1.1:9090/api/v1/write"}],
+        )
 
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")


### PR DESCRIPTION
closes #353 

Added functionality for send-remote-write

When two Prometheuses are related to one another via `receive-remote-write`, then all the alerts from the 1st prometheus should be forwarded to the second.

Prometheus (prometheus-receiver) that provides `receive-remote-write` relation provides `/api/v1/write` API endpoint that will be consumed by Prometheus (prometheus-sender) that requires `send-remote-write` relation. Later, `prometheus-sender` will write all the data it receives from applications to the provided API endpoint of `prometheus-receiver`.

For more information please refer to INTEGRATION.md diagram


Co-authored-by: Leon <82407168+sed-i@users.noreply.github.com>
Co-authored-by: Ryan Barry <ryan.barry@canonical.com>
