### PR TITLE
Allow optional (default false) DNS lookups for aggregator targets

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -2131,7 +2131,7 @@ class MetricsEndpointAggregator(Object):
                         "juju_application": application_name,
                         "juju_unit": unit_name,
                         "host": target["hostname"],
-                        **self._build_extra_info(target),
+                        **self._static_config_extra_labels(target),
                     },
                 }
                 for unit_name, target in targets.items()

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -2131,7 +2131,7 @@ class MetricsEndpointAggregator(Object):
                         "juju_application": application_name,
                         "juju_unit": unit_name,
                         "host": target["hostname"],
-                        **self._build_extra_info(target)
+                        **self._build_extra_info(target),
                     },
                 }
                 for unit_name, target in targets.items()
@@ -2143,7 +2143,7 @@ class MetricsEndpointAggregator(Object):
         return job
 
     def _build_extra_info(self, target: Dict[str, str]) -> Dict[str, str]:
-        """Build a list of extra static config parameters, if specified"""
+        """Build a list of extra static config parameters, if specified."""
         extra_info = {}
 
         if self._resolve_addresses:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -2142,7 +2142,7 @@ class MetricsEndpointAggregator(Object):
 
         return job
 
-    def _build_extra_info(self, target: Dict[str, str]) -> Dict[str, str]:
+    def _static_config_extra_labels(self, target: Dict[str, str]) -> Dict[str, str]:
         """Build a list of extra static config parameters, if specified."""
         extra_info = {}
 


### PR DESCRIPTION
## Issue
Some LMA1 dashboards and workflows rely on the presence of a `dns_name` label, which is set by the `prometheus2` charm when a new target is received. After investigation, the remaining set of labels is a non-overlapping set, with no usable substitute available via relabeling.

## Solution
Do hostname lookups, optionally. There are too many edge cases with trying to do this as a default, and not all workflows need this label. Behave the same way as the old charm -- if a lookup fails, set the name with the passed input/hostname anyway.

## Context
See [here](https://github.com/canonical/cos-proxy-operator/issues/32)

## Release Notes
Allow optional (default false) DNS lookups for aggregator targets