### PR TITLE
Stop using remote storage

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -428,23 +428,6 @@ class PrometheusCharm(CharmBase):
                 "Cannot set workload version at this time: could not get Prometheus version."
             )
 
-    def _update_config(self, container) -> bool:
-        """Pushes new config, if needed.
-
-        Returns a boolean indicating if a new configuration was pushed.
-        """
-        config = self._generate_prometheus_config(container)
-        config_hash = sha256(config)
-
-        if config_hash == self._stored.config_hash:
-            return False
-
-        logger.debug("Prometheus config changed")
-        container.push(PROMETHEUS_CONFIG, config, make_dirs=True)
-        self._stored.config_hash = config_hash
-        logger.info("Pushed new configuration")
-        return True
-
     def _update_layer(self, container) -> bool:
         current_planned_services = container.get_plan().services
         new_layer = self._prometheus_layer

--- a/src/charm.py
+++ b/src/charm.py
@@ -82,14 +82,14 @@ def pull(container, path, *, default: Optional[str] = None) -> Optional[str]:
         File contents if exists; `default` otherwise.
     """
     try:
-        return container.pull(path, encoding="utf8").read()
-    except FileNotFoundError:
+        return container.pull(path, encoding="utf-8").read()
+    except (FileNotFoundError, PebbleError):
         return default
 
 
 def push(container, path, contents):
     """Push file to container, creating subdirs as necessary."""
-    container.push(path, contents, make_dirs=True, encoding="utf8")
+    container.push(path, contents, make_dirs=True, encoding="utf-8")
 
 
 class PrometheusCharm(CharmBase):

--- a/src/charm.py
+++ b/src/charm.py
@@ -76,6 +76,11 @@ def sha256(hashable) -> str:
 
 
 def pull(container, path, *, default: Optional[str] = None) -> Optional[str]:
+    """Pull file from container (without raising FileNotFoundError).
+
+    Returns:
+        File contents if exists; `default` otherwise.
+    """
     try:
         return container.pull(path, encoding="utf8").read()
     except FileNotFoundError:
@@ -83,6 +88,7 @@ def pull(container, path, *, default: Optional[str] = None) -> Optional[str]:
 
 
 def push(container, path, contents):
+    """Push file to container, creating subdirs as necessary."""
     container.push(path, contents, make_dirs=True, encoding="utf8")
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -62,8 +62,8 @@ from utils import convert_k8s_quantity_to_legacy_binary_gigabytes
 
 PROMETHEUS_CONFIG = "/etc/prometheus/prometheus.yml"
 RULES_DIR = "/etc/prometheus/rules"
-CONFIG_HASH_PATH = "/etc/prometheus/config.hash"
-ALERTS_HASH_PATH = "/etc/prometheus/alerts.hash"
+CONFIG_HASH_PATH = "/etc/prometheus/config.sha256"
+ALERTS_HASH_PATH = "/etc/prometheus/alerts.sha256"
 
 logger = logging.getLogger(__name__)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -477,13 +477,12 @@ class PrometheusCharm(CharmBase):
         alerts_hash = sha256(str(metrics_consumer_alerts) + str(remote_write_alerts))
         alert_rules_changed = alerts_hash != pull(container, ALERTS_HASH_PATH)
 
-        # Pushing files every time for situations such as cluster restart:
-        # Relation data and stored state match, but files haven't been written yet.
-        # FIXME don't push every time
-        container.remove_path(RULES_DIR, recursive=True)
-        self._push_alert_rules(container, metrics_consumer_alerts)
-        self._push_alert_rules(container, remote_write_alerts)
-        push(container, ALERTS_HASH_PATH, alerts_hash)
+        if alert_rules_changed:
+            container.remove_path(RULES_DIR, recursive=True)
+            self._push_alert_rules(container, metrics_consumer_alerts)
+            self._push_alert_rules(container, remote_write_alerts)
+            push(container, ALERTS_HASH_PATH, alerts_hash)
+
         return alert_rules_changed
 
     def _push_alert_rules(self, container, alerts):

--- a/src/charm.py
+++ b/src/charm.py
@@ -75,16 +75,16 @@ def sha256(hashable) -> str:
     return hashlib.sha256(hashable).hexdigest()
 
 
-def pull(container, path, *, default: Optional[str] = None) -> Optional[str]:
+def pull(container, path) -> Optional[str]:
     """Pull file from container (without raising FileNotFoundError).
 
     Returns:
-        File contents if exists; `default` otherwise.
+        File contents if exists; None otherwise.
     """
     try:
         return container.pull(path, encoding="utf-8").read()
     except (FileNotFoundError, PebbleError):
-        return default
+        return None
 
 
 def push(container, path, contents):

--- a/src/charm.py
+++ b/src/charm.py
@@ -774,4 +774,4 @@ class PrometheusCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(PrometheusCharm)
+    main(PrometheusCharm, use_juju_for_storage=True)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 import logging
+import subprocess
 from pathlib import Path
 from typing import List
 
@@ -243,3 +244,25 @@ async def has_metric(ops_test, query: str, app_name: str) -> bool:
             return True
 
     return False
+
+
+def get_workload_file(
+    model_name: str, app_name: str, unit_num: int, container_name: str, filepath: str
+) -> bytes:
+    cmd = [
+        "juju",
+        "ssh",
+        "--model",
+        model_name,
+        "--container",
+        container_name,
+        f"{app_name}/{unit_num}",
+        "cat",
+        filepath,
+    ]
+    try:
+        res = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        log.error(e.stdout.decode())
+        raise e
+    return res.stdout

--- a/tests/integration/test_regression.py
+++ b/tests/integration/test_regression.py
@@ -29,7 +29,8 @@ async def test_deploy_from_channel_and_upgrade_with_current(ops_test, prometheus
 
     logger.info("Upgrade %s charm to current charm", channel)
     await ops_test.model.applications[app_name].refresh(
-        path=prometheus_charm, resources=prometheus_resources
+        path=prometheus_charm,
+        resources=prometheus_resources,
     )
     await ops_test.model.wait_for_idle(
         status="active", timeout=300, idle_period=60, raise_on_error=False

--- a/tests/integration/test_regression.py
+++ b/tests/integration/test_regression.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import pytest
+from helpers import oci_image
+
+logger = logging.getLogger(__name__)
+
+prometheus_resources = {"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")}
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.parametrize("channel", ("edge", "beta", "candidate", "stable"))
+async def test_deploy_from_channel_and_upgrade_with_current(ops_test, prometheus_charm, channel):
+    logger.info("Deploy charm from %s channel", channel)
+    app_name = f"prom-{channel}"
+    await ops_test.model.deploy(
+        "ch:prometheus-k8s",
+        application_name=app_name,
+        channel=channel,
+        trust=True,
+    )
+    await ops_test.model.wait_for_idle(
+        status="active", timeout=300, idle_period=60, raise_on_error=False
+    )
+
+    logger.info("Upgrade %s charm to current charm", channel)
+    await ops_test.model.applications[app_name].refresh(
+        path=prometheus_charm, resources=prometheus_resources
+    )
+    await ops_test.model.wait_for_idle(
+        status="active", timeout=300, idle_period=60, raise_on_error=False
+    )
+
+    # Now wait for idle without `raise_on_error=False`
+    await ops_test.model.wait_for_idle(status="active")

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -61,7 +61,7 @@ async def test_deploy_charm(ops_test, prometheus_tester_charm, prometheus_charm)
 
 
 @pytest.mark.abort_on_fail
-async def test_files_are_retained_after_upgrade_from_local_path(ops_test, prometheus_charm):
+async def test_files_are_retained_after_refresh(ops_test, prometheus_charm):
     # Get config from before the upgrade
     def get_config():
         return yaml.safe_load(

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -72,7 +72,7 @@ async def test_files_are_retained_after_upgrade_from_local_path(ops_test, promet
 
     config_before = get_config()
 
-    logger.debug("upgrade deployed charm with local charm %s", prometheus_charm)
+    logger.debug("Refreshing charm")
     await ops_test.model.applications[prometheus_app_name].refresh(
         path=prometheus_charm, resources=prometheus_resources
     )

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -6,16 +6,19 @@ import asyncio
 import logging
 
 import pytest
+import yaml
 from helpers import (
     check_prometheus_is_ready,
     get_prometheus_rules,
     get_rules_for,
+    get_workload_file,
     oci_image,
     run_promql,
 )
 
 logger = logging.getLogger(__name__)
 
+PROMETHEUS_CONFIG = "/etc/prometheus/prometheus.yml"
 prometheus_resources = {"prometheus-image": oci_image("./metadata.yaml", "prometheus-image")}
 tester_resources = {
     "prometheus-tester-image": oci_image(
@@ -29,24 +32,22 @@ app_names = [prometheus_app_name, tester_app_name]
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_from_edge_and_upgrade_from_local_path(ops_test, prometheus_tester_charm):
+async def test_deploy_charm(ops_test, prometheus_tester_charm, prometheus_charm):
     """Build the charm-under-test and deploy it together with related charms.
 
     Assert on the unit status before any relations/configurations take place.
     """
-    logger.debug("deploy charm from charmhub")
     await asyncio.gather(
         ops_test.model.deploy(
-            f"ch:{prometheus_app_name}",
-            application_name=prometheus_app_name,
-            channel="edge",
-            trust=True,  # otherwise errors on ghwf (persistentvolumeclaims ... is forbidden)
+            prometheus_charm, resources=prometheus_resources, application_name=prometheus_app_name
         ),
         ops_test.model.deploy(
             prometheus_tester_charm, resources=tester_resources, application_name=tester_app_name
         ),
     )
-    await ops_test.model.wait_for_idle(apps=app_names, status="active", timeout=300)
+    await ops_test.model.wait_for_idle(
+        apps=app_names, status="active", timeout=300, raise_on_error=False
+    )
 
     await ops_test.model.add_relation(
         f"{prometheus_app_name}:metrics-endpoint", f"{tester_app_name}:metrics-endpoint"
@@ -60,7 +61,17 @@ async def test_deploy_from_edge_and_upgrade_from_local_path(ops_test, prometheus
 
 
 @pytest.mark.abort_on_fail
-async def test_rules_are_retained_after_upgrade(ops_test, prometheus_charm):
+async def test_files_are_retained_after_upgrade_from_local_path(ops_test, prometheus_charm):
+    # Get config from before the upgrade
+    def get_config():
+        return yaml.safe_load(
+            get_workload_file(
+                ops_test.model_name, prometheus_app_name, 0, "prometheus", PROMETHEUS_CONFIG
+            )
+        )
+
+    config_before = get_config()
+
     logger.debug("upgrade deployed charm with local charm %s", prometheus_charm)
     await ops_test.model.applications[prometheus_app_name].refresh(
         path=prometheus_charm, resources=prometheus_resources
@@ -69,6 +80,10 @@ async def test_rules_are_retained_after_upgrade(ops_test, prometheus_charm):
         apps=app_names, status="active", timeout=300, idle_period=60
     )
     assert await check_prometheus_is_ready(ops_test, prometheus_app_name, 0)
+
+    # Get config from after the upgrade
+    config_after = get_config()
+    assert config_before == config_after
 
     # Check only one alert rule exists
     rules_with_relation = await get_prometheus_rules(ops_test, prometheus_app_name, 0)

--- a/tests/integration/test_upgrade_charm.py
+++ b/tests/integration/test_upgrade_charm.py
@@ -39,7 +39,10 @@ async def test_deploy_charm(ops_test, prometheus_tester_charm, prometheus_charm)
     """
     await asyncio.gather(
         ops_test.model.deploy(
-            prometheus_charm, resources=prometheus_resources, application_name=prometheus_app_name
+            prometheus_charm,
+            resources=prometheus_resources,
+            application_name=prometheus_app_name,
+            trust=True,
         ),
         ops_test.model.deploy(
             prometheus_tester_charm, resources=tester_resources, application_name=tester_app_name

--- a/tox.ini
+++ b/tox.ini
@@ -102,8 +102,6 @@ description = Run integration tests
 deps =
     aiohttp
     deepdiff
-    #juju
-    #git+https://github.com/juju/python-libjuju.git
     juju
     lightkube >= 0.11
     lightkube-models >= 1.22.0.4


### PR DESCRIPTION
## Issue
- Incorrectly assumed that the charm uses controller storage, when in fact it was using local storage (see https://github.com/canonical/operator/issues/880)
- Config and alerts hash was originally intended to be written to controller storage, which is wrong because files wouldnt be written to container after an upgrade (because hash(relation-data) would match the hash in stored state).


## Solution
- Do not use remote storage (remove `_stored`).
- Save hashes to container filesystem.

Fixes #399 
Fixes #414 
Fixes #418


## Context
NTA.


## Testing Instructions
- See new tests.
- In a `prom --(self monitoring)-- prom` constellation, refresh one of the proms and make sure the config file, alert rules and scrape targets are as they were before the refresh (covered in itest).


## Release Notes
Stop using remote storage.
