### PR TITLE
Do not blindly set data every time anything happens

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -368,7 +368,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 28
+LIBPATCH = 29
 
 logger = logging.getLogger(__name__)
 
@@ -1591,19 +1591,9 @@ class MetricsEndpointProvider(Object):
             if not isinstance(refresh_event, list):
                 refresh_event = [refresh_event]
 
+        self.framework.observe(events.relation_joined, self.set_scrape_job_spec)
         for ev in refresh_event:
             self.framework.observe(ev, self.set_scrape_job_spec)
-
-        # Update relation data every reinit. If instead we used event hooks then observing only
-        # relation-joined would not be sufficient:
-        # - Would need to observe leader-elected, in case there was no leader during
-        #   relation-joined.
-        # - If later related to an ingress provider, then would need to register and wait for
-        #   update-status interval to elapse before changes would apply.
-        # - The ingerss-ready custom event is currently emitted prematurely and cannot be relied
-        #   upon: https://github.com/canonical/traefik-k8s-operator/issues/78
-        # NOTE We may still end up waiting for update-status before changes are applied.
-        self.set_scrape_job_spec()
 
     def _on_relation_changed(self, event):
         """Check for alert rule messages in the relation data before moving on."""

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -417,10 +417,6 @@ class TestNonStandardProviders(unittest.TestCase):
             rel_id = self.harness.add_relation(RELATION_NAME, "provider")
             self.harness.add_relation_unit(rel_id, "provider/0")
 
-            # Ugly re-init workaround: manually call `set_scrape_job_spec`
-            # https://github.com/canonical/operator/issues/736
-            self.harness.charm.provider.set_scrape_job_spec()
-
             messages = sorted(logger.output)
             self.assertEqual(len(messages), 1)
             self.assertIn("Invalid rules file: missing_expr.rule", messages[0])
@@ -432,10 +428,6 @@ class TestNonStandardProviders(unittest.TestCase):
         with self.assertLogs(level="ERROR") as logger:
             rel_id = self.harness.add_relation(RELATION_NAME, "provider")
             self.harness.add_relation_unit(rel_id, "provider/0")
-
-            # Ugly re-init workaround: manually call `set_scrape_job_spec`
-            # https://github.com/canonical/operator/issues/736
-            self.harness.charm.provider.set_scrape_job_spec()
 
             messages = sorted(logger.output)
             self.assertEqual(len(messages), 1)


### PR DESCRIPTION
## Issue
`MetricsEndpointProvider` was, rather than setting its data on `relation_joined` and on `refresh_event`, clobbering the databag every time it ran, causing users to lose targets.

## Solution
Don't do that. Listen to `relation_joined` and the refresh events. Events are there for a reason (to indicate that something changed), and if there is an ordering problem with even promulgation in constructors/libraries/etc, firing in-code events and/or [providing public methods to set the appropriate field](https://github.com/canonical/prometheus-k8s-operator/pull/397) has far less side effects.

Closes #427 

## Testing Instructions
The steps in #427. Or deploy a dummy charm which instantiates the provider, sets a non-default scrape job spec, and makes sure it stays set after the next `update-status`, `config-changed`, or other event fires.

## Release Notes
Do not blindly set data every time anything happens