### PR TITLE
Strip '://' suffix from remote_write scheme

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -45,7 +45,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 
 logger = logging.getLogger(__name__)
@@ -764,7 +764,7 @@ class PrometheusRemoteWriteProvider(Object):
         self,
         charm: CharmBase,
         relation_name: str = DEFAULT_RELATION_NAME,
-        endpoint_schema: str = "http",
+        endpoint_schema: str = "http",  # TODO: in v1, rename to 'scheme'
         endpoint_address: str = "",
         endpoint_port: Union[str, int] = 9090,
         endpoint_path: str = "/api/v1/write",
@@ -802,7 +802,7 @@ class PrometheusRemoteWriteProvider(Object):
         self._charm = charm
         self.tool = CosTool(self._charm)
         self._relation_name = relation_name
-        self._endpoint_schema = endpoint_schema
+        self._endpoint_scheme = endpoint_schema.rstrip("://")
         self._endpoint_address = endpoint_address
         self._endpoint_port = int(endpoint_port)
         self._endpoint_path = endpoint_path
@@ -852,7 +852,7 @@ class PrometheusRemoteWriteProvider(Object):
             path = "/{}".format(path)
 
         endpoint_url = "{}://{}:{}{}".format(
-            self._endpoint_schema, address, str(self._endpoint_port), path
+            self._endpoint_scheme, address, str(self._endpoint_port), path
         )
 
         relation.data[self._charm.unit]["remote_write"] = json.dumps(

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ deps =
     integration: pytest-operator==1.0.0b1
 commands =
     charm: mypy {[vars]src_path} {posargs}
-    lib: mypy --python-version 3.5 {[vars]lib_path} {posargs}
+    lib: mypy --python-version 3.8 {[vars]lib_path} {posargs}
     unit: mypy {[vars]tst_path}/unit {posargs}
     integration: mypy {[vars]tst_path}/integration {posargs}
 


### PR DESCRIPTION
## Issue
Users could mistakenly pass "http://" with a "://" suffix,
```python
            endpoint_schema="http://",  # should have been just "http"
```

and the generate reldata will be invalid:
```yaml
    related-units:
      mimir/0:
        in-scope: true
        data:
          remote_write: '{"url": "http://://mimir-0.mimir-endpoints.test-alert-propagation-nxl2.svc.cluster.local:9009/api/v1/push"}'
```


## Solution
Eliminate the problem by always stripping the `://` suffix.

Cannot use `Literal["http", "https"]` because it will reject arbitrary strings such as:
```
src/charm.py:130: error: Argument "endpoint_schema" to "PrometheusRemoteWriteProvider" has incompatible type "str"; expected "Literal['http', 'https']"  [arg-type]
                endpoint_schema=external_url.scheme,
```

## Context
NTA.


## Testing Instructions
Relate mimir to avalanche and `juju show-unit avalanche/0`.


## Release Notes
Strip '://' suffix from remote_write scheme.
