### PR TITLE
Add support for TLS client cert/key in `tls_config`

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -62,10 +62,11 @@ from ops.pebble import ExecError, Layer
 from prometheus_server import Prometheus
 from utils import convert_k8s_quantity_to_legacy_binary_gigabytes
 
-PROMETHEUS_CONFIG = "/etc/prometheus/prometheus.yml"
-RULES_DIR = "/etc/prometheus/rules"
-CONFIG_HASH_PATH = "/etc/prometheus/config.sha256"
-ALERTS_HASH_PATH = "/etc/prometheus/alerts.sha256"
+PROMETHEUS_DIR = "/etc/prometheus"
+PROMETHEUS_CONFIG = f"{PROMETHEUS_DIR}/prometheus.yml"
+RULES_DIR = f"{PROMETHEUS_DIR}/rules"
+CONFIG_HASH_PATH = f"{PROMETHEUS_DIR}/config.sha256"
+ALERTS_HASH_PATH = f"{PROMETHEUS_DIR}/alerts.sha256"
 
 logger = logging.getLogger(__name__)
 
@@ -713,17 +714,17 @@ class PrometheusCharm(CharmBase):
                 # Certs are transferred over relation data and need to be written to files on disk.
                 # CA certificate to validate the server certificate with.
                 if ca_file := tls_config.get("ca_file"):
-                    filename = f"/etc/prometheus/{job['job_name']}.crt"
+                    filename = f"{PROMETHEUS_DIR}/{job['job_name']}.crt"
                     certs[filename] = ca_file
                     job["tls_config"]["ca_file"] = filename
                 # Certificate and key files for client cert authentication to the server.
                 if (cert_file := tls_config.get("cert_file")) and (
                     key_file := tls_config.get("key_file")
                 ):
-                    filename = f"/etc/prometheus/client-{job['job_name']}.crt"
+                    filename = f"{PROMETHEUS_DIR}/client-{job['job_name']}.crt"
                     certs[filename] = cert_file
                     job["tls_config"]["cert_file"] = filename
-                    filename = f"/etc/prometheus/client-{job['job_name']}.key"
+                    filename = f"{PROMETHEUS_DIR}/client-{job['job_name']}.key"
                     certs[filename] = key_file
                     job["tls_config"]["key_file"] = filename
                 elif "cert_file" in tls_config or "key_file" in tls_config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,7 +6,6 @@
 """A Juju charm for Prometheus on Kubernetes."""
 import hashlib
 import logging
-import os
 import re
 import socket
 from pathlib import Path
@@ -474,7 +473,7 @@ class PrometheusCharm(CharmBase):
         """
         for topology_identifier, rules_file in alerts.items():
             filename = f"juju_{topology_identifier}.rules"
-            path = os.path.join(RULES_DIR, filename)
+            path = f"{RULES_DIR}/{filename}"
 
             rules = yaml.safe_dump(rules_file)
 
@@ -697,7 +696,7 @@ class PrometheusCharm(CharmBase):
         """
         prometheus_config = {
             "global": self._prometheus_global_config(),
-            "rule_files": [os.path.join(RULES_DIR, "juju_*.rules")],
+            "rule_files": [f"{RULES_DIR}/juju_*.rules"],
             "scrape_configs": [],
         }
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -713,17 +713,17 @@ class PrometheusCharm(CharmBase):
                 # Certs are transferred over relation data and need to be written to files on disk.
                 # CA certificate to validate the server certificate with.
                 if ca_file := tls_config.get("ca_file"):
-                    filename = f"{PROMETHEUS_DIR}/{job['job_name']}.crt"
+                    filename = f"{PROMETHEUS_DIR}/{job['job_name']}-ca.crt"
                     certs[filename] = ca_file
                     job["tls_config"]["ca_file"] = filename
                 # Certificate and key files for client cert authentication to the server.
                 if (cert_file := tls_config.get("cert_file")) and (
                     key_file := tls_config.get("key_file")
                 ):
-                    filename = f"{PROMETHEUS_DIR}/client-{job['job_name']}.crt"
+                    filename = f"{PROMETHEUS_DIR}/{job['job_name']}-client.crt"
                     certs[filename] = cert_file
                     job["tls_config"]["cert_file"] = filename
-                    filename = f"{PROMETHEUS_DIR}/client-{job['job_name']}.key"
+                    filename = f"{PROMETHEUS_DIR}/{job['job_name']}-client.key"
                     certs[filename] = key_file
                     job["tls_config"]["key_file"] = filename
                 elif "cert_file" in tls_config or "key_file" in tls_config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -711,10 +711,12 @@ class PrometheusCharm(CharmBase):
             job["honor_labels"] = True
             if tls_config := job.get("tls_config"):
                 # Certs are transferred over relation data and need to be written to files on disk.
+                # CA certificate to validate the server certificate with.
                 if ca_file := tls_config.get("ca_file"):
                     filename = f"/etc/prometheus/{job['job_name']}.crt"
                     certs[filename] = ca_file
                     job["tls_config"]["ca_file"] = filename
+                # Certificate and key files for client cert authentication to the server.
                 if cert_file := tls_config.get("cert_file"):
                     filename = f"/etc/prometheus/client-{job['job_name']}.crt"
                     certs[filename] = cert_file

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -728,7 +728,11 @@ class TestTlsConfig(unittest.TestCase):
                 "static_configs": [
                     {"targets": ["*:80"]},
                 ],
-                "tls_config": {"ca_file": "CERT DATA 2"},
+                "tls_config": {
+                    "ca_file": "CERT DATA 2",
+                    "cert_file": "CLIENT CERT 1",
+                    "key_file": "CLIENT KEY 1",
+                },
             },
         ]
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -708,6 +708,12 @@ class TestTlsConfig(unittest.TestCase):
         self.rel_id = self.harness.add_relation(RELATION_NAME, "provider-app")
         self.harness.add_relation_unit(self.rel_id, "provider-app/0")
 
+        patcher = patch.object(PrometheusCharm, "_get_pvc_capacity")
+        self.mock_capacity = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.harness.set_model_name(self.__class__.__name__)
+        self.mock_capacity.return_value = "1Gi"
+
         self.harness.begin_with_initial_hooks()
         self.harness.container_pebble_ready("prometheus")
 
@@ -721,7 +727,7 @@ class TestTlsConfig(unittest.TestCase):
                 "static_configs": [
                     {"targets": ["*:80"]},
                 ],
-                "tls_config": {"ca_file": "CERT DATA 1"},
+                "tls_config": {"ca_file": "CA 1"},
             },
             {
                 "job_name": "job2",
@@ -729,8 +735,79 @@ class TestTlsConfig(unittest.TestCase):
                     {"targets": ["*:80"]},
                 ],
                 "tls_config": {
-                    "ca_file": "CERT DATA 2",
-                    "cert_file": "CLIENT CERT 1",
+                    "ca_file": "CA 2",
+                    "cert_file": "CLIENT CERT 2",
+                    "key_file": "CLIENT KEY 2",
+                },
+            },
+        ]
+
+        self.harness.update_relation_data(
+            self.rel_id,
+            "provider-app",
+            {
+                "scrape_jobs": json.dumps(scrape_jobs),
+            },
+        )
+        self.harness.update_relation_data(
+            self.rel_id,
+            "provider-app/0",
+            {
+                "prometheus_scrape_unit_address": "1.1.1.1",
+                "prometheus_scrape_unit_name": "provider-app/0",
+            },
+        )
+
+        self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
+        container = self.harness.charm.unit.get_container("prometheus")
+        self.assertEqual(container.pull("/etc/prometheus/job1-ca.crt").read(), "CA 1")
+        self.assertEqual(container.pull("/etc/prometheus/job2-ca.crt").read(), "CA 2")
+        self.assertEqual(container.pull("/etc/prometheus/job2-client.crt").read(), "CLIENT CERT 2")
+        self.assertEqual(container.pull("/etc/prometheus/job2-client.key").read(), "CLIENT KEY 2")
+
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    @patch("prometheus_server.Prometheus.reload_configuration", lambda *_: True)
+    def test_no_tls_config(self, *_):
+        scrape_jobs = [
+            {
+                "job_name": "job1",
+                "static_configs": [
+                    {"targets": ["*:80"]},
+                ],
+            },
+        ]
+
+        self.harness.update_relation_data(
+            self.rel_id,
+            "provider-app",
+            {
+                "scrape_jobs": json.dumps(scrape_jobs),
+            },
+        )
+        self.harness.update_relation_data(
+            self.rel_id,
+            "provider-app/0",
+            {
+                "prometheus_scrape_unit_address": "1.1.1.1",
+                "prometheus_scrape_unit_name": "provider-app/0",
+            },
+        )
+
+        self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
+
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    @patch("prometheus_server.Prometheus.reload_configuration", lambda *_: True)
+    def test_tls_config_missing_cert(self, *_):
+        scrape_jobs = [
+            {
+                "job_name": "job1",
+                "static_configs": [
+                    {"targets": ["*:80"]},
+                ],
+                "tls_config": {
+                    "ca_file": "CA 1",
                     "key_file": "CLIENT KEY 1",
                 },
             },
@@ -752,9 +829,42 @@ class TestTlsConfig(unittest.TestCase):
             },
         )
 
-        container = self.harness.charm.unit.get_container("prometheus")
-        self.assertEqual(container.pull("/etc/prometheus/job1.crt").read(), "CERT DATA 1")
-        self.assertEqual(container.pull("/etc/prometheus/job2.crt").read(), "CERT DATA 2")
+        self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
+
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    @patch("prometheus_server.Prometheus.reload_configuration", lambda *_: True)
+    def test_tls_config_missing_key(self, *_):
+        scrape_jobs = [
+            {
+                "job_name": "job1",
+                "static_configs": [
+                    {"targets": ["*:80"]},
+                ],
+                "tls_config": {
+                    "ca_file": "CA 1",
+                    "cert_file": "CLIENT CERT 1",
+                },
+            },
+        ]
+
+        self.harness.update_relation_data(
+            self.rel_id,
+            "provider-app",
+            {
+                "scrape_jobs": json.dumps(scrape_jobs),
+            },
+        )
+        self.harness.update_relation_data(
+            self.rel_id,
+            "provider-app/0",
+            {
+                "prometheus_scrape_unit_address": "1.1.1.1",
+                "prometheus_scrape_unit_name": "provider-app/0",
+            },
+        )
+
+        self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
 
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")


### PR DESCRIPTION
## Context

The [prometheus2](https://charmhub.io/prometheus2) machine charm supports injecting a TLS [client cert/key](https://git.launchpad.net/charm-prometheus2/tree/src/reactive/prometheus.py#n869) to use when scraping a given target.

This PR adds support for TLS client cert/key (`cert_file`/`key_file`) to the `tls_config` key.

Note: the [LXD charm](https://charmhub.io/lxd) uses that feature when related with `prometheus2` and we'd like to keep using it when related with `prometheus-k8s`.

## Release Notes
Support TLS client authentication when scraping metrics.
