### PR TITLE
chore: avoid noisy warning logging for non-container charms

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1570,7 +1570,8 @@ class MetricsEndpointProvider(Object):
         if not refresh_event:
             # FIXME remove once podspec charms are verified.
             # `self.set_scrape_job_spec()` is called every re-init so this should not be needed.
-            if len(self._charm.meta.containers) == 1:
+            num_containers = len(self._charm.meta.containers)
+            if num_containers == 1:
                 if "kubernetes" in self._charm.meta.series:
                     # This is a podspec charm
                     refresh_event = [self._charm.on.update_status]
@@ -1579,12 +1580,14 @@ class MetricsEndpointProvider(Object):
                     container = list(self._charm.meta.containers.values())[0]
                     refresh_event = [self._charm.on[container.name.replace("-", "_")].pebble_ready]
             else:
-                logger.warning(
-                    "%d containers are present in metadata.yaml and "
-                    "refresh_event was not specified. Defaulting to update_status. "
-                    "Metrics IP may not be set in a timely fashion.",
-                    len(self._charm.meta.containers),
-                )
+                if num_containers:  # avoids noisy logs on non-K8s charms
+                    logger.warning(
+                        "%d containers are present in metadata.yaml and "
+                        "refresh_event was not specified. Defaulting to update_status. "
+                        "Metrics IP may not be set in a timely fashion.",
+                        num_containers,
+                    )
+
                 refresh_event = [self._charm.on.update_status]
 
         else:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

When using cross-model relations between Prometheus on K8s and some machine/VM charm, the warning logs are unbearable if deferring events where this warning gets logged. Example output from `juju debug-log` on a VM charm over a 1m period:

```
unit-zookeeper-0: 16:23:00 WARNING unit.zookeeper/0.juju-log restart:0: 0 containers are present in metadata.yaml and refresh_event was not specified. Defaulting to update_status. Metrics IP may not be set in a timely fashion.
unit-zookeeper-1: 16:23:02 WARNING unit.zookeeper/1.juju-log restart:0: 0 containers are present in metadata.yaml and refresh_event was not specified. Defaulting to update_status. Metrics IP may not be set in a timely fashion.
unit-zookeeper-3: 16:23:02 WARNING unit.zookeeper/3.juju-log restart:0: 0 containers are present in metadata.yaml and refresh_event was not specified. Defaulting to update_status. Metrics IP may not be set in a timely fashion.
unit-zookeeper-2: 16:23:02 WARNING unit.zookeeper/2.juju-log restart:0: 0 containers are present in metadata.yaml and refresh_event was not specified. Defaulting to update_status. Metrics IP may not be set in a timely fashion.
unit-zookeeper-0: 16:23:02 WARNING unit.zookeeper/0.juju-log restart:0: 0 containers are present in metadata.yaml and refresh_event was not specified. Defaulting to update_status. Metrics IP may not be set in a timely fashion.
unit-zookeeper-4: 16:23:02 WARNING unit.zookeeper/4.juju-log restart:0: 0 containers are present in metadata.yaml and refresh_event was not specified. Defaulting to update_status. Metrics IP may not be set in a timely fashion.
unit-zookeeper-1: 16:23:03 WARNING unit.zookeeper/1.juju-log restart:0: 0 containers are present in metadata.yaml and refresh_event was not specified. Defaulting to update_status. Metrics IP may not be set in a timely fashion.
unit-zookeeper-3: 16:23:03 WARNING unit.zookeeper/3.juju-log restart:0: 0 containers are present in metadata.yaml and refresh_event was not specified. Defaulting to update_status. Metrics IP may not be set in a timely fashion.
unit-zookeeper-2: 16:23:03 WARNING unit.zookeeper/2.juju-log restart:0: 0 containers are present in metadata.yaml and refresh_event was not specified. Defaulting to update_status. Metrics IP may not be set in a timely fashion.
unit-zookeeper-4: 16:23:03 WARNING unit.zookeeper/4.juju-log restart:0: 0 containers are present in metadata.yaml and refresh_event was not specified. Defaulting to update_status. Metrics IP may not be set in a timely fashion.
unit-zookeeper-4: 16:23:32 WARNING unit.zookeeper/4.juju-log 0 containers are present in metadata.yaml and refresh_event was not specified. Defaulting to update_status. Metrics IP may not be set in a timely fashion.
unit-zookeeper-4: 16:23:32 WARNING unit.zookeeper/4.juju-log No relation: certificates
unit-zookeeper-1: 16:23:54 WARNING unit.zookeeper/1.juju-log 0 containers are present in metadata.yaml and refresh_event was not specified. Defaulting to update_status. Metrics IP may not be set in a timely fashion.
unit-zookeeper-1: 16:23:54 WARNING unit.zookeeper/1.juju-log No relation: certificates
unit-zookeeper-0: 16:24:16 WARNING unit.zookeeper/0.juju-log 0 containers are present in metadata.yaml and refresh_event was not 
```

## Solution
<!-- A summary of the solution addressing the above issue -->

Check if ANY containers exist in `charm.meta.containers`, if not, skip the `WARNING` log

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

I am not sure the implication of skipping this warning for 'normal' K8s charms that want to deploy without a container. If we want to log the warning there, then this change is probably not a good solution. There may be a more specific way of inferring K8s/VM substrate for charms implementing the library as opposed to just checking for 1+ containers, but it isn't clear to me if `ops` exposes this somewhere.

There are various Juju env-vars that could be useful, `KUBERNETES_*` to identify K8s, or `JUJU_MACHINE_ID` to identify VM, but not sure if they're exposed in `ops`, or if it's worth the effort. Please let me know!

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
N/A

## Release Notes
<!-- A digestable summary of the change in this PR -->
chore: avoid noisy warning logging for non-container charms
