### PR TITLE
Use Juju 3.1 for CI

### DIFF
--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -67,7 +67,6 @@ topology = JujuTopology(
 ```
 
 """
-import warnings
 from collections import OrderedDict
 from typing import Dict, List, Optional
 from uuid import UUID
@@ -76,7 +75,7 @@ from uuid import UUID
 LIBID = "bced1658f20f49d28b88f61f83c2d232"
 
 LIBAPI = 0
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 class InvalidUUIDError(Exception):
@@ -120,11 +119,6 @@ class JujuTopology:
             unit: a unit name as a string
             charm_name: name of charm as a string
         """
-        warnings.warn(
-            "observability_libs.v0.juju_topology is deprecated. Use `pip install cosl` instead",
-            category=DeprecationWarning,
-        )
-
         if not self.is_valid_uuid(model_uuid):
             raise InvalidUUIDError(model_uuid)
 

--- a/tox.ini
+++ b/tox.ini
@@ -122,7 +122,7 @@ lma_bundle_dir = {envtmpdir}/lma-light-bundle
 deps =
     # deps from lma-bundle - these are needed here because will be running pytest on lma-bundle
     jinja2
-    juju ~= 3.0.0
+    juju
     pytest
     pytest-operator
 allowlist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -104,7 +104,7 @@ description = Run integration tests
 deps =
     aiohttp
     deepdiff
-    juju ~= 3.0.0
+    juju
     lightkube >= 0.11
     lightkube-models >= 1.22.0.4
     pytest


### PR DESCRIPTION
## Issue
Use Juju 3.1 to get around the unit termination issue. Update libs.

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
