### PR TITLE
Sync up the `alerts` method in the libraries

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -368,7 +368,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 31
+LIBPATCH = 32
 
 logger = logging.getLogger(__name__)
 
@@ -1125,6 +1125,7 @@ class MetricsEndpointConsumer(Object):
 
         return scrape_jobs
 
+    @property
     def alerts(self) -> dict:
         """Fetch alerts for all relations.
 
@@ -1175,37 +1176,38 @@ class MetricsEndpointConsumer(Object):
             if not alert_rules:
                 continue
 
-            try:
-                scrape_metadata = json.loads(relation.data[relation.app]["scrape_metadata"])
-                identifier = JujuTopology.from_dict(scrape_metadata).identifier
-                alerts[identifier] = self._tool.apply_label_matchers(alert_rules)
+            identifier, topology = self._get_identifier_by_alert_rules(alert_rules)
+            if not topology:
+                try:
+                    scrape_metadata = json.loads(relation.data[relation.app]["scrape_metadata"])
+                    identifier = JujuTopology.from_dict(scrape_metadata).identifier
+                    alerts[identifier] = self._tool.apply_label_matchers(alert_rules)  # type: ignore
 
-            except KeyError as e:
-                logger.debug(
-                    "Relation %s has no 'scrape_metadata': %s",
-                    relation.id,
-                    e,
-                )
-                identifier = self._get_identifier_by_alert_rules(alert_rules)
+                except KeyError as e:
+                    logger.debug(
+                        "Relation %s has no 'scrape_metadata': %s",
+                        relation.id,
+                        e,
+                    )
 
             if not identifier:
                 logger.error(
-                    "Alert rules were found but no usable group or identifier was present"
+                    "Alert rules were found but no usable group or identifier was present."
                 )
+                continue
+
+            _, errmsg = self._tool.validate_alert_rules(alert_rules)
+            if errmsg:
+                relation.data[self._charm.app]["event"] = json.dumps({"errors": errmsg})
                 continue
 
             alerts[identifier] = alert_rules
 
-            _, errmsg = self._tool.validate_alert_rules(alert_rules)
-            if errmsg:
-                if alerts[identifier]:
-                    del alerts[identifier]
-                relation.data[self._charm.app]["event"] = json.dumps({"errors": errmsg})
-                continue
-
         return alerts
 
-    def _get_identifier_by_alert_rules(self, rules: dict) -> Union[str, None]:
+    def _get_identifier_by_alert_rules(
+        self, rules: dict
+    ) -> Tuple[Union[str, None], Union[JujuTopology, None]]:
         """Determine an appropriate dict key for alert rules.
 
         The key is used as the filename when writing alerts to disk, so the structure
@@ -1213,21 +1215,28 @@ class MetricsEndpointConsumer(Object):
 
         Args:
             rules: a dict of alert rules
+        Returns:
+            A tuple containing an identifier, if found, and a JujuTopology, if it could
+            be constructed.
         """
         if "groups" not in rules:
             logger.debug("No alert groups were found in relation data")
-            return None
+            return None, None
 
         # Construct an ID based on what's in the alert rules if they have labels
         for group in rules["groups"]:
             try:
                 labels = group["rules"][0]["labels"]
-                identifier = "{}_{}_{}".format(
-                    labels["juju_model"],
-                    labels["juju_model_uuid"],
-                    labels["juju_application"],
+                topology = JujuTopology(
+                    # Don't try to safely get required constructor fields. There's already
+                    # a handler for KeyErrors
+                    model_uuid=labels["juju_model_uuid"],
+                    model=labels["juju_model"],
+                    application=labels["juju_application"],
+                    unit=labels.get("juju_unit", ""),
+                    charm_name=labels.get("juju_charm", ""),
                 )
-                return identifier
+                return topology.identifier, topology
             except KeyError:
                 logger.debug("Alert rules were found but no usable labels were present")
                 continue
@@ -1238,11 +1247,11 @@ class MetricsEndpointConsumer(Object):
         )
         try:
             for group in rules["groups"]:
-                return group["name"]
+                return group["name"], None
         except KeyError:
             logger.debug("No group name was found to use as identifier")
 
-        return None
+        return None, None
 
     def _static_scrape_config(self, relation) -> list:
         """Generate the static scrape configuration for a single relation.

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1176,6 +1176,8 @@ class MetricsEndpointConsumer(Object):
             if not alert_rules:
                 continue
 
+            alert_rules = self._inject_alert_expr_labels(alert_rules)
+
             identifier, topology = self._get_identifier_by_alert_rules(alert_rules)
             if not topology:
                 try:
@@ -1252,6 +1254,50 @@ class MetricsEndpointConsumer(Object):
             logger.debug("No group name was found to use as identifier")
 
         return None, None
+
+    def _inject_alert_expr_labels(self, rules: Dict[str, Any]) -> Dict[str, Any]:
+        """Iterate through alert rules and inject topology into expressions.
+
+        Args:
+            rules: a dict of alert rules
+        """
+        if "groups" not in rules:
+            return rules
+
+        modified_groups = []
+        for group in rules["groups"]:
+            # Copy off rules, so we don't modify an object we're iterating over
+            rules_copy = group["rules"]
+            for idx, rule in enumerate(rules_copy):
+                labels = rule.get("labels")
+
+                if labels:
+                    try:
+                        topology = JujuTopology(
+                            # Don't try to safely get required constructor fields. There's already
+                            # a handler for KeyErrors
+                            model_uuid=labels["juju_model_uuid"],
+                            model=labels["juju_model"],
+                            application=labels["juju_application"],
+                            unit=labels.get("juju_unit", ""),
+                            charm_name=labels.get("juju_charm", ""),
+                        )
+
+                        # Inject topology and put it back in the list
+                        rule["expr"] = self._tool.inject_label_matchers(
+                            re.sub(r"%%juju_topology%%,?", "", rule["expr"]),
+                            topology.label_matcher_dict,
+                        )
+                    except KeyError:
+                        # Some required JujuTopology key is missing. Just move on.
+                        pass
+
+                    group["rules"][idx] = rule
+
+            modified_groups.append(group)
+
+        rules["groups"] = modified_groups
+        return rules
 
     def _static_scrape_config(self, relation) -> list:
         """Generate the static scrape configuration for a single relation.

--- a/src/charm.py
+++ b/src/charm.py
@@ -449,8 +449,8 @@ class PrometheusCharm(CharmBase):
 
         Returns: A boolean indicating if new or different alert rules were pushed.
         """
-        metrics_consumer_alerts = self.metrics_consumer.alerts()
-        remote_write_alerts = self.remote_write_provider.alerts()
+        metrics_consumer_alerts = self.metrics_consumer.alerts
+        remote_write_alerts = self.remote_write_provider.alerts
         alerts_hash = sha256(str(metrics_consumer_alerts) + str(remote_write_alerts))
         alert_rules_changed = alerts_hash != self._pull(ALERTS_HASH_PATH)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -341,7 +341,7 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
 class TestAlertsFilename(unittest.TestCase):
     REMOTE_SCRAPE_METADATA = {
         "model": "remote-model",
-        "model_uuid": "f299585c-9ac6-4b0c-ae06-46d1be2a7262",
+        "model_uuid": "be44e4b8-32eb-48e1-a843-b1c12e47b9b3",
         "application": "remote-app",
         "charm_name": "remote-charm",
     }
@@ -349,7 +349,7 @@ class TestAlertsFilename(unittest.TestCase):
     LABELED_ALERT_RULES = {
         "groups": [
             {
-                "name": "ZZZ_f2c1b2a6-e006-11eb-ba80-0242ac130004_consumer-tester_alerts",
+                "name": "ZZZ_a5edc336-b02e-4fad-b847-c530500c1c86_consumer-tester_alerts",
                 "rules": [
                     {
                         "alert": "CPUOverUse",
@@ -357,14 +357,14 @@ class TestAlertsFilename(unittest.TestCase):
                         "labels": {
                             "severity": "Low",
                             "juju_model": "ZZZ-model",
-                            "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                            "juju_model_uuid": "a5edc336-b02e-4fad-b847-c530500c1c86",
                             "juju_application": "zzz-app",
                         },
                     },
                 ],
             },
             {
-                "name": "AAA_f2c1b2a6-e006-11eb-ba80-0242ac130004_consumer-tester_alerts",
+                "name": "AAA_a5edc336-b02e-4fad-b847-c530500c1c86_consumer-tester_alerts",
                 "rules": [
                     {
                         "alert": "PrometheusTargetMissing",
@@ -372,7 +372,7 @@ class TestAlertsFilename(unittest.TestCase):
                         "labels": {
                             "severity": "critical",
                             "juju_model": "AAA-model",
-                            "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                            "juju_model_uuid": "a5edc336-b02e-4fad-b847-c530500c1c86",
                             "juju_application": "aaa-app",
                         },
                     },
@@ -441,12 +441,12 @@ class TestAlertsFilename(unittest.TestCase):
             },
         )
 
-        # THEN rules filename is derived from the contents of scrape_metadata
+        # THEN rules filename is derived from the contents of alert labels
         container = self.harness.charm.unit.get_container(self.harness.charm._name)
         files = container.list_files("/etc/prometheus/rules")
         self.assertEqual(
             {file.path for file in files},
-            {"/etc/prometheus/rules/juju_remote-model_f299585c_remote-app.rules"},
+            {"/etc/prometheus/rules/juju_ZZZ-model_a5edc336_zzz-app.rules"},
         )
 
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
@@ -470,9 +470,7 @@ class TestAlertsFilename(unittest.TestCase):
         files = container.list_files("/etc/prometheus/rules")
         self.assertEqual(
             {file.path for file in files},
-            {
-                "/etc/prometheus/rules/juju_ZZZ-model_f2c1b2a6-e006-11eb-ba80-0242ac130004_zzz-app.rules"
-            },
+            {"/etc/prometheus/rules/juju_ZZZ-model_a5edc336_zzz-app.rules"},
         )
 
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
@@ -495,7 +493,7 @@ class TestAlertsFilename(unittest.TestCase):
         files = container.list_files("/etc/prometheus/rules")
         self.assertEqual(
             {file.path for file in files},
-            {"/etc/prometheus/rules/juju_remote-model_f299585c_remote-app.rules"},
+            {"/etc/prometheus/rules/juju_remote-model_be44e4b8_remote-app.rules"},
         )
 
     @patch("charm.KubernetesServicePatch", lambda x, y: None)

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -69,7 +69,7 @@ SCRAPE_JOBS = [
 ALERT_RULES = {
     "groups": [
         {
-            "name": "None_f2c1b2a6-e006-11eb-ba80-0242ac130004_consumer-tester_alerts",
+            "name": "None_a5edc336-b02e-4fad-b847-c530500c1c86_consumer-tester_alerts",
             "rules": [
                 {
                     "alert": "CPUOverUse",
@@ -78,7 +78,7 @@ ALERT_RULES = {
                     "labels": {
                         "severity": "Low",
                         "juju_model": "None",
-                        "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                        "juju_model_uuid": "a5edc336-b02e-4fad-b847-c530500c1c86",
                         "juju_application": "consumer-tester",
                     },
                     "annotations": {
@@ -94,7 +94,7 @@ ALERT_RULES = {
                     "labels": {
                         "severity": "critical",
                         "juju_model": "None",
-                        "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                        "juju_model_uuid": "a5edc336-b02e-4fad-b847-c530500c1c86",
                         "juju_application": "consumer-tester",
                     },
                     "annotations": {
@@ -445,7 +445,7 @@ class TestEndpointConsumer(unittest.TestCase):
         self.harness.add_relation_unit(rel_id, "consumer/0")
         self.assertEqual(self.harness.charm._stored.num_events, 1)
 
-        rules_file = self.harness.charm.prometheus_consumer.alerts()
+        rules_file = self.harness.charm.prometheus_consumer.alerts
         alerts = list(rules_file.values())[0]
 
         alert_names = [x["alert"] for x in alerts["groups"][0]["rules"]]
@@ -470,7 +470,7 @@ class TestEndpointConsumer(unittest.TestCase):
         self.harness.add_relation_unit(rel_id, "consumer/0")
         self.assertEqual(self.harness.charm._stored.num_events, 1)
         with self.assertLogs(level="WARNING") as logger:
-            _ = self.harness.charm.prometheus_consumer.alerts()
+            _ = self.harness.charm.prometheus_consumer.alerts
             messages = logger.output
             self.assertEqual(len(messages), 1)
             self.assertIn(
@@ -491,15 +491,14 @@ class TestEndpointConsumer(unittest.TestCase):
         self.harness.add_relation_unit(rel_id, "consumer/0")
         self.assertEqual(self.harness.charm._stored.num_events, 1)
         with self.assertLogs(level="DEBUG") as logger:
-            _ = self.harness.charm.prometheus_consumer.alerts()
+            _ = self.harness.charm.prometheus_consumer.alerts
             messages = logger.output
-            self.assertIn("Alert rules were found but no usable labels were present", messages[1])
             self.assertIn(
                 "No labeled alert rules were found, and no 'scrape_metadata' "
                 "was available. Using the alert group name as filename.",
-                messages[2],
+                messages[1],
             )
-        alerts = self.harness.charm.prometheus_consumer.alerts()
+        alerts = self.harness.charm.prometheus_consumer.alerts
         self.assertIn("unlabeled_external_cpu_alerts", alerts.keys())
         self.assertEqual(UNLABELED_ALERT_RULES, alerts["unlabeled_external_cpu_alerts"])
 

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -263,7 +263,7 @@ class TestRemoteWriteProvider(unittest.TestCase):
 
         self.harness.add_relation_unit(rel_id, "consumer/0")
 
-        alerts = self.harness.charm.remote_write_provider.alerts()
+        alerts = self.harness.charm.remote_write_provider.alerts
         alerts = list(alerts.values())[0]  # drop the topology identifier
         self.assertEqual(len(alerts), 1)
         self.assertDictEqual(alerts, ALERT_RULES)


### PR DESCRIPTION
## Issue
Make `prometheus_scrape` and `prometheus_remote_write` use the same logic for alerts -- one which prioritizes the labels on alerts (if present) over metadata, since providing charms who use `AlertRules` will have them injected, and we shouldn't clobber them.

`prometheus_remote_write` already does this, but `prometheus_scrape` (and `loki_push_api`) would otherwise overwrite forwarded rules with possibly misleading/meaningless data.

Make all of the UUIDs in the tests valid.

Fix a couple of tests with the trimmed JujuTopology-style identifier, as it's always used now.