### PR TITLE
correctly enable remote write flag

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -498,7 +498,7 @@ class PrometheusCharm(CharmBase):
         args.append(f"--web.external-url={external_url}")
 
         if self.model.relations[DEFAULT_REMOTE_WRITE_RELATION_NAME]:
-            args.append("--enable-feature=remote-write-receiver")
+            args.append("--web.enable-remote-write-receiver")
 
         args.append(f"--log.level={self.log_level}")
 


### PR DESCRIPTION
## Issue
Resolves #455.

## Solution
As suggested in the issue, change the remote-write-receiver flag to the newer one.

## Testing Instructions
* pack and delpoy the charm
* `kubectl logs prometheus/0`
* verify the absence of the `warn` message described in the issue

## Release Notes
Update the *remote-write enabling flag* from the deprecated one.
