### PR TITLE
Add diagnostics tox env

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Relation provider                Requirer                         Interface     
 prometheus-k8s:prometheus-peers  prometheus-k8s:prometheus-peers  prometheus_peers  peer
 ```
 
+To run diagnostics on a running deployment,
+
+```bash
+tox -e diag -- prom/0
+```
 
 ### Accessing the Prometheus User Interface
 

--- a/tests/diagnostics.sh
+++ b/tests/diagnostics.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# $1 = prometheus unit name, e.g. prom/0
+
+if [[ $# -ne 1 ]]; then
+  echo "Invalid number of arguments."
+  echo "Usage:   diagnostics prom/0"
+  return 1
+fi
+
+UNIT=$1
+API_ENDPOINT=$(juju exec --unit $UNIT -- PEBBLE_SOCKET=/charm/containers/prometheus/pebble.socket pebble plan | grep -oP -- '--web.external-url=\K[^ ]+')
+
+echo "Alert rules present from the following juju_applications:"
+curl -s "$API_ENDPOINT/api/v1/rules" | jq | grep -oP -- '"juju_application": "\K[^"]+' | sort | uniq
+
+echo
+
+echo "Metrics present from the following 'metrics groups':"
+curl -s --data-urlencode 'match[]={__name__=~".+"}' "$API_ENDPOINT/api/v1/series" | jq -r '.data[].__name__' | cut -d'_' -f1 | sort | uniq | tr '\n' ','
+echo

--- a/tests/diagnostics.sh
+++ b/tests/diagnostics.sh
@@ -9,14 +9,35 @@ if [[ $# -ne 1 ]]; then
   return 1
 fi
 
-UNIT=$1
-API_ENDPOINT=$(juju exec --unit $UNIT -- PEBBLE_SOCKET=/charm/containers/prometheus/pebble.socket pebble plan | grep -oP -- '--web.external-url=\K[^ ]+')
+UNIT="$1"
+
+# The following commented out two checks won't work with ingress because of the path
+
+#echo "Checking reachability via localhost"
+#juju ssh "$UNIT" curl localhost:9090/-/ready
+#
+#echo
+#
+#echo "Checking reachability via pod ip"
+#POD_IP="$(juju status --format json | jq -r ".applications[].units.\"$UNIT\".address" | grep -v 'null')"
+#echo "Pod IP: $POD_IP"
+#curl "$POD_IP:9090/-/ready"
+#
+#echo
+
+echo "Checking reachability via external URL"
+API_ENDPOINT=$(juju exec --unit "$UNIT" -- PEBBLE_SOCKET=/charm/containers/prometheus/pebble.socket pebble plan | grep -oP -- '--web.external-url=\K[^ ]+')
+echo "External URL: $API_ENDPOINT"
+# Need to use juju ssh because if the external url is the fqdn, it won't be reachable from the host
+juju ssh "$UNIT" curl "$API_ENDPOINT/-/ready"
+
+echo
 
 echo "Alert rules present from the following juju_applications:"
-curl -s "$API_ENDPOINT/api/v1/rules" | jq | grep -oP -- '"juju_application": "\K[^"]+' | sort | uniq
+juju ssh "$UNIT" curl -s "$API_ENDPOINT/api/v1/rules" | jq | grep -oP -- '"juju_application": "\K[^"]+' | sort | uniq
 
 echo
 
 echo "Metrics present from the following 'metrics groups':"
-curl -s --data-urlencode 'match[]={__name__=~".+"}' "$API_ENDPOINT/api/v1/series" | jq -r '.data[].__name__' | cut -d'_' -f1 | sort | uniq | tr '\n' ','
+juju ssh "$UNIT" curl -s --data-urlencode 'match[]={__name__=~\".+\"}' "$API_ENDPOINT/api/v1/series" | jq -r '.data[].__name__' | cut -d'_' -f1 | sort | uniq | tr '\n' ','
 echo

--- a/tox.ini
+++ b/tox.ini
@@ -114,8 +114,6 @@ deps =
     tenacity
 commands =
     pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {toxinidir}/tests/integration
-allowlist_externals =
-    /usr/bin/env
 
 [testenv:integration-lma]
 description = Run lma bundle integration tests but with prometheus built from source
@@ -133,3 +131,10 @@ commands =
     # run pytest on the integration tests of the lma bundle, but override alertmanager with path to
     # this source dir
     pytest -v --tb native --log-cli-level=INFO -s --prometheus={toxinidir} {posargs} {[testenv:integration-lma]lma_bundle_dir}/tests/integration
+
+[testenv:diag]
+description = Run diagnostics on a running deployment
+allowlist_externals =
+    /usr/bin/env
+commands =
+    /usr/bin/env bash {toxinidir}/tests/diagnostics.sh {posargs}


### PR DESCRIPTION
## Issue
When doing manual tests, I keep using the same lengthy commands over and over.


## Solution
Add a diagnostics script to output all the interesting integration-related content.


## Context
Came up in during work on https://github.com/canonical/grafana-agent-k8s-operator/pull/160.


## Testing Instructions
`tox -e diag -- prom/0`


## Release Notes
Add diagnostics tox env.
