### PR TITLE
use ruff instead of flake8

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -45,7 +45,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 15
 
 
 logger = logging.getLogger(__name__)
@@ -407,7 +407,7 @@ def _validate_relation_by_interface_and_direction(
     if relation_name not in charm.meta.relations:
         raise RelationNotFoundError(relation_name)
 
-    relation = charm.meta.relations[relation_name]  # type: RelationMeta
+    relation: RelationMeta = charm.meta.relations[relation_name]
 
     actual_relation_interface = relation.interface_name
     if actual_relation_interface != expected_relation_interface:
@@ -609,6 +609,7 @@ class PrometheusRemoteWriteConsumer(Object):
             charm: The charm object that instantiated this class.
             relation_name: Name of the relation with the `prometheus_remote_write` interface as
                 defined in metadata.yaml.
+            alert_rules_path: Path of the directory containing the alert rules.
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -370,7 +370,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 35
+LIBPATCH = 36
 
 logger = logging.getLogger(__name__)
 
@@ -715,13 +715,12 @@ def _type_convert_stored(obj):
     """Convert Stored* to their appropriate types, recursively."""
     if isinstance(obj, StoredList):
         return list(map(_type_convert_stored, obj))
-    elif isinstance(obj, StoredDict):
+    if isinstance(obj, StoredDict):
         rdict = {}  # type: Dict[Any, Any]
         for k in obj.keys():
             rdict[k] = _type_convert_stored(obj[k])
         return rdict
-    else:
-        return obj
+    return obj
 
 
 def _validate_relation_by_interface_and_direction(
@@ -1440,7 +1439,7 @@ def _dedupe_job_names(jobs: List[dict]):
                 job["job_name"] = "{}_{}".format(job["job_name"], hashed)
     new_jobs = []
     for key in jobs_dict:
-        new_jobs.extend([i for i in jobs_dict[key]])
+        new_jobs.extend(list(jobs_dict[key]))
 
     # Deduplicate jobs which are equal
     # Again this in O(n^2) but it should be okay
@@ -1796,8 +1795,7 @@ class MetricsEndpointProvider(Object):
         jobs = self._jobs if self._jobs else [DEFAULT_JOB]
         if callable(self._lookaside_jobs):
             return jobs + PrometheusConfig.sanitize_scrape_configs(self._lookaside_jobs())
-        else:
-            return jobs
+        return jobs
 
     @property
     def _scrape_metadata(self) -> dict:
@@ -2078,6 +2076,7 @@ class MetricsEndpointAggregator(Object):
         Args:
             targets: a `dict` containing target information
             app_name: a `str` identifying the application
+            kwargs: a `dict` of the extra arguments passed to the function
         """
         if not self._charm.unit.is_leader():
             return
@@ -2203,6 +2202,7 @@ class MetricsEndpointAggregator(Object):
                 "port".
             application_name: a string name of the application for
                 which this static scrape job is being constructed.
+            kwargs: a `dict` of the extra arguments passed to the function
 
         Returns:
             A dictionary corresponding to a Prometheus static scrape

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 [tool.ruff.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
-max-complexity = 10
-
 [tool.mypy]
 pretty = true
 python_version = 3.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,25 +13,22 @@ show_missing = true
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107", "E203"]
+ignore = ["E501", "D107", "RET504", "C901"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
 
 [tool.mypy]
 pretty = true

--- a/src/charm.py
+++ b/src/charm.py
@@ -57,7 +57,6 @@ from ops.model import (
 )
 from ops.pebble import Error as PebbleError
 from ops.pebble import ExecError, Layer
-
 from prometheus_server import Prometheus
 from utils import convert_k8s_quantity_to_legacy_binary_gigabytes
 
@@ -407,7 +406,7 @@ class PrometheusCharm(CharmBase):
                 logger.error("Prometheus failed to reload the configuration")
                 self.unit.status = early_return_statuses["cfg_load_fail"]
                 return
-            elif reloaded == "read_timeout":
+            if reloaded == "read_timeout":
                 self.unit.status = early_return_statuses["cfg_load_timeout"]
                 return
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -15,8 +15,8 @@ def convert_k8s_quantity_to_legacy_binary_gigabytes(
     """Convert a K8s quantity string to legacy binary notation in GB, which prometheus expects.
 
     Args:
-        capacity, a storage quantity in K8s notation.
-        multiplier, an optional convenience argument for scaling capacity.
+        capacity: a storage quantity in K8s notation.
+        multiplier: an optional convenience argument for scaling capacity.
 
     Returns:
         The capacity, multiplied by `multiplier`, in Prometheus GB (legacy binary) notation.

--- a/tests/integration/test_prometheus_scrape_multiunit.py
+++ b/tests/integration/test_prometheus_scrape_multiunit.py
@@ -218,7 +218,7 @@ async def test_upgrade_prometheus(ops_test: OpsTest, prometheus_charm):
     up_after = [int(next(iter(response))["value"][1]) for response in up_after]
     # The count after an upgrade must be greater than or equal to the count before the upgrade, for
     # every prometheus unit (units start at different times so the count across units may differ).
-    assert all([up_before[i] <= up_after[i] for i in range(num_units)])
+    assert all(up_before[i] <= up_after[i] for i in range(num_units))
 
 
 @pytest.mark.xfail

--- a/tests/integration/test_remote_write_grafana_agent.py
+++ b/tests/integration/test_remote_write_grafana_agent.py
@@ -78,7 +78,7 @@ async def test_remote_write_with_grafana_agent(
     topology_labels = [
         f'{k}="{v}"' for k, v in tester_rules["labels"].items() if k.startswith("juju_")
     ]
-    assert all([field in expr for field in topology_labels])
+    assert all(field in expr for field in topology_labels)
 
     assert await has_metric(
         ops_test,

--- a/tests/integration/test_resource_limits.py
+++ b/tests/integration/test_resource_limits.py
@@ -25,7 +25,7 @@ resched_timeout = 600
 
 CONFIG = yaml.safe_load(Path("./config.yaml").read_text())
 default_limits = None
-default_requests = dict(cpu="0.25", memory="200Mi")
+default_requests = {"cpu": "0.25", "memory": "200Mi"}
 
 
 async def test_setup_env(ops_test: OpsTest):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,11 +10,10 @@ from unittest.mock import patch
 
 import ops
 import yaml
+from charm import PROMETHEUS_CONFIG, PrometheusCharm
 from helpers import cli_arg, k8s_resource_multipatch, prom_multipatch
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
-
-from charm import PROMETHEUS_CONFIG, PrometheusCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_charm_status.py
+++ b/tests/unit/test_charm_status.py
@@ -8,12 +8,11 @@ import unittest
 from unittest.mock import Mock, patch
 
 import ops
+from charm import PrometheusCharm
 from helpers import k8s_resource_multipatch, patch_network_get, prom_multipatch
 from ops.model import ActiveStatus, BlockedStatus
 from ops.pebble import Change, ChangeError, ChangeID
 from ops.testing import Harness
-
-from charm import PrometheusCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -254,7 +254,7 @@ class TestEndpointConsumer(unittest.TestCase):
             relabel_config = relabel_configs[0]
             self.assertGreaterEqual(
                 set(relabel_config.get("source_labels")),
-                set(["juju_model", "juju_model_uuid", "juju_application"]),
+                {"juju_model", "juju_model_uuid", "juju_application"},
             )
 
     def test_consumer_notifies_on_new_scrape_relation(self):

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -5,6 +5,7 @@ import json
 import unittest
 from unittest.mock import patch
 
+from charm import Prometheus, PrometheusCharm
 from charms.prometheus_k8s.v0.prometheus_remote_write import (
     DEFAULT_RELATION_NAME as RELATION_NAME,
 )
@@ -25,8 +26,6 @@ from ops import framework
 from ops.charm import CharmBase
 from ops.model import ActiveStatus
 from ops.testing import Harness
-
-from charm import Prometheus, PrometheusCharm
 
 METADATA = f"""
 name: consumer-tester

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -4,7 +4,6 @@
 import unittest
 
 import responses
-
 from prometheus_server import Prometheus
 
 

--- a/tests/unit/test_web_external_url.py
+++ b/tests/unit/test_web_external_url.py
@@ -8,10 +8,9 @@ from unittest.mock import patch
 
 import ops
 import yaml
+from charm import PROMETHEUS_CONFIG, PrometheusCharm
 from helpers import cli_arg, k8s_resource_multipatch, patch_network_get, prom_multipatch
 from ops.testing import Harness
-
-from charm import PROMETHEUS_CONFIG, PrometheusCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 logger = logging.getLogger(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -31,30 +31,21 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
+    ruff
     codespell
-    # Pinned until pyproject-flake8 supports flake8 >= 5
-    flake8 < 5
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
 commands =
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv* --skip .mypy_cache
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib,unit,integration}]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same, the only difference being two new rules being ignored (which weren't checked before anyway): 
* `C901: Function is too complex`, which I excluded as we were not checking it before either (an eventual refactor should have its own PR);
* `RET504: Unnecessary variable assignment before return statement`, which we do everywhere as it increases readability.