### PR TITLE
Add `docs` entry pointing to discourse

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,6 +20,7 @@ description: |
 website: https://charmhub.io/prometheus-k8s
 source: https://github.com/canonical/prometheus-k8s-operator
 issues: https://github.com/canonical/prometheus-k8s-operator/issues
+docs: https://discourse.charmhub.io/t/prometheus-k8s-docs-index/5803
 
 containers:
   prometheus:


### PR DESCRIPTION
## Issue
Prometheus docs on charmhub weren't rendered from discourse.


## Solution
Add link to discourse.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
Add `docs` entry pointing to discourse.
