### PR TITLE
Add yaml linting

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+extends: default
+
+rules:
+  line-length:
+    max: 99
+    level: warning
+  document-start: disable
+  indentation: disable
+  trailing-spaces: disable
+  empty-lines: disable

--- a/tox.ini
+++ b/tox.ini
@@ -42,11 +42,16 @@ deps =
     black
     ruff
     codespell
+    yamllint
+allowlist_externals =
+    sh
 commands =
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv* --skip .mypy_cache
     ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
+    yamllint .
+    sh -c "yamllint {toxinidir}/src/prometheus_alert_rules/*"
 
 [testenv:static-{charm,lib,unit,integration}]
 description = Run static analysis checks


### PR DESCRIPTION
## Issue
YAML files aren't linted.


## Solution
Lint YAML files.


## Context
Using yamllint may be obviated when:
- `charmcraft analyze` is fixed -- https://github.com/canonical/observability/issues/21
- rule validation is implemented -- https://github.com/canonical/observability/pull/22


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
Add yaml linting.
