### PR TITLE
Add authorization to allowed scrape jobs keys

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -391,6 +391,7 @@ ALLOWED_KEYS = {
     "scheme",
     "basic_auth",
     "tls_config",
+    "authorization",
 }
 DEFAULT_JOB = {
     "metrics_path": "/metrics",

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -370,7 +370,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 36
+LIBPATCH = 37
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Scrape jobs that require a bearer token for authorization must provide it via the `authorization` configuration field, see https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config


## Solution
<!-- A summary of the solution addressing the above issue -->

Allow passing `authorization` field to the scrape jobs

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

This is required for properly defining scrape jobs in the MicroK8s charm, otherwise the bearer token gets dropped and the metrics endpoints cannot be scraped.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Pass a scrape job with a set `authorization` field. Did not see any existing unit tests for scrape job sanitization, so I did not go through the effort to add one.

## Release Notes
<!-- A digestable summary of the change in this PR -->

Add authorization in the allowlist for scrape jobs configuration