### PR TITLE
do not add default metrics if lookaside jobs not empty

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1793,10 +1793,10 @@ class MetricsEndpointProvider(Object):
            A list of dictionaries, where each dictionary specifies a
            single scrape job for Prometheus.
         """
-        jobs = self._jobs if self._jobs else [DEFAULT_JOB]
+        jobs = self._jobs or []
         if callable(self._lookaside_jobs):
-            return jobs + PrometheusConfig.sanitize_scrape_configs(self._lookaside_jobs())
-        return jobs
+            jobs.extend(PrometheusConfig.sanitize_scrape_configs(self._lookaside_jobs()))
+        return jobs or [DEFAULT_JOB]
 
     @property
     def _scrape_metadata(self) -> dict:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

`MetricsEndpointProvider` supports a callable function to generate the jobs dynamically. If no static jobs are set, the default scrape job is always added to the scrape jobs.

```
self._jobs = self._jobs if self._jobs else [DEFAULT_JOB]
```

## Solution
<!-- A summary of the solution addressing the above issue -->

Only return the default job if no static jobs and no lookaside jobs are defined

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

https://github.com/canonical/charm-microk8s/pull/88

I have assumed that the `[DEFAULT_JOB]` is just a default fallback, so I do not expect that it should be added in this case. Setting the jobs to an empty list is still adding the default job.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

## Release Notes
<!-- A digestable summary of the change in this PR -->

Do not add a default scrape job if there are lookaside jobs