### PR TITLE
fix prometheus library for cos-proxy

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -2264,7 +2264,6 @@ class MetricsEndpointAggregator(Object):
                 logger.debug("Could not perform DNS lookup for %s", target["hostname"])
                 dns_name = target["hostname"]
             extra_info["dns_name"] = dns_name
-        re.compile(r'(?P<label>juju.*?)="(?P<value>.*?)",?')
 
         return extra_info
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -343,9 +343,7 @@ import tempfile
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
-from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
-from urllib.request import urlopen
 
 import yaml
 from charms.observability_libs.v0.juju_topology import JujuTopology
@@ -370,7 +368,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 38
+LIBPATCH = 39
 
 logger = logging.getLogger(__name__)
 
@@ -2266,16 +2264,8 @@ class MetricsEndpointAggregator(Object):
                 logger.debug("Could not perform DNS lookup for %s", target["hostname"])
                 dns_name = target["hostname"]
             extra_info["dns_name"] = dns_name
-        label_re = re.compile(r'(?P<label>juju.*?)="(?P<value>.*?)",?')
+        re.compile(r'(?P<label>juju.*?)="(?P<value>.*?)",?')
 
-        try:
-            with urlopen(f'http://{target["hostname"]}:{target["port"]}/metrics') as resp:
-                data = resp.read().decode("utf-8").splitlines()
-                for metric in data:
-                    for match in label_re.finditer(metric):
-                        extra_info[match.group("label")] = match.group("value")
-        except (HTTPError, URLError, OSError, ConnectionResetError, Exception) as e:
-            logger.debug("Could not scrape target: %s", e)
         return extra_info
 
     @property


### PR DESCRIPTION
## Issue
Tied to https://github.com/canonical/cos-proxy-operator/issues/72.

**The modified code is only used by COS Proxy.** While not entirely sure what this piece of code was supposed to do, it currently doesn't do anything (except failing).

What happens is that when COS Proxy defines a Prometheus scrape job (for Prometheus to scrape COS Proxy), we:
1. set the target to the NRPE endpoint;
2. relabel `__address__` so the scrape actually happens on COS Proxy instead.

However, the `_static_config_extra_labels()` function doesn't see the relabeling, and tries to scrape `<nrpe-endpoint>:5666/metrics`, which doesn't make sense as that's not an HTTP endpoint at all.

It seems like this part of code it's trying to get some topology information from somewhere (there are no metrics there), but it doesn't affect what is currently there as it just fails. This has been manually tested and verified.


## Solution
Remove the offending code.