### PR TITLE
fix: only add TLS config if cert file has been written to disk

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -411,9 +411,11 @@ class PrometheusCharm(CharmBase):
 
         self.grafana_source_provider.update_source(self.external_url)
         self._configure(_)
-        if isinstance(self.unit.status, WaitingStatus) and self.unit.status.message == "Waiting for TLS certificates to be written to file":
+        if (
+            isinstance(self.unit.status, WaitingStatus)
+            and self.unit.status.message == "Waiting for TLS certificates to be written to file"
+        ):
             self.unit.status = ActiveStatus()
-
 
     def _configure(self, _):
         """Reconfigure and either reload or restart Prometheus.
@@ -904,7 +906,9 @@ class PrometheusCharm(CharmBase):
             # expected to happen as soon as the the related CA replies with a cert.
             self.stop()
             if isinstance(self.unit.status, ActiveStatus):
-                self.unit.status = WaitingStatus("Waiting for TLS certificates to be written to file")
+                self.unit.status = WaitingStatus(
+                    "Waiting for TLS certificates to be written to file"
+                )
         else:
             if web_config := self._web_config():
                 self._push(WEB_CONFIG_PATH, yaml.safe_dump(web_config))

--- a/src/charm.py
+++ b/src/charm.py
@@ -789,7 +789,7 @@ class PrometheusCharm(CharmBase):
 
         Ref: https://prometheus.io/docs/prometheus/latest/configuration/https/
         """
-        if self._is_tls_enabled():
+        if self._is_tls_enabled() and self.container.exists(CERT_PATH):
             return {
                 "tls_server_config": {
                     "cert_file": CERT_PATH,

--- a/src/charm.py
+++ b/src/charm.py
@@ -795,6 +795,8 @@ class PrometheusCharm(CharmBase):
         """
         if self._is_tls_enabled():
             if not self.container.exists(CERT_PATH):
+                # After a `stop`, the service will autostart on next call to `_configure`, which is
+                # expected to happen as soon as the the related CA replies with a cert.
                 self.stop()
             else:
                 return {

--- a/src/charm.py
+++ b/src/charm.py
@@ -794,15 +794,15 @@ class PrometheusCharm(CharmBase):
         Ref: https://prometheus.io/docs/prometheus/latest/configuration/https/
         """
         if self._is_tls_enabled():
-            if self.container.exists(CERT_PATH):
+            if not self.container.exists(CERT_PATH):
+                self.stop()
+            else:
                 return {
                     "tls_server_config": {
                         "cert_file": CERT_PATH,
                         "key_file": KEY_PATH,
                     }
                 }
-            else:
-                self.stop()
         return None
 
     def _alerting_config(self) -> dict:


### PR DESCRIPTION
## Issue
Fixes #506.

This likely happens when `_configure()` is called by something other than `_on_server_cert_changed` (e.g., a perfectly timed `update-status`), but when the certificate is already in relation data (or Prometheus has already been related through the `certificates` interface but the certificate is not ready yet).


## Solution
Only add the `tls_server_config` for Prometheus if the certificate exists on the file sytstem.

The `_configure()` method is also called by `_on_server_cert_changed()`, which (sequentially) writes the cert to disk before calling `_configure()`. This means we don't risk skip adding the TLS configuration with this extra check.


## Testing Instructions
It's pretty much a race condition, so it's hard to add a test for it. I guess trying to replicate the issue is something, though of course it doesn't guarantee it.


## Release Notes
Only add the `tls_server_config` for Prometheus if the certificate exists on the file sytstem.
