### PR TITLE
feat: remote_write_receiver option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -72,8 +72,3 @@ options:
       automatically deduced from it).
       See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
     type: string
-  remote_write_receiver:
-    description: |
-      enforce the remote-write-receiver feature
-    type: boolean
-    default: false

--- a/config.yaml
+++ b/config.yaml
@@ -72,3 +72,8 @@ options:
       automatically deduced from it).
       See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
     type: string
+  remote_write_receiver:
+    description: |
+      enforce the remote-write-receiver feature
+    type: boolean
+    default: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -667,10 +667,7 @@ class PrometheusCharm(CharmBase):
         args.append(f"--web.external-url={external_url}")
         args.append("--web.route-prefix=/")
 
-        if self.model.relations[DEFAULT_REMOTE_WRITE_RELATION_NAME] or config.get(
-            "remote_write_receiver"
-        ):
-            args.append("--web.enable-remote-write-receiver")
+        args.append("--web.enable-remote-write-receiver")
 
         args.append(f"--log.level={self.log_level}")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -667,7 +667,9 @@ class PrometheusCharm(CharmBase):
         args.append(f"--web.external-url={external_url}")
         args.append("--web.route-prefix=/")
 
-        if self.model.relations[DEFAULT_REMOTE_WRITE_RELATION_NAME]:
+        if self.model.relations[DEFAULT_REMOTE_WRITE_RELATION_NAME] or config.get(
+            "remote_write_receiver"
+        ):
             args.append("--web.enable-remote-write-receiver")
 
         args.append(f"--log.level={self.log_level}")


### PR DESCRIPTION
## Issue
the juju cos setup cannot receive data from the grafana-agent if the grafana-agent is not running inside juju.



## Solution
Add a charm option to enable the remote `remote_write_receiver` feature even when no relation is established.


## Context
IoT devices cannot run juju due to resources constraint, so they must run grafana-agent snap standalone.
This way the COS stack can be used on servers and snaps can be used on devices to export data.


## Notes

This is a draft PR as a suggestion as I am exploring the usage of COS for robots.
The PR is based on my recent learning of Juju/Charm and COS.
