### PR TITLE
Force gagent series to jammy

### DIFF
--- a/tests/integration/test_remote_write_grafana_agent.py
+++ b/tests/integration/test_remote_write_grafana_agent.py
@@ -41,6 +41,7 @@ async def test_remote_write_with_grafana_agent(
             "grafana-agent-k8s",
             application_name=agent_name,
             channel="edge",
+            series="jammy",
         ),
         ops_test.model.deploy(
             prometheus_tester_charm,

--- a/tests/integration/test_resource_limits.py
+++ b/tests/integration/test_resource_limits.py
@@ -42,7 +42,8 @@ async def test_build_and_deploy(ops_test: OpsTest, prometheus_charm):
         trust=True,
     )
 
-    await ops_test.model.wait_for_idle(status="active", timeout=deploy_timeout)
+    await ops_test.model.wait_for_idle(status="active", timeout=deploy_timeout, raise_on_error=False)
+    await ops_test.model.wait_for_idle(status="active")
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
## Issue
The grafana-agent itest fails in CI.
https://github.com/canonical/grafana-agent-k8s-operator/issues/245


## Solution
Force grafana agent series to jammy.


## Context
See "Context" section in https://github.com/canonical/grafana-agent-k8s-operator/pull/242.


## Testing Instructions
`tox -e integration -- -k test_remote_write_grafana_agent`


## Release Notes
Force gagent series to jammy in itest.
