### PR TITLE
Fix handling of tls config

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 34
+LIBPATCH = 35
 
 logger = logging.getLogger(__name__)
 
@@ -1195,6 +1195,7 @@ class GrafanaDashboardProvider(Object):
                 `grafana_dashboaard` relationship is joined
         """
         if self._charm.unit.is_leader():
+            self._update_all_dashboards_from_dir()
             self._upset_dashboards_on_relation(event.relation)
 
     def _on_grafana_dashboard_relation_changed(self, event: RelationChangedEvent) -> None:

--- a/lib/charms/tempo_k8s/v0/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v0/charm_tracing.py
@@ -313,7 +313,7 @@ def trace_charm(
     method calls on instances of this class.
 
     Usage:
-    >>> from charms.tempo_k8s.v0.charm_tracing import trace_charm
+    >>> from charms.tempo_k8s.v0.charm_instrumentation import trace_charm
     >>> from charms.tempo_k8s.v0.tracing import TracingEndpointProvider
     >>> from ops import CharmBase
     >>>
@@ -370,7 +370,7 @@ def _autoinstrument(
 
     Usage:
 
-    >>> from charms.tempo_k8s.v0.charm_tracing import _autoinstrument
+    >>> from charms.tempo_k8s.v0.charm_instrumentation import _autoinstrument
     >>> from ops.main import main
     >>> _autoinstrument(
     >>>         MyCharm,

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -77,4 +77,4 @@ resources:
   prometheus-image:
     type: oci-image
     description: Container image for Prometheus
-    upstream-source: ghcr.io/canonical/prometheus:latest
+    upstream-source: ghcr.io/canonical/prometheus:dev

--- a/src/charm.py
+++ b/src/charm.py
@@ -401,7 +401,6 @@ class PrometheusCharm(CharmBase):
         )
 
     def _is_tls_ready(self) -> bool:
-        # self._update_cert()  # This setter has side effects to avoid code ordering issues.
         return (
             self.container.can_connect()
             and self.container.exists(CERT_PATH)

--- a/src/charm.py
+++ b/src/charm.py
@@ -143,8 +143,6 @@ class PrometheusCharm(CharmBase):
             relation_name="alertmanager",
         )
 
-        urlparse(self.external_url)
-
         self._scraping = MetricsEndpointProvider(
             self,
             relation_name="self-metrics-endpoint",

--- a/src/charm.py
+++ b/src/charm.py
@@ -133,7 +133,7 @@ class PrometheusCharm(CharmBase):
             port=self._port,
             strip_prefix=True,
             redirect_https=True,
-            scheme=lambda: "https" if self._is_cert_available() else "http",
+            scheme=lambda: "https" if self._is_tls_ready() else "http",
         )
 
         self._topology = JujuTopology.from_charm(self)
@@ -307,7 +307,7 @@ class PrometheusCharm(CharmBase):
             ],
         }
 
-        if self._is_cert_available():
+        if self._is_tls_ready():
             config.update(
                 {
                     "scheme": "https",
@@ -322,7 +322,7 @@ class PrometheusCharm(CharmBase):
     @property
     def internal_url(self) -> str:
         """Returns workload's FQDN. Used for ingress."""
-        scheme = "https" if self._is_cert_available() else "http"
+        scheme = "https" if self._is_tls_ready() else "http"
         return f"{scheme}://{socket.getfqdn()}:{self._port}"
 
     @property

--- a/tests/manual/bundle_1_tls.yaml
+++ b/tests/manual/bundle_1_tls.yaml
@@ -1,0 +1,16 @@
+bundle: kubernetes
+applications:
+  ca:
+    charm: self-signed-certificates
+    channel: edge
+    scale: 1
+  prom:
+    charm: ../../prometheus-k8s_ubuntu-20.04-amd64.charm
+    series: focal
+    scale: 1
+    trust: true
+    resources:
+        prometheus-image: ghcr.io/canonical/prometheus:dev
+relations:
+- - ca:certificates
+  - prom:certificates

--- a/tests/manual/bundle_2_e2e_tls.yaml
+++ b/tests/manual/bundle_2_e2e_tls.yaml
@@ -1,0 +1,32 @@
+bundle: kubernetes
+applications:
+  ca:
+    charm: self-signed-certificates
+    channel: edge
+    scale: 1
+  cat:
+    charm: catalogue-k8s
+    channel: edge
+    series: focal
+    scale: 1
+  prom:
+    charm: ../../prometheus-k8s_ubuntu-20.04-amd64.charm
+    series: focal
+    scale: 1
+    trust: true
+    resources:
+        prometheus-image: ghcr.io/canonical/prometheus:dev
+  trfk:
+    charm: traefik-k8s
+    channel: edge
+    series: focal
+    scale: 1
+relations:
+- - cat:catalogue
+  - prom:catalogue
+- - ca:certificates
+  - prom:certificates
+- - prom:ingress
+  - trfk:ingress-per-unit
+- - trfk:certificates
+  - ca:certificates

--- a/tests/scenario/helpers.py
+++ b/tests/scenario/helpers.py
@@ -1,11 +1,15 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from scenario import Container, Context, Network, PeerRelation, Relation, State
+from scenario import Container, Context, ExecOutput, Network, PeerRelation, Relation, State
 
 
 def begin_with_initial_hooks_isolated(context: Context, *, leader: bool = True) -> State:
-    container = Container("prometheus", can_connect=False)
+    container = Container(
+        "prometheus",
+        can_connect=False,
+        exec_mock={("update-ca-certificates", "--fresh"): ExecOutput(return_code=0, stdout="")},
+    )
     state = State(containers=[container])
     peer_rel = PeerRelation("prometheus-peers")
 

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -218,6 +218,7 @@ class TestRemoteWriteProvider(unittest.TestCase):
     def setUp(self, *unused):
         self.harness = Harness(PrometheusCharm)
         self.harness.set_model_info("lma", "12de4fae-06cc-4ceb-9089-567be09fec78")
+        self.harness.handle_exec("prometheus", ["update-ca-certificates", "--fresh"], result=0)
         self.addCleanup(self.harness.cleanup)
 
         patcher = patch.object(PrometheusCharm, "_get_pvc_capacity")

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1,0 +1,66 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import patch
+
+from charm import Prometheus, PrometheusCharm
+from helpers import (
+    k8s_resource_multipatch,
+    patch_network_get,
+    prom_multipatch,
+)
+from ops.testing import Harness
+
+
+@prom_multipatch
+class TestTls(unittest.TestCase):
+    @prom_multipatch
+    def setUp(self, *unused):
+        self.harness = Harness(PrometheusCharm)
+        self.harness.set_model_info("lma", "12de4fae-06cc-4ceb-9089-567be09fec78")
+        self.harness.handle_exec("prometheus", ["update-ca-certificates", "--fresh"], result=0)
+        self.addCleanup(self.harness.cleanup)
+
+        patcher = patch.object(PrometheusCharm, "_get_pvc_capacity")
+        self.mock_capacity = patcher.start()
+        self.mock_capacity.return_value = "1Gi"
+        self.addCleanup(patcher.stop)
+
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    @patch.object(Prometheus, "reload_configuration", new=lambda _: True)
+    @patch("socket.getfqdn", new=lambda *args: "fqdn")
+    @patch_network_get()
+    def test_tls_relation_without_certs(self, *unused):
+        self.harness.begin_with_initial_hooks()
+
+        # WHEN a certificates relation is added
+        rel_id = self.harness.add_relation("certificates", "ca")
+        self.harness.add_relation_unit(rel_id, "ca/0")
+
+        # AND no certs are provided over relation data
+        # THEN the scheme of the internal URL is http
+        self.assertTrue(self.harness.charm.internal_url.startswith("http://"))
+
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    @patch.object(Prometheus, "reload_configuration", new=lambda _: True)
+    @patch("socket.getfqdn", new=lambda *args: "fqdn")
+    @patch_network_get()
+    @patch.multiple(
+        "charm.PrometheusCharm",
+        _is_tls_ready=lambda *_: True,
+        _is_cert_available=lambda *_: True,
+        _update_cert=lambda *_: None,
+    )
+    def test_tls_relation_with_tls_ready(self, *unused):
+        self.harness.begin_with_initial_hooks()
+
+        # WHEN a certificates relation is added
+        rel_id = self.harness.add_relation("certificates", "ca")
+        self.harness.add_relation_unit(rel_id, "ca/0")
+
+        # AND certs become available (see decorators)
+        # THEN the scheme of the internal URL is https
+        self.assertTrue(self.harness.charm.internal_url.startswith("https://"))


### PR DESCRIPTION
## Issue
TLS config is written and workload restarted, before the cert is written to disk.


## Solution
- [x] Use rock from https://github.com/canonical/prometheus-rock/pull/30
  - [x] Use the `update-ca-certificates` machinery
- [x] Instead of `stop()`, have `_scheme` return `http` and `_is_tls_enabled` return `False` until the cert is in place.

Depends on:
- https://github.com/canonical/prometheus-rock/pull/30 (https://github.com/canonical/oci-factory/pull/58)

Fixes https://github.com/canonical/prometheus-k8s-operator/issues/521


## Testing Instructions
- Run itests in https://github.com/canonical/cos-lite-bundle/pull/80
- Manually test with the following bundles

```yaml
bundle: kubernetes
applications:
  ca:
    charm: self-signed-certificates
    channel: edge
    scale: 1
  prom:
    charm: ./prometheus-k8s_ubuntu-20.04-amd64.charm
    series: focal
    scale: 1
    trust: true
    resources:
        prometheus-image: ghcr.io/canonical/prometheus:dev
relations:
- - ca:certificates
  - prom:certificates
```

```yaml
bundle: kubernetes
applications:
  ca:
    charm: self-signed-certificates
    channel: edge
    scale: 1
  cat:
    charm: catalogue-k8s
    channel: edge
    series: focal
    scale: 1
  prom:
    charm: ./prometheus-k8s_ubuntu-20.04-amd64.charm
    series: focal
    scale: 1
    trust: true
    resources:
        prometheus-image: ghcr.io/canonical/prometheus:dev
  trfk:
    charm: traefik-k8s
    channel: edge
    series: focal
    scale: 1
relations:
- - cat:catalogue
  - prom:catalogue
- - ca:certificates
  - prom:certificates
- - prom:ingress
  - trfk:ingress-per-unit
- - trfk:certificates
  - ca:certificates
```

## Release Notes
Fix handling of tls config.
