### PR TITLE
Attempt to fix update-libs failing with "(Unknown event)"

### DIFF
--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -11,4 +11,3 @@ jobs:
     name: Check libraries
     uses: canonical/observability/.github/workflows/update-libs.yaml@main
     secrets: inherit
-


### PR DESCRIPTION
## Issue
Prom's github actions list "Unknown event" instead of update-libs.
![image](https://github.com/canonical/prometheus-k8s-operator/assets/82407168/8fa2e7ec-057e-4f3d-a576-92d5107ba943)


## Solution
Per GitHub Support, need to push any change to the file.

