### PR TITLE
Use dockerhub image

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -77,4 +77,4 @@ resources:
   prometheus-image:
     type: oci-image
     description: Container image for Prometheus
-    upstream-source: ghcr.io/canonical/prometheus:dev
+    upstream-source: ubuntu/prometheus:2.46.0-22.04_stable


### PR DESCRIPTION
## Issue
Upstream source had opaque image tag.

## Solution
Use versioned tag.

Fixes #529 
Fixes #491