### PR TITLE
Grafana needs to know scrape_interval for $__rate_interval

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -63,6 +63,7 @@ from utils import convert_k8s_quantity_to_legacy_binary_gigabytes
 
 PROMETHEUS_DIR = "/etc/prometheus"
 PROMETHEUS_CONFIG = f"{PROMETHEUS_DIR}/prometheus.yml"
+PROMETHEUS_GLOBAL_SCRAPE_INTERVAL = "1m"
 RULES_DIR = f"{PROMETHEUS_DIR}/rules"
 CONFIG_HASH_PATH = f"{PROMETHEUS_DIR}/config.sha256"
 ALERTS_HASH_PATH = f"{PROMETHEUS_DIR}/alerts.sha256"
@@ -171,6 +172,7 @@ class PrometheusCharm(CharmBase):
             source_type="prometheus",
             source_url=self.internal_url,  # https://github.com/canonical/operator/issues/970
             refresh_event=self.cert_handler.on.cert_changed,
+            extra_fields={"timeInterval": PROMETHEUS_GLOBAL_SCRAPE_INTERVAL},
         )
 
         self.catalogue = CatalogueConsumer(charm=self, item=self._catalogue_item)
@@ -827,7 +829,10 @@ class PrometheusCharm(CharmBase):
             a dictionary consisting of global configuration for Prometheus.
         """
         config = self.model.config
-        global_config = {"scrape_interval": "1m", "scrape_timeout": "10s"}
+        global_config = {
+            "scrape_interval": PROMETHEUS_GLOBAL_SCRAPE_INTERVAL,
+            "scrape_timeout": "10s",
+        }
 
         if config.get("evaluation_interval") and self._is_valid_timespec(
             config["evaluation_interval"]


### PR DESCRIPTION
## Issue

Closes: #543



## Solution
<!-- A summary of the solution addressing the above issue -->

Grafana assumes the scrape interval as 15s by default but COS stack assumes 1m. Without telling Grafana that COS Prometheus uses 1m as the global scrape interval, many graphs will break since $__rate_interval won't be calculated properly.



## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Hardcoding 1m itself is in question, but this patch fixes many graphs using $__rate_interval without touching the fundamental pieces.

ref:
https://grafana.com/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/#interval-behavior https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/ https://github.com/canonical/prometheus-k8s-operator/issues/544


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Deploy the COS stack and grafana-agent machine charm and relate those. Open the node-exporter dashboard in Grafana and zoom into 15 min and confirm the graphs are shown instead of "no data".

Also, double check the scrape interval is set as 1m in the data source configuration.

![image](https://github.com/canonical/prometheus-k8s-operator/assets/4356209/383ac157-d501-4263-a868-f922d461546a)


## Release Notes
<!-- A digestable summary of the change in this PR -->
