### PR TITLE
Unique identifiers

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1014,7 +1014,6 @@ class MetricsEndpointConsumer(Object):
                 try:
                     scrape_metadata = json.loads(relation.data[relation.app]["scrape_metadata"])
                     identifier = JujuTopology.from_dict(scrape_metadata).identifier
-                    alerts[identifier] = self._tool.apply_label_matchers(alert_rules)  # type: ignore
 
                 except KeyError as e:
                     logger.debug(

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 43
+LIBPATCH = 44
 
 PYDEPS = ["cosl"]
 
@@ -1028,6 +1028,10 @@ class MetricsEndpointConsumer(Object):
                     "Alert rules were found but no usable group or identifier was present."
                 )
                 continue
+
+            # We need to append the relation info to the identifier. This is to allow for cases for there are two
+            # relations which eventually scrape the same application. Issue #551.
+            identifier = f"{identifier}_{relation.name}_{relation.id}"
 
             alerts[identifier] = alert_rules
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -413,7 +413,9 @@ class TestAlertsFilename(unittest.TestCase):
         files = container.list_files("/etc/prometheus/rules")
         self.assertEqual(
             {file.path for file in files},
-            {"/etc/prometheus/rules/juju_ZZZ-model_a5edc336_zzz-app.rules"},
+            {
+                f"/etc/prometheus/rules/juju_ZZZ-model_a5edc336_zzz-app_{RELATION_NAME}_{self.rel_id}.rules"
+            },
         )
 
     @k8s_resource_multipatch
@@ -436,7 +438,9 @@ class TestAlertsFilename(unittest.TestCase):
         files = container.list_files("/etc/prometheus/rules")
         self.assertEqual(
             {file.path for file in files},
-            {"/etc/prometheus/rules/juju_ZZZ-model_a5edc336_zzz-app.rules"},
+            {
+                f"/etc/prometheus/rules/juju_ZZZ-model_a5edc336_zzz-app_{RELATION_NAME}_{self.rel_id}.rules"
+            },
         )
 
     @k8s_resource_multipatch
@@ -458,7 +462,9 @@ class TestAlertsFilename(unittest.TestCase):
         files = container.list_files("/etc/prometheus/rules")
         self.assertEqual(
             {file.path for file in files},
-            {"/etc/prometheus/rules/juju_remote-model_be44e4b8_remote-app.rules"},
+            {
+                f"/etc/prometheus/rules/juju_remote-model_be44e4b8_remote-app_{RELATION_NAME}_{self.rel_id}.rules"
+            },
         )
 
     @k8s_resource_multipatch
@@ -480,7 +486,8 @@ class TestAlertsFilename(unittest.TestCase):
         container = self.harness.charm.unit.get_container(self.harness.charm._name)
         files = container.list_files("/etc/prometheus/rules")
         self.assertEqual(
-            {file.path for file in files}, {"/etc/prometheus/rules/juju_ZZZ_group_alerts.rules"}
+            {file.path for file in files},
+            {f"/etc/prometheus/rules/juju_ZZZ_group_alerts_{RELATION_NAME}_{self.rel_id}.rules"},
         )
 
 

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -499,8 +499,9 @@ class TestEndpointConsumer(unittest.TestCase):
                 messages[1],
             )
         alerts = self.harness.charm.prometheus_consumer.alerts
-        self.assertIn("unlabeled_external_cpu_alerts", alerts.keys())
-        self.assertEqual(UNLABELED_ALERT_RULES, alerts["unlabeled_external_cpu_alerts"])
+        identifier = f"unlabeled_external_cpu_alerts_{RELATION_NAME}_{rel_id}"
+        self.assertIn(identifier, alerts.keys())
+        self.assertEqual(UNLABELED_ALERT_RULES, alerts[identifier])
 
     def test_bad_scrape_job(self):
         self.harness.set_leader(True)


### PR DESCRIPTION
## Issue
Fixes #551


## Solution
Append the relation name and id to the alert rule file name.


## Testing Instructions
Fix has been verified by @nobuto-m


## Release Notes
Fixed an issue where two relations over different routes to the same application could cause alert rules to be dropped.