### PR TITLE
Fix charm links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ This UI is accessed on port 9090 at the Prometheus charm's address. This assumes
 When Prometheus is deployed it will only scrape metrics from itself. This is the default behavior of Prometheus. Additional metrics endpoints may be added to the Prometheus charm through relations with other charms. Currently the following charms are supported
 
 - Any charm that uses the `prometheus_scrape` interface to provide a metrics endpoint and optionally alert rules for Prometheus.
-- The [Prometheus Scrape Target]() charm may be used to scrape metrics endpoint that are not part of any Juju Model.
-- The [Prometheus Scrape Config]() charm may be used to scrape metrics endpoints across different Juju models. The charm also support overriding some of the scrape job configurations provided by metrics endpoints.
+- The [Prometheus Scrape Target](https://github.com/canonical/prometheus-scrape-target-k8s-operator) charm may be used to scrape metrics endpoint that are not part of any Juju Model.
+- The [Prometheus Scrape Config](https://github.com/canonical/prometheus-scrape-config-k8s-operator) charm may be used to scrape metrics endpoints across different Juju models. The charm also support overriding some of the scrape job configurations provided by metrics endpoints.
 
 
 


### PR DESCRIPTION
The links to the Prometheus Scrape/Config charms are empty; this PR adds them.