### PR TITLE
Set ActiveStatus when retention size config option is valid

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -7,12 +7,10 @@
 import hashlib
 import logging
 import re
-from typing import List, TypedDict, cast
-
 import socket
 import subprocess
 from pathlib import Path
-from typing import Dict, Optional, TypedDict, cast
+from typing import Dict, List, Optional, TypedDict, cast
 from urllib.parse import urlparse
 
 import yaml
@@ -576,7 +574,9 @@ class PrometheusCharm(CharmBase):
 
             logger.info("Prometheus configuration reloaded")
 
-        self.unit.status = StatusBase._get_highest_priority(cast(List[StatusBase], list(self.status.values())))
+        self.unit.status = StatusBase._get_highest_priority(
+            cast(List[StatusBase], list(self.status.values()))
+        )
 
     def _on_pebble_ready(self, event) -> None:
         """Pebble ready hook.

--- a/src/charm.py
+++ b/src/charm.py
@@ -110,7 +110,8 @@ def to_tuple(status: StatusBase) -> Tuple[str, str]:
 
 def to_status(tpl: Tuple[str, str]) -> StatusBase:
     """Convert a tuple to a StatusBase, so it could be used natively with ops."""
-    return StatusBase.from_name(*tpl)
+    name, message = tpl
+    return StatusBase.from_name(name, message)
 
 
 @trace_charm(
@@ -229,9 +230,8 @@ class PrometheusCharm(CharmBase):
 
     def _on_collect_unit_status(self, event: CollectStatusEvent):
         # "Pull" statuses
-        if not self._is_valid_timespec(
-            retention_time := self.model.config.get("metrics_retention_time", "")
-        ):
+        retention_time = self.model.config.get("metrics_retention_time", "")
+        if not self._is_valid_timespec(retention_time):
             event.add_status(BlockedStatus(f"Invalid time spec : {retention_time}"))
 
         # "Push" statuses

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,12 +7,10 @@
 import hashlib
 import logging
 import re
-from typing import TypedDict
-
 import socket
 import subprocess
 from pathlib import Path
-from typing import Dict, Optional, cast
+from typing import Dict, Optional, TypedDict, cast
 from urllib.parse import urlparse
 
 import yaml
@@ -56,8 +54,8 @@ from ops.model import (
     MaintenanceStatus,
     ModelError,
     OpenedPort,
-    WaitingStatus,
     StatusBase,
+    WaitingStatus,
 )
 from ops.pebble import Error as PebbleError
 from ops.pebble import ExecError, Layer
@@ -95,6 +93,8 @@ class ConfigError(Exception):
 
 
 class CompositeStatus(TypedDict):
+    """Per-component status holder."""
+
     retention_size: StatusBase
     timespec: StatusBase
     k8s_patch: StatusBase
@@ -696,7 +696,9 @@ class PrometheusCharm(CharmBase):
                     self._get_pvc_capacity(), ratio
                 )
             except ValueError as e:
-                self.status["retention_size"] = BlockedStatus(f"Error calculating retention size: {e}")
+                self.status["retention_size"] = BlockedStatus(
+                    f"Error calculating retention size: {e}"
+                )
             except LightkubeApiError as e:
                 self.status["retention_size"] = BlockedStatus(
                     "Error calculating retention size "

--- a/src/charm.py
+++ b/src/charm.py
@@ -115,7 +115,9 @@ class PrometheusCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.status = CompositeStatus()
+        self.status = CompositeStatus(
+            retention_size=ActiveStatus(), timespec=ActiveStatus(), k8s_patch=ActiveStatus()
+        )
 
         self._name = "prometheus"
         self._port = 9090

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,6 +7,8 @@
 import hashlib
 import logging
 import re
+from typing import List, TypedDict, cast
+
 import socket
 import subprocess
 from pathlib import Path
@@ -574,7 +576,7 @@ class PrometheusCharm(CharmBase):
 
             logger.info("Prometheus configuration reloaded")
 
-        self.unit.status = StatusBase._get_highest_priority(list(self.status.values()))
+        self.unit.status = StatusBase._get_highest_priority(cast(List[StatusBase], list(self.status.values())))
 
     def _on_pebble_ready(self, event) -> None:
         """Pebble ready hook.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -216,6 +216,7 @@ class TestCharm(unittest.TestCase):
     def test_configuration_reload_success(self, trigger_configuration_reload, *unused):
         trigger_configuration_reload.return_value = True
         self.harness.update_config({"evaluation_interval": "1234m"})
+        self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
 
     @k8s_resource_multipatch
@@ -322,6 +323,7 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
         self.mock_capacity.return_value = "1Gi"
         self.harness.begin_with_initial_hooks()
         self.harness.container_pebble_ready("prometheus")
+        self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
 
         # WHEN the config option is set to an invalid string
@@ -330,6 +332,7 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
         # THEN cli arg is unspecified and the unit is blocked
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertIsNone(cli_arg(plan, "--storage.tsdb.retention.size"))
+        self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
 
         # AND WHEN the config option is corrected
@@ -338,6 +341,7 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
         # THEN cli arg is updated and the unit is goes back to active
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(cli_arg(plan, "--storage.tsdb.retention.size"), "0.42GB")
+        self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
 
 
@@ -689,6 +693,7 @@ class TestTlsConfig(unittest.TestCase):
             },
         )
 
+        self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
         container = self.harness.charm.unit.get_container("prometheus")
         self.assertEqual(container.pull("/etc/prometheus/job1-ca.crt").read(), "CA 1")
@@ -725,6 +730,7 @@ class TestTlsConfig(unittest.TestCase):
             },
         )
 
+        self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
 
     @k8s_resource_multipatch

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -287,10 +287,10 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(cli_arg(plan, "--storage.tsdb.retention.size"), "0.8GB")
 
-       # AND WHEN the config option is set and then unset
+        # AND WHEN the config option is set and then unset
         self.harness.update_config({"maximum_retention_size": "50%"})
         self.harness.update_config(unset={"maximum_retention_size"})
-        
+
         # THEN the pebble plan is back to 80%
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(cli_arg(plan, "--storage.tsdb.retention.size"), "0.8GB")
@@ -306,7 +306,7 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
         self.harness.begin_with_initial_hooks()
         self.harness.container_pebble_ready("prometheus")
 
-        for (set_point, read_back) in [("0%", "0GB"), ("50%", "0.5GB"), ("100%", "1GB")]:
+        for set_point, read_back in [("0%", "0GB"), ("50%", "0.5GB"), ("100%", "1GB")]:
             with self.subTest(limit=set_point):
                 # WHEN a limit is set
                 self.harness.update_config({"maximum_retention_size": set_point})
@@ -314,7 +314,7 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
                 # THEN the pebble plan the adjusted capacity
                 plan = self.harness.get_container_pebble_plan("prometheus")
                 self.assertEqual(cli_arg(plan, "--storage.tsdb.retention.size"), read_back)
-        
+
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
     def test_invalid_retention_size_config_option_string(self, *unused):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -225,6 +225,7 @@ class TestCharm(unittest.TestCase):
     def test_configuration_reload_error(self, trigger_configuration_reload, *unused):
         trigger_configuration_reload.return_value = False
         self.harness.update_config({"evaluation_interval": "1234m"})
+        self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
 
     @k8s_resource_multipatch
@@ -233,6 +234,7 @@ class TestCharm(unittest.TestCase):
     def test_configuration_reload_read_timeout(self, trigger_configuration_reload, *unused):
         trigger_configuration_reload.return_value = "read_timeout"
         self.harness.update_config({"evaluation_interval": "1234m"})
+        self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, MaintenanceStatus)
 
 
@@ -766,6 +768,7 @@ class TestTlsConfig(unittest.TestCase):
             },
         )
 
+        self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
 
     @k8s_resource_multipatch
@@ -801,4 +804,5 @@ class TestTlsConfig(unittest.TestCase):
             },
         )
 
+        self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -287,6 +287,14 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(cli_arg(plan, "--storage.tsdb.retention.size"), "0.8GB")
 
+       # AND WHEN the config option is set and then unset
+        self.harness.update_config({"maximum_retention_size": "50%"})
+        self.harness.update_config(unset={"maximum_retention_size"})
+        
+        # THEN the pebble plan is back to 80%
+        plan = self.harness.get_container_pebble_plan("prometheus")
+        self.assertEqual(cli_arg(plan, "--storage.tsdb.retention.size"), "0.8GB")
+
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
     def test_multiplication_factor_applied_to_pvc_capacity(self, *unused):
@@ -294,16 +302,43 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
         # GIVEN a capacity limit in binary notation (k8s notation)
         self.mock_capacity.return_value = "1Gi"
 
-        # AND a multiplication factor as a config option
-        self.harness.update_config({"maximum_retention_size": "50%"})
-
         # WHEN the charm starts
         self.harness.begin_with_initial_hooks()
         self.harness.container_pebble_ready("prometheus")
 
-        # THEN the pebble plan the adjusted capacity
+        for (set_point, read_back) in [("0%", "0GB"), ("50%", "0.5GB"), ("100%", "1GB")]:
+            with self.subTest(limit=set_point):
+                # WHEN a limit is set
+                self.harness.update_config({"maximum_retention_size": set_point})
+
+                # THEN the pebble plan the adjusted capacity
+                plan = self.harness.get_container_pebble_plan("prometheus")
+                self.assertEqual(cli_arg(plan, "--storage.tsdb.retention.size"), read_back)
+        
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    def test_invalid_retention_size_config_option_string(self, *unused):
+        # GIVEN a running charm with default values
+        self.mock_capacity.return_value = "1Gi"
+        self.harness.begin_with_initial_hooks()
+        self.harness.container_pebble_ready("prometheus")
+        self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
+
+        # WHEN the config option is set to an invalid string
+        self.harness.update_config({"maximum_retention_size": "42"})
+
+        # THEN cli arg is unspecified and the unit is blocked
         plan = self.harness.get_container_pebble_plan("prometheus")
-        self.assertEqual(cli_arg(plan, "--storage.tsdb.retention.size"), "0.5GB")
+        self.assertIsNone(cli_arg(plan, "--storage.tsdb.retention.size"))
+        self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
+
+        # AND WHEN the config option is corrected
+        self.harness.update_config({"maximum_retention_size": "42%"})
+
+        # THEN cli arg is updated and the unit is goes back to active
+        plan = self.harness.get_container_pebble_plan("prometheus")
+        self.assertEqual(cli_arg(plan, "--storage.tsdb.retention.size"), "0.42GB")
+        self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
 
 
 @prom_multipatch

--- a/tests/unit/test_charm_status.py
+++ b/tests/unit/test_charm_status.py
@@ -91,6 +91,7 @@ class TestActiveStatus(unittest.TestCase):
             # WHEN no config is provided or relations created
 
             # THEN the unit goes into blocked state
+            self.harness.evaluate_status()
             self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
 
             # AND pebble plan is not empty

--- a/tests/unit/test_charm_status.py
+++ b/tests/unit/test_charm_status.py
@@ -58,6 +58,7 @@ class TestActiveStatus(unittest.TestCase):
             # WHEN no config is provided or relations created
 
             # THEN the unit goes into active state
+            self.harness.evaluate_status()
             self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
 
             # AND pebble plan is not empty

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -241,6 +241,7 @@ class TestRemoteWriteProvider(unittest.TestCase):
             self.harness.get_relation_data(rel_id, self.harness.charm.unit.name),
             {"remote_write": json.dumps({"url": "http://fqdn:9090/api/v1/write"})},
         )
+        self.harness.evaluate_status()
         self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
 
     @k8s_resource_multipatch


### PR DESCRIPTION
## Issue
BlockedStatus from an invalid retention size config option was never cleared.

## Solution
- Add a TypedDict for per-component status setting.
- Use the per-component status dict to set status centrally in `_configure`.

Fixes #560.

