### PR TITLE
Use spread

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,68 @@
+# Project: prometheus-k8s
+# Backend: multipass/lxd? 4cpu7gb, 8cpu16gb, amd, arm
+# System: doesn't matter for charms
+# Suite: group of tasks
+
+
+# Task: one and same dir per suite, one dir per task, and one task.yaml inside it
+
+# Variants: juju, uk8s versions
+
+# spread -list prints out [backend:system:suite/task:variant]
+
+
+project: prometheus-k8s
+
+prepare: |
+  systemctl start snapd.seeded.service
+  
+  # Install Juju
+  snap install juju --channel=3.3/stable
+  
+  # Make sure juju directory is there
+  # https://bugs.launchpad.net/juju/+bug/1995697
+  sudo -u ubuntu mkdir -p /home/ubuntu/.local/share/juju
+
+backends:
+  lxd:
+    systems: [ubuntu-20.04]
+
+suites:
+  tests/spread/k8s/:
+    summary: Prometheus-k8s tests
+
+    prepare: |
+
+      # Install MicroK8s
+      snap install microk8s --channel=1.26-strict/stable
+      usermod -a -G snap_microk8s ubuntu
+      #usermod -a -G microk8s ubuntu
+      microk8s status --wait-ready
+
+      # The dns addon will restart the api server so you may see a blip in the availability
+      # Separating addons to avoid errors such as
+      # dial tcp 127.0.0.1:16443: connect: connection refused
+      microk8s.enable dns rbac
+      microk8s.kubectl rollout status deployments/coredns -n kube-system -w --timeout=600s
+
+      # wait for storage become available
+      microk8s.enable hostpath-storage
+      microk8s.kubectl rollout status deployments/hostpath-provisioner -n kube-system -w --timeout=600s
+
+      # MetalLB
+      ip_range="$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')/32"
+      microk8s enable metallb:$ip_range
+      microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
+
+      # bootstrap controllers
+      sudo -u ubuntu juju bootstrap microk8s microk8s
+      sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-k8s
+
+
+path: /remote/path
+
+exclude:
+  - .tox/*
+  - .git/*
+  - .mypy_cache/*
+

--- a/spread.yaml
+++ b/spread.yaml
@@ -14,9 +14,9 @@
 project: prometheus-k8s
 
 prepare: |
-    # Without this command, spread fails with:
-    # error: too early for operation, device not yet seeded or device model not acknowledged
-    systemctl start snapd.seeded.service
+  # Without this command, spread fails with:
+  # error: too early for operation, device not yet seeded or device model not acknowledged
+  systemctl start snapd.seeded.service
   
   # Install Juju
   snap install juju --channel=3.3/stable

--- a/spread.yaml
+++ b/spread.yaml
@@ -14,7 +14,9 @@
 project: prometheus-k8s
 
 prepare: |
-  systemctl start snapd.seeded.service
+    # Without this command, spread fails with:
+    # error: too early for operation, device not yet seeded or device model not acknowledged
+    systemctl start snapd.seeded.service
   
   # Install Juju
   snap install juju --channel=3.3/stable
@@ -54,9 +56,8 @@ suites:
       microk8s enable metallb:$ip_range
       microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
 
-      # bootstrap controllers
+      # bootstrap controller
       sudo -u ubuntu juju bootstrap microk8s microk8s
-      sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-k8s
 
 
 path: /remote/path

--- a/tests/spread/k8s/integration/task.yaml
+++ b/tests/spread/k8s/integration/task.yaml
@@ -1,40 +1,7 @@
 summary: Greet the planet
 
 prepare: |
-    
-    # Get IP range for MetalLB
-
-    # Install Juju
-    snap install juju --channel=3.3/stable
-    snap install microk8s --channel=1.26-strict/stable
-    snap refresh
-
-    # Make sure juju directory is there
-    # https://bugs.launchpad.net/juju/+bug/1995697
-    sudo -u ubuntu mkdir -p /home/ubuntu/.local/share/juju
-
-    usermod -a -G snap_microk8s ubuntu
-    usermod -a -G microk8s ubuntu
-    microk8s status --wait-ready
-
-    # The dns addon will restart the api server so you may see a blip in the availability
-    # Separating addons to avoid errors such as
-    # dial tcp 127.0.0.1:16443: connect: connection refused
-    microk8s.enable dns rbac
-    microk8s.kubectl rollout status deployments/coredns -n kube-system -w --timeout=600s
-
-    # wait for storage become available
-    microk8s.enable hostpath-storage
-    microk8s.kubectl rollout status deployments/hostpath-provisioner -n kube-system -w --timeout=600s
-
-    # MetalLB
-    ip_range="$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')/32"
-    microk8s enable metallb:$ip_range
-    microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
-
-    # bootstrap controllers
-    sudo -u ubuntu juju bootstrap microk8s microk8s
-    sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-k8s
+    sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" integration-k8s
 
 execute: |
     tox -vve integration

--- a/tests/spread/k8s/integration/task.yaml
+++ b/tests/spread/k8s/integration/task.yaml
@@ -1,0 +1,41 @@
+summary: Greet the planet
+
+prepare: |
+    
+    # Get IP range for MetalLB
+
+    # Install Juju
+    snap install juju --channel=3.3/stable
+    snap install microk8s --channel=1.26-strict/stable
+    snap refresh
+
+    # Make sure juju directory is there
+    # https://bugs.launchpad.net/juju/+bug/1995697
+    sudo -u ubuntu mkdir -p /home/ubuntu/.local/share/juju
+
+    usermod -a -G snap_microk8s ubuntu
+    usermod -a -G microk8s ubuntu
+    microk8s status --wait-ready
+
+    # The dns addon will restart the api server so you may see a blip in the availability
+    # Separating addons to avoid errors such as
+    # dial tcp 127.0.0.1:16443: connect: connection refused
+    microk8s.enable dns rbac
+    microk8s.kubectl rollout status deployments/coredns -n kube-system -w --timeout=600s
+
+    # wait for storage become available
+    microk8s.enable hostpath-storage
+    microk8s.kubectl rollout status deployments/hostpath-provisioner -n kube-system -w --timeout=600s
+
+    # MetalLB
+    ip_range="$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')/32"
+    microk8s enable metallb:$ip_range
+    microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
+
+    # bootstrap controllers
+    sudo -u ubuntu juju bootstrap microk8s microk8s
+    sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-k8s
+
+execute: |
+    tox -vve integration
+


### PR DESCRIPTION
## Issue
- The javascript actions operator is difficult to maintain.
- Vectorization of integration tests currently depends on the github ci language.

## Solution
Use [spread](https://github.com/snapcore/spread).
- [ ] task/suite or `promtool check rules` and `promtool test rules` (refs: [1](https://www.robustperception.io/unit-testing-alerts-with-prometheus/), [2](https://github.com/prometheus/prometheus/blob/main/docs/configuration/unit_testing_rules.md), [3](https://stackoverflow.com/questions/46589949/how-to-automatically-test-prometheus-alerts#53761836))

References:
- https://github.com/canonical/rockcraft/blob/main/spread.yaml
- https://github.com/canonical/chisel/blob/main/spread.yaml
- arm backend: https://github.com/snapcore/snapd/blob/master/spread.yaml#L199
- https://github.com/canonical/charmcraft/blob/main/tests/spread/charms/k8s-operator/task.yaml

## Testing Instructions
```
$ spread
```

