### PR TITLE
Update image to dockerhub, major version

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -79,4 +79,5 @@ resources:
     description: Container image for Prometheus
     # Use ghcr image until the missing udpate-ca-certificates issue is resolved.
     # https://github.com/canonical/prometheus-rock/issues/33
-    upstream-source: ghcr.io/canonical/prometheus:dev
+    #upstream-source: ghcr.io/canonical/prometheus:dev
+    upstream-source: ubuntu/prometheus:2-22.04

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ deps =
     cosl
     ops >= 2.5.0
     pytest
-    ops-scenario >= 5.1
+    ops-scenario == 5.8.1
     -r{toxinidir}/requirements.txt
     opentelemetry-exporter-otlp-proto-grpc==1.17.0  # PYDEPS for tracing
     importlib-metadata==6.0.0  # PYDEPS for tracing


### PR DESCRIPTION
## Issue
Metadata point to ghcr latest.

## Solution
Use dockerhub image, with major version
https://github.com/canonical/prometheus-rock/blob/main/2.49.1/rockcraft.yaml
