### PR TITLE
Fix topology for self-scraping

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -282,7 +282,8 @@ class PrometheusCharm(CharmBase):
                         "juju_model": self._topology.model,
                         "juju_model_uuid": self._topology.model_uuid,
                         "juju_application": self._topology.application,
-                        "juju_unit": self._topology.charm_name,
+                        "juju_unit": self._topology.unit,
+                        "juju_charm": self._topology.charm_name,
                         "host": "localhost",
                     },
                 }


### PR DESCRIPTION
## Issue
Currently, we populate the unit name label with the charm name, and discard the unit name.

## Solution
<!-- A summary of the solution addressing the above issue -->
- Make `juju_unit` the unit name. 
- Add `juju_charm` and store the charm name there.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
N/A

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Check the labels for Prometheus `up`1 and make sure it has the right values.

## Release Notes
<!-- A digestable summary of the change in this PR -->
Apply the correct Juju topology while self-scraping.