### PR TITLE
Update tracing to use OTLP/HTTP

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -20,6 +20,7 @@ parts:
       - ops
       - wheel==0.37.1
       - setuptools==45.2.0
+      - pydantic>=2
   cos-tool:
     plugin: dump
     source: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ version = "0.1" # not relevant
 
 [project.optional-dependencies]
 lib_pydeps = [
-  "opentelemetry-exporter-otlp-proto-grpc",
-  "pydantic<2"
+  "opentelemetry-exporter-otlp-proto-http",
+  "pydantic>=2"
 ]
 
 # Testing tools configuration

--- a/src/charm.py
+++ b/src/charm.py
@@ -35,8 +35,8 @@ from charms.prometheus_k8s.v1.prometheus_remote_write import (
 from charms.prometheus_k8s.v1.prometheus_remote_write import (
     PrometheusRemoteWriteProvider,
 )
-from charms.tempo_k8s.v0.charm_tracing import trace_charm
-from charms.tempo_k8s.v0.tracing import TracingEndpointRequirer
+from charms.tempo_k8s.v1.charm_tracing import trace_charm
+from charms.tempo_k8s.v1.tracing import TracingEndpointRequirer
 from charms.traefik_k8s.v1.ingress_per_unit import (
     IngressPerUnitReadyForUnitEvent,
     IngressPerUnitRequirer,
@@ -116,6 +116,7 @@ def to_status(tpl: Tuple[str, str]) -> StatusBase:
 
 @trace_charm(
     tracing_endpoint="tempo",
+    server_cert="server_cert_path",
     extra_types=[
         KubernetesComputeResourcesPatch,
         CertHandler,
@@ -1061,7 +1062,12 @@ class PrometheusCharm(CharmBase):
     @property
     def tempo(self) -> Optional[str]:
         """Tempo endpoint for charm tracing."""
-        return self.tracing.otlp_grpc_endpoint()
+        return self.tracing.otlp_http_endpoint()
+
+    @property
+    def server_cert_path(self) -> Optional[str]:
+        """Server certificate path for TLS tracing."""
+        return CERT_PATH
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -493,11 +493,13 @@ class TestEndpointConsumer(unittest.TestCase):
         with self.assertLogs(level="DEBUG") as logger:
             _ = self.harness.charm.prometheus_consumer.alerts
             messages = logger.output
-            self.assertIn(
+
+            searched_message = (
                 "No labeled alert rules were found, and no 'scrape_metadata' "
-                "was available. Using the alert group name as filename.",
-                messages[1],
+                "was available. Using the alert group name as filename."
             )
+            any_matches = any(searched_message in log_message for log_message in messages)
+            self.assertTrue(any_matches)
         alerts = self.harness.charm.prometheus_consumer.alerts
         identifier = f"unlabeled_external_cpu_alerts_{RELATION_NAME}_{rel_id}"
         self.assertIn(identifier, alerts.keys())

--- a/tox.ini
+++ b/tox.ini
@@ -96,9 +96,9 @@ deps =
     pytest
     ops-scenario >=5.1,<6.0
     -r{toxinidir}/requirements.txt
-    opentelemetry-exporter-otlp-proto-grpc==1.17.0  # PYDEPS for tracing
+    opentelemetry-exporter-otlp-proto-http==1.21.0  # PYDEPS for tracing
     importlib-metadata==6.0.0  # PYDEPS for tracing
-    pydantic  # PYDEPS for tracing
+    pydantic>=2  # PYDEPS for tracing
 commands =
     pytest -v --tb native {[vars]tst_path}/scenario --log-cli-level=INFO -s {posargs}
 


### PR DESCRIPTION
## Issue
Prometheus charm grew significantly in size due to a new GRPC dependency introduced by tracing as noticed in #545. Because of that, we reconsidered the protocol used by tracing in canonical/tempo-k8s-operator#53 and decided to use OTLP/HTTP.

## Solution
Switch to the new version of charm_tracing and use OTLP/HTTP(S) endpoints of tempo.

## Context
This PR implicitly bumps pydantic used by tracing to v2 which is a complete rewrite in Rust. Because rust compiler isn't found in `charmcraft pack` in this repo I needed to add pydantic to `charm-binary-python-packages`.


## Testing Instructions
First run `charmcraft pack` to see that prometheus charm is now reduced back to 26MB.

Then, using the packed charm, use the following bundle:
```
bundle: kubernetes
applications:
  alertmanager:
    charm: alertmanager-k8s
    channel: stable
    revision: 96
    series: focal
    resources:
      alertmanager-image: 84
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  catalogue:
    charm: catalogue-k8s
    channel: stable
    revision: 33
    series: focal
    resources:
      catalogue-image: 32
    scale: 1
    options:
      description: "Canonical Observability Stack Lite, or COS Lite, is a light-weight,
        highly-integrated, \nJuju-based observability suite running on Kubernetes.\n"
      tagline: Model-driven Observability Stack deployed with a single command.
      title: Canonical Observability Stack
    constraints: arch=amd64
    trust: true
  grafana:
    charm: grafana-k8s
    channel: stable
    revision: 93
    series: focal
    resources:
      grafana-image: 62
      litestream-image: 43
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  loki:
    charm: loki-k8s
    channel: stable
    revision: 105
    series: focal
    resources:
      loki-image: 88
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
  prometheus-k8s:
    charm: local:prometheus-k8s-0
    series: focal
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  self-signed-certificates:
    charm: self-signed-certificates
    channel: stable
    revision: 57
    scale: 1
    constraints: arch=amd64
  tempo-k8s:
    charm: tempo-k8s
    channel: candidate
    revision: 22
    resources:
      tempo-image: 14
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
  traefik:
    charm: traefik-k8s
    channel: stable
    revision: 166
    series: focal
    resources:
      traefik-image: 155
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - traefik:ingress-per-unit
  - loki:ingress
- - traefik:traefik-route
  - grafana:ingress
- - traefik:ingress
  - alertmanager:ingress
- - grafana:grafana-source
  - loki:grafana-source
- - grafana:grafana-source
  - alertmanager:grafana-source
- - loki:alertmanager
  - alertmanager:alerting
- - grafana:grafana-dashboard
  - loki:grafana-dashboard
- - grafana:grafana-dashboard
  - alertmanager:grafana-dashboard
- - catalogue:ingress
  - traefik:ingress
- - catalogue:catalogue
  - grafana:catalogue
- - catalogue:catalogue
  - alertmanager:catalogue
- - tempo-k8s:grafana-source
  - grafana:grafana-source
- - prometheus-k8s:certificates
  - self-signed-certificates:certificates
- - tempo-k8s:tracing
  - prometheus-k8s:tracing
- - traefik:metrics-endpoint
  - prometheus-k8s:metrics-endpoint
- - prometheus-k8s:grafana-source
  - grafana:grafana-source
```
You should be able to see traces in Grafana:
![Screenshot from 2024-01-31 19-07-25](https://github.com/canonical/prometheus-k8s-operator/assets/232859/da669c92-956b-4320-a2dc-1f8b3014b23c)


## Release Notes
<!-- A digestable summary of the change in this PR -->
