### PR TITLE
Update issue/pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,6 +23,7 @@ body:
       label: To Reproduce
       description: >
         Please provide the output of `juju export-bundle` and step-by-step instructions for how to reproduce the behavior.
+        A deployment diagram could be handy too.
       placeholder: |
         1. `juju deploy ...`
         2. `juju relate ...`

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,7 @@ body:
     attributes:
       label: To Reproduce
       description: >
-        Please provide a step-by-step instruction of how to reproduce the behavior.
+        Please provide the output of `juju export-bundle` and step-by-step instructions for how to reproduce the behavior.
       placeholder: |
         1. `juju deploy ...`
         2. `juju relate ...`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,5 +14,5 @@
 <!-- What steps need to be taken to test this PR? -->
 
 
-## Release Notes
-<!-- A digestable summary of the change in this PR -->
+## Upgrade Notes
+<!-- To upgrade from an older revision of charmed prometheus, ... -->


### PR DESCRIPTION
## Issue
1. Bug reports are often missing some context.
2. "Release Notes" is not useful: there is no automation around it, and it's always identical to the PR title.
3. The PR template overlooks upgrade concerns.

## Solution
1. In the bug report template, ask for the output of `juju export-bundle`.
2. Replace "Release Notes" with "Upgrade Notes". [Usage example](https://github.com/canonical/alertmanager-k8s-operator/pull/212).