### PR TITLE
Less log spam from imported libs

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -77,6 +77,10 @@ CERT_PATH = f"{PROMETHEUS_DIR}/server.cert"
 CA_CERT_PATH = f"{PROMETHEUS_DIR}/ca.cert"
 WEB_CONFIG_PATH = f"{PROMETHEUS_DIR}/prometheus-web-config.yml"
 
+# To keep a tidy debug-log, we suppress some DEBUG/INFO logs from some imported libs,
+# even when charm logging is set to a lower level.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Issue
The juju debug-log is quite handy even at DEBUG level.
Since we started using lightkube, we see an increase in repeated log spam such as:
```
unit-prometheus-0: 19:48:01 DEBUG unit.prometheus/0.juju-log receive_response_body.started request=<Request [b'GET']>
unit-prometheus-0: 19:48:01 DEBUG unit.prometheus/0.juju-log receive_response_body.complete
unit-prometheus-0: 19:48:01 DEBUG unit.prometheus/0.juju-log response_closed.started
unit-prometheus-0: 19:48:01 DEBUG unit.prometheus/0.juju-log response_closed.complete
```
which come from httpx and httpcore libraries, and which are not useful.


## Solution
Only show WARNING and higher logs from httpx, httpcore, even when charm level is set to DEBUG.

Ref: https://github.com/encode/httpx/blob/c51af4ba52d4103517a91f770e617cc579803b2d/docs/logging.md?plain=1#L46