### PR TITLE
Adding Prometheus scrape interface tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ lightkube >= 0.11
 lightkube-models >= 1.22.0.4
 # From PYDEPS
 importlib-metadata~=6.0.0
+opentelemetry-exporter-otlp-proto-http

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -1,0 +1,48 @@
+# # Copyright 2022 Canonical Ltd.
+# # See LICENSE file for licensing details.
+# from unittest.mock import patch
+
+from unittest.mock import patch
+
+import pytest
+from charm import PrometheusCharm
+from interface_tester import InterfaceTester
+from scenario import Container, ExecOutput, State
+
+
+def tautology(*_, **__) -> bool:
+    return True
+
+
+@pytest.fixture
+def prometheus_charm():
+    with patch("lightkube.core.client.GenericSyncClient"), patch.multiple(
+        "charm.KubernetesComputeResourcesPatch",
+        _namespace="test-namespace",
+        _patch=tautology,
+        is_ready=tautology,
+    ), patch("prometheus_client.Prometheus.reload_configuration"), patch.multiple(
+        "charm.PrometheusCharm",
+        _promtool_check_config=lambda *_: ("stdout", ""),
+        _prometheus_version="0.1.0",
+    ):
+        yield PrometheusCharm
+
+
+def begin_with_initial_hooks_isolated() -> State:
+    container = Container(
+        "prometheus",
+        can_connect=True,
+        exec_mock={("update-ca-certificates", "--fresh"): ExecOutput(return_code=0, stdout="")},
+    )
+    state = State(containers=[container], leader=True)
+    return state
+
+
+@pytest.fixture
+def interface_tester(interface_tester: InterfaceTester, prometheus_charm):
+    interface_tester.configure(
+        charm_type=prometheus_charm,
+        state_template=begin_with_initial_hooks_isolated(),
+    )
+    yield interface_tester

--- a/tests/interface/test_prometheus_scrape.py
+++ b/tests/interface/test_prometheus_scrape.py
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from interface_tester import InterfaceTester
+
+
+def test_prometheus_scrape_v0_interface(interface_tester: InterfaceTester):
+    interface_tester.configure(
+        interface_name="prometheus_scrape",
+        branch="prom_scrape",  # TODO: Remove when prom_scrape in CRI is merged
+    )
+    interface_tester.run()

--- a/tox.ini
+++ b/tox.ini
@@ -102,6 +102,19 @@ deps =
 commands =
     pytest -v --tb native {[vars]tst_path}/scenario --log-cli-level=INFO -s {posargs}
 
+
+[testenv:interface]
+description = Run interface tests
+deps =
+    pytest
+    ops-scenario>=5.3.1
+    ; pytest-interface-tester > 0.3
+    ;TODO Remove below this when pydantic-v2 is merged
+    pytest-interface-tester@git+https://github.com/canonical/pytest-interface-tester.git@pydantic-v2
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native {[vars]tst_path}/interface --log-cli-level=INFO -s {posargs}
+
 [testenv:integration]
 description = Run integration tests
 deps =


### PR DESCRIPTION
This PR Implements a base for the prometheus_scrape interface tests corresponding to https://github.com/canonical/charm-relation-interfaces/pull/138 

PR is still targeting a specific branch `prom_scrape` in [CRI](https://github.com/canonical/charm-relation-interfaces) as [#138](https://github.com/canonical/charm-relation-interfaces/pull/138) isn't merged yet, once this branch is merged refs should be removed/updated to point to main