### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cosl
 cryptography
 jsonschema
-ops
+ops @ git+https://github.com/tonyandrewmeyer/operator@fix-config-types-1182
 pyaml
 requests
 lightkube >= 0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cosl
 cryptography
 jsonschema
-ops @ git+https://github.com/tonyandrewmeyer/operator@fix-config-types-1182
+ops
 pyaml
 requests
 lightkube >= 0.11

--- a/src/charm.py
+++ b/src/charm.py
@@ -733,11 +733,15 @@ class PrometheusCharm(CharmBase):
         if config.get("metrics_wal_compression"):
             args.append("--storage.tsdb.wal-compression")
 
-        if self._is_valid_timespec(retention_time := cast(str, config.get("metrics_retention_time", ""))):
+        if self._is_valid_timespec(
+            retention_time := cast(str, config.get("metrics_retention_time", ""))
+        ):
             args.append(f"--storage.tsdb.retention.time={retention_time}")
 
         try:
-            ratio = self._percent_string_to_ratio(cast(str, config.get("maximum_retention_size", "")))
+            ratio = self._percent_string_to_ratio(
+                cast(str, config.get("maximum_retention_size", ""))
+            )
 
         except ValueError as e:
             logger.warning(e)

--- a/src/charm.py
+++ b/src/charm.py
@@ -236,7 +236,7 @@ class PrometheusCharm(CharmBase):
     def _on_collect_unit_status(self, event: CollectStatusEvent):
         # "Pull" statuses
         retention_time = self.model.config.get("metrics_retention_time", "")
-        if not self._is_valid_timespec(retention_time):
+        if not self._is_valid_timespec(cast(str, retention_time)):
             event.add_status(BlockedStatus(f"Invalid time spec : {retention_time}"))
 
         # "Push" statuses
@@ -301,7 +301,7 @@ class PrometheusCharm(CharmBase):
     def log_level(self):
         """The log level configured for the charm."""
         allowed_log_levels = ["debug", "info", "warn", "error", "fatal"]
-        log_level = self.model.config["log_level"].lower()
+        log_level = cast(str, self.model.config["log_level"]).lower()
 
         if log_level not in allowed_log_levels:
             logging.warning(
@@ -733,11 +733,11 @@ class PrometheusCharm(CharmBase):
         if config.get("metrics_wal_compression"):
             args.append("--storage.tsdb.wal-compression")
 
-        if self._is_valid_timespec(retention_time := config.get("metrics_retention_time", "")):
+        if self._is_valid_timespec(retention_time := cast(str, config.get("metrics_retention_time", ""))):
             args.append(f"--storage.tsdb.retention.time={retention_time}")
 
         try:
-            ratio = self._percent_string_to_ratio(config.get("maximum_retention_size", ""))
+            ratio = self._percent_string_to_ratio(cast(str, config.get("maximum_retention_size", "")))
 
         except ValueError as e:
             logger.warning(e)
@@ -903,9 +903,9 @@ class PrometheusCharm(CharmBase):
         }
 
         if config.get("evaluation_interval") and self._is_valid_timespec(
-            config["evaluation_interval"]
+            cast(str, config["evaluation_interval"])
         ):
-            global_config["evaluation_interval"] = config["evaluation_interval"]
+            global_config["evaluation_interval"] = cast(str, config["evaluation_interval"])
 
         return global_config
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

## Solution
<!-- A summary of the solution addressing the above issue -->

Six `typing.cast` calls where the config values are loaded and used where the type should be str.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Covered above.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run `tox -e static-charm` with/without the PR with ops 2.12 and with either the PR branch linked above or once that's merged ops main/2.13.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A