### PR TITLE
don't override existing labels in scrape jobs

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 45
+LIBPATCH = 46
 
 PYDEPS = ["cosl"]
 
@@ -521,8 +521,8 @@ class PrometheusConfig:
                         # for such a target. Therefore labeling with Juju topology, excluding the
                         # unit name.
                         non_wildcard_static_config["labels"] = {
-                            **non_wildcard_static_config.get("labels", {}),
                             **topology.label_matcher_dict,
+                            **non_wildcard_static_config.get("labels", {}),
                         }
 
                     non_wildcard_static_configs.append(non_wildcard_static_config)
@@ -547,9 +547,9 @@ class PrometheusConfig:
                         if topology:
                             # Add topology labels
                             modified_static_config["labels"] = {
-                                **modified_static_config.get("labels", {}),
                                 **topology.label_matcher_dict,
                                 **{"juju_unit": unit_name},
+                                **modified_static_config.get("labels", {}),
                             }
 
                             # Instance relabeling for topology should be last in order.

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -367,36 +367,6 @@ class TestEndpointConsumer(unittest.TestCase):
         jobs = self.harness.charm.prometheus_consumer.jobs()
         self.validate_jobs(jobs)
 
-    def test_consumer_overwrites_juju_topology_labels(self):
-        self.assertEqual(self.harness.charm._stored.num_events, 0)
-        rel_id = self.harness.add_relation(RELATION_NAME, "consumer")
-        self.harness.update_relation_data(
-            rel_id,
-            "consumer",
-            {
-                "scrape_metadata": json.dumps(SCRAPE_METADATA),
-                "scrape_jobs": json.dumps(BAD_JOBS),
-            },
-        )
-        self.assertEqual(self.harness.charm._stored.num_events, 1)
-        self.harness.add_relation_unit(rel_id, "consumer/0")
-        self.harness.update_relation_data(
-            rel_id,
-            "consumer/0",
-            {
-                "prometheus_scrape_unit_address": "1.1.1.1",
-                "prometheus_scrape_unit_name": "provider/0",
-            },
-        )
-        self.assertEqual(self.harness.charm._stored.num_events, 2)
-        jobs = self.harness.charm.prometheus_consumer.jobs()
-        self.assertEqual(len(jobs), 1)
-        self.validate_jobs(jobs)
-        bad_labels = juju_job_labels(BAD_JOBS[0])
-        labels = juju_job_labels(jobs[0])
-        for label_name, label_value in labels.items():
-            self.assertNotEqual(label_value, bad_labels[label_name])
-
     def test_consumer_accepts_targets_without_a_port_set(self):
         self.assertEqual(self.harness.charm._stored.num_events, 0)
 


### PR DESCRIPTION
## Issue
Closes #571.


## Solution

Changing the order of the dictionaries to unpack makes sure that pre-exising labels have priority over the automatically-generated topology.


## Testing Instructions

Modify a charm (e.g., blackbox) to specify a custom `juju_application` label; then relate it to two Prometheus instances (one without the fix, the other with the fix) and check the difference in the targets section.

Before:
![Screenshot_20240424_100749](https://github.com/canonical/prometheus-k8s-operator/assets/36242061/a9cad247-f96f-4ebc-939e-923af651a5c1)

After:
![Screenshot_20240424_100923](https://github.com/canonical/prometheus-k8s-operator/assets/36242061/38721d59-4cb9-4414-861b-5ac92fe79e01)

---

There is a **unit test** that explicitly checks that we *do* overwrite the topology labels (and it's aptly called `test_consumer_overwrites_juju_topology_labels`, in the file `tests/unit/test_endpoint_consumer.py`). I'm removing that test, since it doesn't really make sense with this PR :)

I would like another pair of eyes to confirm this PR is something we want to do!