### PR TITLE
fix: codespell ignore and ruff deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ target-version = ["py38"]
 [tool.ruff]
 line-length = 99
 extend-exclude = ["__pycache__", "*.egg_info"]
+
+[tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
 # Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
@@ -33,7 +35,7 @@ ignore = ["E501", "D107", "RET504", "C901"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
 [tool.pyright]
@@ -43,3 +45,7 @@ pythonPlatform = "All"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+[tool.codespell]
+skip = ".git,.tox,build,venv*"
+ignore-words-list = "assertIn"

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     black
     ruff
 commands =
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
@@ -38,9 +38,8 @@ deps =
     ruff
     codespell
 commands =
-    codespell {[vars]lib_path}
-    codespell . --skip .git --skip .tox --skip build --skip lib --skip venv* --skip .mypy_cache
-    ruff {[vars]all_path}
+    codespell .
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib,unit,integration}]


### PR DESCRIPTION
## Issue

* `codespell` started marking `assertIn` as an error
* `ruff` has been issuing deprecation warnings on its configuration format

## Solution
* Configure `codespell` to ignore the word `assertIn` (and clean the tox environment a bit)
* Change the `ruff` configuration to the new format