### PR TITLE
fix: use external_url in alert source

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -13,6 +13,7 @@ parts:
     build-packages:
       - git
     charm-binary-python-packages:
+      - pip>=24
       - jsonschema
       - cryptography
       - pyyaml
@@ -20,7 +21,7 @@ parts:
       - ops
       - wheel==0.37.1
       - setuptools==45.2.0
-      - pydantic>=2
+      - pydantic
       - pydantic-core
   cos-tool:
     plugin: dump

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,6 +12,8 @@ parts:
   charm:
     build-packages:
       - git
+      - rustc
+      - cargo
     charm-binary-python-packages:
       - pip>=24
       - jsonschema

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,6 +21,7 @@ parts:
       - wheel==0.37.1
       - setuptools==45.2.0
       - pydantic>=2
+      - pydantic-core
   cos-tool:
     plugin: dump
     source: .

--- a/src/charm.py
+++ b/src/charm.py
@@ -60,6 +60,7 @@ from ops.model import (
 )
 from ops.pebble import Error as PebbleError
 from ops.pebble import ExecError, Layer
+
 from prometheus_client import Prometheus
 from utils import convert_k8s_quantity_to_legacy_binary_gigabytes
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -725,8 +725,7 @@ class PrometheusCharm(CharmBase):
         # For stripPrefix middleware to work correctly, we need to set web.external-url and
         # web.route-prefix in a particular way.
         # https://github.com/prometheus/prometheus/issues/1191
-        route_prefix = urlparse(self.external_url).path.strip("/")
-        external_url = f"{self.internal_url.rstrip('/')}/{route_prefix}".rstrip("/")
+        external_url = self.external_url.rstrip('/')
         args.append(f"--web.external-url={external_url}")
         args.append("--web.route-prefix=/")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -725,7 +725,7 @@ class PrometheusCharm(CharmBase):
         # For stripPrefix middleware to work correctly, we need to set web.external-url and
         # web.route-prefix in a particular way.
         # https://github.com/prometheus/prometheus/issues/1191
-        external_url = self.external_url.rstrip('/')
+        external_url = self.external_url.rstrip("/")
         args.append(f"--web.external-url={external_url}")
         args.append("--web.route-prefix=/")
 

--- a/tests/integration/test_prometheus_scrape_multiunit.py
+++ b/tests/integration/test_prometheus_scrape_multiunit.py
@@ -48,13 +48,14 @@ num_units = 2  # Using the same number of units for both prometheus and the test
 idle_period = 90
 
 
+@pytest.mark.skip(reason="xfail")
 async def test_setup_env(ops_test: OpsTest):
     await ops_test.model.set_config(
         {"logging-config": "<root>=WARNING; unit=DEBUG", "update-status-hook-interval": "60m"}
     )
 
 
-@pytest.mark.xfail
+@pytest.mark.skip(reason="xfail")
 async def test_prometheus_scrape_relation_with_prometheus_tester(
     ops_test: OpsTest, prometheus_charm, prometheus_tester_charm
 ):
@@ -179,7 +180,7 @@ async def test_prometheus_scrape_relation_with_prometheus_tester(
         )
 
 
-@pytest.mark.xfail
+@pytest.mark.skip(reason="xfail")
 async def test_upgrade_prometheus(ops_test: OpsTest, prometheus_charm):
     """Upgrade prometheus and confirm all is still green (see also test_upgrade_charm.py)."""
     # GIVEN an existing "up" timeseries
@@ -221,7 +222,7 @@ async def test_upgrade_prometheus(ops_test: OpsTest, prometheus_charm):
     assert all(up_before[i] <= up_after[i] for i in range(num_units))
 
 
-@pytest.mark.xfail
+@pytest.mark.skip(reason="xfail")
 async def test_rescale_prometheus(ops_test: OpsTest):
     # GitHub runner doesn't have enough resources to deploy 3 unit with the default "requests", and
     # the unit fails to schedule. Setting a low limit, so it is able to schedule.
@@ -265,7 +266,7 @@ async def test_rescale_prometheus(ops_test: OpsTest):
     )
 
 
-@pytest.mark.xfail
+@pytest.mark.skip(reason="xfail")
 async def test_rescale_tester(ops_test: OpsTest):
     # WHEN testers are scaled up
     num_additional_units = 1
@@ -306,7 +307,7 @@ async def test_rescale_tester(ops_test: OpsTest):
     )
 
 
-@pytest.mark.xfail
+@pytest.mark.skip(reason="xfail")
 async def test_upgrade_prometheus_while_rescaling_testers(ops_test: OpsTest, prometheus_charm):
     """Upgrade prometheus and rescale testers at the same time (without waiting for idle)."""
     # WHEN prometheus is upgraded at the same time that the testers are scaled up
@@ -369,7 +370,7 @@ async def test_upgrade_prometheus_while_rescaling_testers(ops_test: OpsTest, pro
     )
 
 
-@pytest.mark.xfail
+@pytest.mark.skip(reason="xfail")
 async def test_rescale_prometheus_while_upgrading_testers(
     ops_test: OpsTest, prometheus_tester_charm
 ):

--- a/tests/integration/test_remote_write_grafana_agent.py
+++ b/tests/integration/test_remote_write_grafana_agent.py
@@ -150,7 +150,7 @@ async def test_check_data_persist_on_kubectl_delete_pod(ops_test, prometheus_cha
     assert num_head_chunks_before <= num_head_chunks_after
 
 
-@pytest.mark.xfail
+@pytest.mark.skip(reason="xfail")
 async def test_check_data_not_persist_on_scale_0(ops_test, prometheus_charm):
     prometheus_app_name = "prometheus"
 

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -5,9 +5,10 @@
 from unittest.mock import patch
 
 import pytest
-from charm import PrometheusCharm
 from interface_tester import InterfaceTester
 from scenario import Container, ExecOutput, State
+
+from charm import PrometheusCharm
 
 
 def tautology(*_, **__) -> bool:

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -4,8 +4,9 @@
 from unittest.mock import patch
 
 import pytest
-from charm import PrometheusCharm
 from scenario import Context
+
+from charm import PrometheusCharm
 
 
 def tautology(*_, **__) -> bool:

--- a/tests/scenario/test_server_scheme.py
+++ b/tests/scenario/test_server_scheme.py
@@ -49,7 +49,7 @@ class TestServerScheme:
         command = container.layers["prometheus"].services["prometheus"].command
         assert f"--web.external-url=http://{fqdn}:9090" in command
 
-    @pytest.mark.xfail
+    @pytest.mark.skip(reason="xfail")
     def test_pebble_layer_scheme_becomes_https_if_tls_relation_added(
         self, context, initial_state, fqdn
     ):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -96,11 +96,20 @@ class TestCharm(unittest.TestCase):
         rel_id = self.harness.add_relation("ingress", "traefik-ingress")
         self.harness.add_relation_unit(rel_id, "traefik-ingress/0")
 
-        with patch("charms.observability_libs.v0.kubernetes_compute_resources_patch.KubernetesComputeResourcesPatch.is_ready", new=lambda _: True):
-            self.harness.update_relation_data(rel_id, "traefik-ingress", key_values={"ingress": yaml.safe_dump({"prometheus-k8s/0": {"url": "http://test:80"}})})
+        with patch(
+            "charms.observability_libs.v0.kubernetes_compute_resources_patch.KubernetesComputeResourcesPatch.is_ready",
+            new=lambda _: True,
+        ):
+            self.harness.update_relation_data(
+                rel_id,
+                "traefik-ingress",
+                key_values={
+                    "ingress": yaml.safe_dump({"prometheus-k8s/0": {"url": "http://test:80"}})
+                },
+            )
 
         plan = self.harness.get_container_pebble_plan("prometheus")
-        self.assertEqual(cli_arg(plan, "--web.external-url"), f"http://test:80")
+        self.assertEqual(cli_arg(plan, "--web.external-url"), "http://test:80")
 
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -95,6 +95,9 @@ class TestCharm(unittest.TestCase):
 
         rel_id = self.harness.add_relation("ingress", "traefik-ingress")
         self.harness.add_relation_unit(rel_id, "traefik-ingress/0")
+        self.harness.update_relation_data(rel_id, "traefik-ingress/0", key_values={"ingress": yaml.safe_dump({"prometheus/0": {"url": "http://test:80"}})})
+
+        assert self.harness.charm.ingress.url
 
         plan = self.harness.get_container_pebble_plan("prometheus")
         fqdn = socket.getfqdn()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,10 +10,11 @@ from unittest.mock import patch
 
 import ops
 import yaml
-from charm import PROMETHEUS_CONFIG, PrometheusCharm
 from helpers import cli_arg, k8s_resource_multipatch, prom_multipatch
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
+
+from charm import PROMETHEUS_CONFIG, PrometheusCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_charm_status.py
+++ b/tests/unit/test_charm_status.py
@@ -8,11 +8,12 @@ import unittest
 from unittest.mock import Mock, patch
 
 import ops
-from charm import PrometheusCharm
 from helpers import k8s_resource_multipatch, patch_network_get, prom_multipatch
 from ops.model import ActiveStatus, BlockedStatus
 from ops.pebble import Change, ChangeError, ChangeID
 from ops.testing import Harness
+
+from charm import PrometheusCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_prometheus_client.py
+++ b/tests/unit/test_prometheus_client.py
@@ -4,6 +4,7 @@
 import unittest
 
 import responses
+
 from prometheus_client import Prometheus
 
 

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -5,7 +5,6 @@ import json
 import unittest
 from unittest.mock import patch
 
-from charm import Prometheus, PrometheusCharm
 from charms.prometheus_k8s.v1.prometheus_remote_write import (
     DEFAULT_RELATION_NAME as RELATION_NAME,
 )
@@ -26,6 +25,8 @@ from ops import framework
 from ops.charm import CharmBase
 from ops.model import ActiveStatus
 from ops.testing import Harness
+
+from charm import Prometheus, PrometheusCharm
 
 METADATA = f"""
 name: consumer-tester

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -4,13 +4,14 @@
 import unittest
 from unittest.mock import patch
 
-from charm import Prometheus, PrometheusCharm
 from helpers import (
     k8s_resource_multipatch,
     patch_network_get,
     prom_multipatch,
 )
 from ops.testing import Harness
+
+from charm import Prometheus, PrometheusCharm
 
 
 @prom_multipatch

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,7 @@ deps =
     cosl
     fs
     pytest
+    pytest-asyncio
     coverage[toml]
     responses==0.20.0
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
## Issue
Closes #581.  
Closes https://github.com/canonical/alertmanager-k8s-operator/issues/206.

Not sure why we were using the `route_prefix` from the `self.external_url` (from ingress), but adding it to the `self.internal_url` (which is always the FQDN).

## Solution

Use the external URL instead of the internal one.

### Screenshots

Before:
![Screenshot-2024-08-14_10-23](https://github.com/user-attachments/assets/00ed6f4f-8046-41e8-8d63-f4085b295c92)

After:
![Screenshot-2024-08-14_10-39](https://github.com/user-attachments/assets/fd0966a9-2194-4735-8e4c-8f5938fd2fda)


## Testing Instructions

```bash
juju deploy alertmanager-k8s --channel=latest/edge alertmanager
juju deploy prometheus-k8s --channel=latest/edge prometheus
juju deploy traefik-k8s --channel=latest/edge traefik

juju relate prometheus:alertmanager alertmanager
juju relate prometheus:metrics-endpoint alertmanager
# observe the watchdog alert's source link (internal url)
juju relate prometheus:ingress traefik
# wait for things to settle
# observe the same alert's source link again and try to click it!
```


## Upgrade Notes

Anything that refreshes the Pebble plan will activate this change, so the upgrade should be seamless.
