### PR TITLE
test: fix deepdiff transient dep

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,8 @@ deps =
     -r{toxinidir}/requirements.txt
     .[lib_pydeps]
     deepdiff
+    # deepdiff 8.0 requires numpy, see https://github.com/seperman/deepdiff/issues/478
+    numpy
     httpcore==0.14.7
 commands =
     python -m doctest {[vars]src_path}/charm.py
@@ -121,6 +123,8 @@ description = Run integration tests
 deps =
     aiohttp
     deepdiff
+    # deepdiff 8.0 requires numpy, see https://github.com/seperman/deepdiff/issues/478
+    numpy
     .[lib_pydeps]
     # Libjuju needs to track the juju version
     juju ~= 3.1.0


### PR DESCRIPTION
Unit tests failing with

```
collected 110 items / 2 errors

========================================================================================================================== ERRORS ===========================================================================================================================
___________________________________________________________________________________________________ ERROR collecting tests/unit/test_endpoint_provider.py ___________________________________________________________________________________________________
ImportError while importing test module '/code/prometheus-k8s-operator/tests/unit/test_endpoint_provider.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/unit/test_endpoint_provider.py:22: in <module>
    from deepdiff import DeepDiff
    black {[vars]all_path}

[testenv:lint]
description = Check code against coding style standards
deps =
    black
    ruff
    codespell
commands =
.tox/unit/lib/python3.12/site-packages/deepdiff/__init__.py:10: in <module>
    from .diff import DeepDiff
.tox/unit/lib/python3.12/site-packages/deepdiff/diff.py:30: in <module>
    from deepdiff.distance import DistanceMixin, logarithmic_similarity
.tox/unit/lib/python3.12/site-packages/deepdiff/distance.py:1: in <module>
    import numpy as np
E   ModuleNotFoundError: No module named 'numpy'
_______________________________________________________________________________________________________ ERROR collecting tests/unit/test_functions.py _______________________________________________________________________________________________________
test: fix deepdiff transient dep
ImportError while importing test module '/code/prometheus-k8s-operator/tests/unit/test_functions.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/unit/test_functions.py:7: in <module>
    import deepdiff
.tox/unit/lib/python3.12/site-packages/deepdiff/__init__.py:10: in <module>
    from .diff import DeepDiff
.tox/unit/lib/python3.12/site-packages/deepdiff/diff.py:30: in <module>
    from deepdiff.distance import DistanceMixin, logarithmic_similarity
.tox/unit/lib/python3.12/site-packages/deepdiff/distance.py:1: in <module>
    import numpy as np
E   ModuleNotFoundError: No module named 'numpy'
===================================================================================================================== warnings summary ======================================================================================================================
```

see https://github.com/seperman/deepdiff/issues/478