### PR TITLE
forward grafana source UIDs

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -432,7 +432,8 @@ class GrafanaSourceProvider(Object):
     def get_source_uids(self) -> Dict[str, Dict[str, str]]:
         """Get the datasource UID(s) assigned by the remote end(s) to this datasource.
 
-        Returns a mapping from remote application names to unit names to datasource uids."""
+        Returns a mapping from remote application names to unit names to datasource uids.
+        """
         uids = {}
         for rel in self._charm.model.relations.get(self._relation_name, []):
             if not rel:

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -438,7 +438,10 @@ class GrafanaSourceProvider(Object):
         for rel in self._charm.model.relations.get(self._relation_name, []):
             if not rel:
                 continue
-            uids[rel.app.name] = json.loads(rel.data[rel.app]["datasource_uids"])
+            ds_uids_raw = rel.data[rel.app].get("datasource_uids")
+            if not ds_uids_raw:
+                continue
+            uids[rel.app.name] = json.loads(ds_uids_raw)
         return uids
 
     def _set_sources_from_event(self, event: RelationJoinedEvent) -> None:

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -46,7 +46,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 PYDEPS = ["cosl"]
 
@@ -600,7 +600,7 @@ class PrometheusRemoteWriteProvider(Object):
         *,
         server_url_func: Callable[[], str] = lambda: f"http://{socket.getfqdn()}:9090",
         endpoint_path: str = "/api/v1/write",
-        datasource_uids: Optional[Dict[str,Dict[str, str]]] = None
+        datasource_uids: Optional[Dict[str, Dict[str, str]]] = None,
     ):
         """API to manage a provided relation with the `prometheus_remote_write` interface.
 
@@ -682,8 +682,8 @@ class PrometheusRemoteWriteProvider(Object):
         for relation in relations:
             self._set_endpoint_on_relation(relation)
 
-        if self._charm.unit.is_leader() and self._datasource_uids:
-            self._set_datasource_ids_on_relation(relation)
+            if self._datasource_uids:
+                self._set_datasource_ids_on_relation(relation)
 
     def _set_datasource_ids_on_relation(self, relation: Relation) -> None:
         """Set the remote_write endpoint on relations.
@@ -691,6 +691,8 @@ class PrometheusRemoteWriteProvider(Object):
         Args:
             relation: The relation whose data to update.
         """
+        if not self._charm.unit.is_leader():
+            return
         relation.data[self._charm.app]["datasource_uids"] = json.dumps(self._datasource_uids)
 
     def _set_endpoint_on_relation(self, relation: Relation) -> None:

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -524,6 +524,23 @@ class PrometheusRemoteWriteConsumer(Object):
 
         return endpoints
 
+    def get_grafana_datasource_uids(self) -> Optional[Dict[str, Dict[str, Dict[str, str]]]]:
+        """Retrieve the grafana datasource UIDs assigned by grafana to the remote application.
+
+        Returns a mapping from remote application names (prometheus applications)
+        to remote grafana application names to datasource UIDs.
+        This amount of fanning out is unavoidable as each prometheus might be sourced by multiple
+        grafanas, and each remote-write consumer might be remote-writing to multiple prometheai.
+        Technically it won't matter much which datasource uid is chosen, as all data
+        should be copied to all instances.
+        """
+        ds_uids = {}
+        for relation in self.model.relations[self._relation_name]:
+            ds_uids_raw = relation.data[relation.app].get("datasource_uids")
+            if ds_uids_raw:
+                ds_uids[relation.app.name] = json.loads(ds_uids_raw)
+        return ds_uids
+
 
 class PrometheusRemoteWriteAlertsChangedEvent(EventBase):
     """Event emitted when Prometheus remote_write alerts change."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -219,7 +219,7 @@ class PrometheusCharm(CharmBase):
             relation_name=DEFAULT_REMOTE_WRITE_RELATION_NAME,
             server_url_func=lambda: PrometheusCharm.external_url.fget(self),  # type: ignore
             endpoint_path="/api/v1/write",
-            datasource_uids=self.grafana_source_provider.get_source_uids()
+            datasource_uids=self.grafana_source_provider.get_source_uids(),
         )
 
         self.catalogue = CatalogueConsumer(charm=self, item=self._catalogue_item)

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -28,6 +28,12 @@ def prometheus_charm():
         yield PrometheusCharm
 
 
+@pytest.fixture(autouse=True)
+def disable_charm_tracing_buffer():
+    with patch("charms.tempo_coordinator_k8s.v0.charm_tracing._Buffer.save", lambda *_: None):
+        yield
+
+
 @pytest.fixture(scope="function")
 def context(prometheus_charm):
     return Context(charm_type=prometheus_charm, juju_version="3.0.3")

--- a/tests/scenario/test_grafana_source.py
+++ b/tests/scenario/test_grafana_source.py
@@ -1,0 +1,61 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+
+import pytest
+import yaml
+from scenario import Container, ExecOutput, Relation, State
+
+
+@pytest.mark.parametrize("this_app", ("prometheus", "prom"))
+@pytest.mark.parametrize("this_unit_id", (0, 42))
+def test_remote_write_dashboard_uid_propagation(context, this_app, this_unit_id):
+    """Check that the grafana dashboard UIds are propagated over remote-write."""
+    # GIVEN a remote-write relation
+
+    remote_write_relation = Relation(
+        endpoint="receive-remote-write",
+    )
+
+    # AND a grafana-source relation
+    grafana_source_relation = Relation(
+        endpoint="grafana-source",
+        remote_app_name="grafana",
+        local_unit_data={
+            "grafana_source_host": "some-hostname"
+        },
+        local_app_data={
+            "grafana_source_data": json.dumps(
+                {"model": "foo", "model_uuid": "bar", "application": "baz", "type": "tempo"}
+            )
+        },
+
+        remote_app_data={
+            # the datasources provisioned by grafana for this relation
+            "datasource_uids": json.dumps(
+                {
+                    f"{this_app}/{this_unit_id}": f"juju_foo_bar_{this_app}_{this_unit_id}",
+                    # some peer unit
+                    f"{this_app}/{this_unit_id+1}": f"juju_foo_bar_{this_app}_{this_unit_id+1}",
+                 }
+            )
+    }
+    )
+
+    container = Container(
+        name="prometheus",
+        can_connect=True,
+        exec_mock={("update-ca-certificates", "--fresh"): ExecOutput(return_code=0, stdout="")},
+    )
+    state = State(leader=True, containers=[container], relations=[remote_write_relation, grafana_source_relation])
+
+    state_out = context.run(event=grafana_source_relation.changed_event, state=state)
+
+    remote_write_out = state_out.get_relations("receive-remote-write")[0]
+    shared_ds_uids = remote_write_out.local_app_data.get("datasource_uids")
+    assert shared_ds_uids
+
+
+
+

--- a/tests/scenario/test_grafana_source.py
+++ b/tests/scenario/test_grafana_source.py
@@ -4,7 +4,6 @@
 import json
 
 import pytest
-import yaml
 from scenario import Container, ExecOutput, Relation, State
 
 

--- a/tests/scenario/test_grafana_source.py
+++ b/tests/scenario/test_grafana_source.py
@@ -75,6 +75,7 @@ def test_remote_write_dashboard_uid_consumer():
     }
 
     remote_write_relation = Relation(
+        remote_app_name="prometheus",
         endpoint="send-remote-write",
         remote_app_data={"datasource_uids": json.dumps({"grafana": datasource_uids})},
     )
@@ -99,5 +100,5 @@ def test_remote_write_dashboard_uid_consumer():
         charm = mgr.charm
         # THEN we can access prometheus' datasource uids
         assert charm.remote_write.get_grafana_datasource_uids() == {
-            "remote": {"grafana": datasource_uids}
+            "prometheus": {"grafana": datasource_uids}
         }

--- a/tests/scenario/test_grafana_source.py
+++ b/tests/scenario/test_grafana_source.py
@@ -21,15 +21,12 @@ def test_remote_write_dashboard_uid_propagation(context, this_app, this_unit_id)
     grafana_source_relation = Relation(
         endpoint="grafana-source",
         remote_app_name="grafana",
-        local_unit_data={
-            "grafana_source_host": "some-hostname"
-        },
+        local_unit_data={"grafana_source_host": "some-hostname"},
         local_app_data={
             "grafana_source_data": json.dumps(
                 {"model": "foo", "model_uuid": "bar", "application": "baz", "type": "tempo"}
             )
         },
-
         remote_app_data={
             # the datasources provisioned by grafana for this relation
             "datasource_uids": json.dumps(
@@ -37,9 +34,9 @@ def test_remote_write_dashboard_uid_propagation(context, this_app, this_unit_id)
                     f"{this_app}/{this_unit_id}": f"juju_foo_bar_{this_app}_{this_unit_id}",
                     # some peer unit
                     f"{this_app}/{this_unit_id+1}": f"juju_foo_bar_{this_app}_{this_unit_id+1}",
-                 }
+                }
             )
-    }
+        },
     )
 
     container = Container(
@@ -47,14 +44,14 @@ def test_remote_write_dashboard_uid_propagation(context, this_app, this_unit_id)
         can_connect=True,
         exec_mock={("update-ca-certificates", "--fresh"): ExecOutput(return_code=0, stdout="")},
     )
-    state = State(leader=True, containers=[container], relations=[remote_write_relation, grafana_source_relation])
+    state = State(
+        leader=True,
+        containers=[container],
+        relations=[remote_write_relation, grafana_source_relation],
+    )
 
     state_out = context.run(event=grafana_source_relation.changed_event, state=state)
 
     remote_write_out = state_out.get_relations("receive-remote-write")[0]
     shared_ds_uids = remote_write_out.local_app_data.get("datasource_uids")
     assert shared_ds_uids
-
-
-
-

--- a/tests/scenario/test_server_scheme.py
+++ b/tests/scenario/test_server_scheme.py
@@ -34,9 +34,9 @@ class TestServerScheme:
 
             # Add relations
             rels = [
-                Relation("self-metrics-endpoint", relation_id=10),  # external self-monitoring
-                Relation("grafana-source", relation_id=11),  # grafana
-                Relation("receive-remote-write", relation_id=12),  # grafana-agent
+                Relation("self-metrics-endpoint"),  # external self-monitoring
+                Relation("grafana-source"),  # grafana
+                Relation("receive-remote-write"),  # grafana-agent
             ]
             for rel in rels:
                 state = add_relation_sequence(context, state, rel)


### PR DESCRIPTION
## Issue
the `grafana_datasource` interface has been updated to give prometheus back the datasource UID provisioned for its units.
This PR instructs prometheus to forward those UIDs over remote-write, so that applications remote-writing to prometheus, such as Tempo or Loki, can obtain the datasource UIDs that have been created for their datasources.

Tandem PR: https://github.com/canonical/grafana-k8s-operator/pull/359