### PR TITLE
feat: add support for disabling alert rules forwarding

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 39
+LIBPATCH = 41
 
 PYDEPS = ["cosl >= 0.0.50"]
 
@@ -417,8 +417,7 @@ class RelationInterfaceMismatchError(Exception):
         self.expected_relation_interface = expected_relation_interface
         self.actual_relation_interface = actual_relation_interface
         self.message = (
-            "The '{}' relation has '{}' as "
-            "interface rather than the expected '{}'".format(
+            "The '{}' relation has '{}' as " "interface rather than the expected '{}'".format(
                 relation_name, actual_relation_interface, expected_relation_interface
             )
         )
@@ -634,7 +633,10 @@ class CharmedDashboard:
         deletions = []
         for tmpl in dict_content["templating"]["list"]:
             if tmpl["name"] and tmpl["name"] in used_replacements:
-                deletions.append(tmpl)
+                # it might happen that existing template var name is the same as the one we insert (i.e prometheusds or lokids)
+                # in that case, we want to pop the existing one only.
+                if tmpl not in DATASOURCE_TEMPLATE_DROPDOWNS:
+                    deletions.append(tmpl)
 
         for d in deletions:
             dict_content["templating"]["list"].remove(d)
@@ -1601,7 +1603,7 @@ class GrafanaDashboardConsumer(Object):
 
         if not coerced_data == stored_data:
             stored_dashboards = self.get_peer_data("dashboards")
-            stored_dashboards[relation.id] = stored_data
+            stored_dashboards[str(relation.id)] = stored_data
             self.set_peer_data("dashboards", stored_dashboards)
             return True
         return None  # type: ignore

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1847,6 +1847,9 @@ class MetricsEndpointAggregator(Object):
         self.framework.observe(alert_rule_events.relation_changed, self._on_alert_rules_changed)
         self.framework.observe(alert_rule_events.relation_departed, self._on_alert_rules_departed)
 
+        # refresh alert rules on config-changed
+        self.framework.observe(self._charm.on.config_changed, self._on_alert_rules_changed)
+
     def _set_prometheus_data(self, event):
         """Ensure every new Prometheus instances is updated.
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -341,7 +341,7 @@ from urllib.parse import urlparse
 import yaml
 from cosl import JujuTopology
 from cosl.rules import AlertRules, generic_alert_groups
-from ops.charm import CharmBase, RelationRole
+from ops.charm import CharmBase, RelationJoinedEvent, RelationRole
 from ops.framework import (
     BoundEvent,
     EventBase,
@@ -1847,41 +1847,7 @@ class MetricsEndpointAggregator(Object):
         self.framework.observe(alert_rule_events.relation_changed, self._on_alert_rules_changed)
         self.framework.observe(alert_rule_events.relation_departed, self._on_alert_rules_departed)
 
-    def reset_prometheus_alerts(self):
-        """Re-set Prometheus alert rules."""
-        if not self._charm.unit.is_leader():
-            return
-
-        for prometheus_relation in self.model.relations[self._prometheus_relation]:
-            # Gather the alert rules
-            groups = []
-            if self._stored.alert_rules:
-                groups += _type_convert_stored(
-                    self._stored.alert_rules  # pyright: ignore
-                )  # list of alert rule groups
-            for relation in self.model.relations[self._alert_rules_relation]:
-                unit_rules = self._get_alert_rules(relation)
-                if unit_rules and relation.app:
-                    appname = relation.app.name
-                    rules = self._label_alert_rules(unit_rules, appname)
-                    group = {"name": self.group_name(appname), "rules": rules}
-                    groups.append(group)
-            alert_rules = AlertRules(query_type="promql", topology=self.topology)
-            # Add alert rules from file
-            if self.path_to_own_alert_rules:
-                alert_rules.add_path(self.path_to_own_alert_rules, recursive=True)
-            # Add generic alert rules
-            alert_rules.add(
-                generic_alert_groups.application_rules, group_name_prefix=self.topology.identifier
-            )
-            groups.extend(alert_rules.as_dict()["groups"])
-
-            # Set scrape jobs and alert rules in relation data
-            prometheus_relation.data[self._charm.app]["alert_rules"] = json.dumps(
-                {"groups": groups if self._forward_alert_rules else []}
-            )
-
-    def _set_prometheus_data(self, event):
+    def _set_prometheus_data(self, event: Optional[RelationJoinedEvent] = None):
         """Ensure every new Prometheus instances is updated.
 
         Any time a new Prometheus unit joins the relation with
@@ -1922,10 +1888,12 @@ class MetricsEndpointAggregator(Object):
         groups.extend(alert_rules.as_dict()["groups"])
 
         # Set scrape jobs and alert rules in relation data
-        event.relation.data[self._charm.app]["scrape_jobs"] = json.dumps(jobs)
-        event.relation.data[self._charm.app]["alert_rules"] = json.dumps(
-            {"groups": groups if self._forward_alert_rules else []}
-        )
+        relations = [event.relation] if event else self.model.relations[self._prometheus_relation]
+        for rel in relations:
+            rel.data[self._charm.app]["scrape_jobs"] = json.dumps(jobs)  # type: ignore
+            rel.data[self._charm.app]["alert_rules"] = json.dumps(  # type: ignore
+                {"groups": groups if self._forward_alert_rules else []}
+            )
 
     def _on_prometheus_targets_changed(self, event):
         """Update scrape jobs in response to scrape target changes.

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1413,7 +1413,7 @@ class MetricsEndpointProvider(Object):
                 files.  Defaults to "./prometheus_alert_rules",
                 resolved relative to the directory hosting the charm entry file.
                 The alert rules are automatically updated on charm upgrade.
-            forward_alert_rules: a boolean flag to toggle forwarding alert rules.
+            forward_alert_rules: a boolean flag to toggle forwarding of charmed alert rules.
             refresh_event: an optional bound event or list of bound events which
                 will be observed to re-set scrape job data (IP address and others)
             external_url: an optional argument that represents an external url that
@@ -1452,7 +1452,7 @@ class MetricsEndpointProvider(Object):
 
         self._charm = charm
         self._alert_rules_path = alert_rules_path
-        self._enable_alerts = forward_alert_rules
+        self._forward_alert_rules = forward_alert_rules
         self._relation_name = relation_name
         # sanitize job configurations to the supported subset of parameters
         jobs = [] if jobs is None else jobs
@@ -1534,7 +1534,7 @@ class MetricsEndpointProvider(Object):
             return
 
         alert_rules = AlertRules(query_type="promql", topology=self.topology)
-        if self._enable_alerts:
+        if self._forward_alert_rules:
             alert_rules.add_path(self._alert_rules_path, recursive=True)
             alert_rules.add(
                 generic_alert_groups.application_rules, group_name_prefix=self.topology.identifier

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1537,6 +1537,7 @@ class MetricsEndpointProvider(Object):
         if not self._disable_alerts:
             alert_rules.add_path(self._alert_rules_path, recursive=True)
         alert_rules_as_dict = alert_rules.as_dict()
+        logger.info(f"+++ alert_rules_as_dict: {alert_rules_as_dict}")  # TODO: remove, debug
 
         for relation in self._charm.model.relations[self._relation_name]:
             relation.data[self._charm.app]["scrape_metadata"] = json.dumps(self._scrape_metadata)

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1452,7 +1452,7 @@ class MetricsEndpointProvider(Object):
 
         self._charm = charm
         self._alert_rules_path = alert_rules_path
-        self._disable_alerts = forward_alert_rules
+        self._enable_alerts = forward_alert_rules
         self._relation_name = relation_name
         # sanitize job configurations to the supported subset of parameters
         jobs = [] if jobs is None else jobs
@@ -1534,7 +1534,7 @@ class MetricsEndpointProvider(Object):
             return
 
         alert_rules = AlertRules(query_type="promql", topology=self.topology)
-        if not self._disable_alerts:
+        if self._enable_alerts:
             alert_rules.add_path(self._alert_rules_path, recursive=True)
             alert_rules.add(
                 generic_alert_groups.application_rules, group_name_prefix=self.topology.identifier

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1306,10 +1306,11 @@ class MetricsEndpointProvider(Object):
         relation_name: str = DEFAULT_RELATION_NAME,
         jobs=None,
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
-        disable_forwarding_alert_rules: bool = False,
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
         external_url: str = "",
         lookaside_jobs_callable: Optional[Callable] = None,
+        *,
+        forward_alert_rules: bool = True,
     ):
         """Construct a metrics provider for a Prometheus charm.
 
@@ -1412,8 +1413,7 @@ class MetricsEndpointProvider(Object):
                 files.  Defaults to "./prometheus_alert_rules",
                 resolved relative to the directory hosting the charm entry file.
                 The alert rules are automatically updated on charm upgrade.
-            disable_forwarding_alert_rules: a boolean flag to toggle forwarding
-                alert rules.
+            forward_alert_rules: a boolean flag to toggle forwarding alert rules.
             refresh_event: an optional bound event or list of bound events which
                 will be observed to re-set scrape job data (IP address and others)
             external_url: an optional argument that represents an external url that
@@ -1452,7 +1452,7 @@ class MetricsEndpointProvider(Object):
 
         self._charm = charm
         self._alert_rules_path = alert_rules_path
-        self._disable_alerts = disable_forwarding_alert_rules
+        self._disable_alerts = forward_alert_rules
         self._relation_name = relation_name
         # sanitize job configurations to the supported subset of parameters
         jobs = [] if jobs is None else jobs
@@ -1537,7 +1537,6 @@ class MetricsEndpointProvider(Object):
         if not self._disable_alerts:
             alert_rules.add_path(self._alert_rules_path, recursive=True)
         alert_rules_as_dict = alert_rules.as_dict()
-        logger.info(f"+++ alert_rules_as_dict: {alert_rules_as_dict}")  # TODO: remove, debug
 
         for relation in self._charm.model.relations[self._relation_name]:
             relation.data[self._charm.app]["scrape_metadata"] = json.dumps(self._scrape_metadata)

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -442,7 +442,7 @@ class PrometheusRemoteWriteConsumer(Object):
         self._charm = charm
         self._relation_name = relation_name
         self._alert_rules_path = alert_rules_path
-        self._disable_alerts = forward_alert_rules
+        self._enable_alerts = forward_alert_rules
 
         self.topology = JujuTopology.from_charm(charm)
 
@@ -493,7 +493,7 @@ class PrometheusRemoteWriteConsumer(Object):
             return
 
         alert_rules = AlertRules(query_type="promql", topology=self.topology)
-        if not self._disable_alerts:
+        if self._enable_alerts:
             alert_rules.add_path(self._alert_rules_path)
             alert_rules.add(
                 generic_alert_groups.aggregator_rules, group_name_prefix=self.topology.identifier
@@ -501,7 +501,7 @@ class PrometheusRemoteWriteConsumer(Object):
 
         alert_rules_as_dict = alert_rules.as_dict()
 
-        if alert_rules_as_dict or self._disable_alerts:
+        if alert_rules_as_dict or not self._enable_alerts:
             relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
 
     def reload_alerts(self) -> None:

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -460,6 +460,8 @@ class PrometheusRemoteWriteConsumer(Object):
             self._charm.on.upgrade_charm, self._push_alerts_to_all_relation_databags
         )
         if refresh_event:
+            if not isinstance(refresh_event, list):
+                refresh_event = [refresh_event]
             for ev in refresh_event:
                 self.framework.observe(ev, self._push_alerts_to_all_relation_databags)
 

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -456,6 +456,9 @@ class PrometheusRemoteWriteConsumer(Object):
         self.framework.observe(
             self._charm.on.upgrade_charm, self._push_alerts_to_all_relation_databags
         )
+        self.framework.observe(
+            self._charm.on.config_changed, self._push_alerts_to_all_relation_databags
+        )
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         self.on.endpoints_changed.emit(relation_id=event.relation.id)
@@ -492,7 +495,7 @@ class PrometheusRemoteWriteConsumer(Object):
 
         alert_rules_as_dict = alert_rules.as_dict()
 
-        if alert_rules_as_dict:
+        if alert_rules_as_dict or self._disable_alerts:
             relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
 
     def reload_alerts(self) -> None:

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -46,7 +46,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 PYDEPS = ["cosl"]
 
@@ -401,6 +401,7 @@ class PrometheusRemoteWriteConsumer(Object):
         charm: CharmBase,
         relation_name: str = DEFAULT_CONSUMER_NAME,
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
+        disable_forwarding_alert_rules: bool = False,
     ):
         """API to manage a required relation with the `prometheus_remote_write` interface.
 
@@ -409,6 +410,7 @@ class PrometheusRemoteWriteConsumer(Object):
             relation_name: Name of the relation with the `prometheus_remote_write` interface as
                 defined in metadata.yaml.
             alert_rules_path: Path of the directory containing the alert rules.
+            disable_forwarding_alert_rules: Flag to toggle alert rule forwarding.
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -437,6 +439,7 @@ class PrometheusRemoteWriteConsumer(Object):
         self._charm = charm
         self._relation_name = relation_name
         self._alert_rules_path = alert_rules_path
+        self._disable_alerts = disable_forwarding_alert_rules
 
         self.topology = JujuTopology.from_charm(charm)
 
@@ -484,7 +487,8 @@ class PrometheusRemoteWriteConsumer(Object):
             return
 
         alert_rules = AlertRules(query_type="promql", topology=self.topology)
-        alert_rules.add_path(self._alert_rules_path)
+        if not self._disable_alerts:
+            alert_rules.add_path(self._alert_rules_path)
 
         alert_rules_as_dict = alert_rules.as_dict()
 


### PR DESCRIPTION
## Issue
First step in addressing https://github.com/canonical/grafana-agent-operator/issues/154


## Solution
Allow charm authors to pass `forward_alert_rules=False` to both `MetricsEndpointProvider` (scrape) and `PrometheusRemoteWriteConsumer` (remote write).

When the flag is `True`, the alert rules information is simply not put in relation data.

## Testing Instructions
Pack and deploy both this charm and grafana-agent from https://github.com/canonical/grafana-agent-operator/pull/252 , and test the new config option.

## Screenshots

### prometheus_scrape

![Screenshot-2025-02-05_10-12](https://github.com/user-attachments/assets/9f56f2d8-63d9-42bd-904e-212b8478792d)

### prometheus_remote_write

![Screenshot-2025-02-05_10-33](https://github.com/user-attachments/assets/8ef61f0a-1c17-4eff-a3d9-d8b8b9be7135)
