### PR TITLE
fix pydeps version

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -364,7 +364,8 @@ LIBAPI = 0
 # to 0 if you are raising the major API version
 LIBPATCH = 50
 
-PYDEPS = ["cosl"]
+# Version 0.0.53 needed for cosl.rules.generic_alert_groups
+PYDEPS = ["cosl>=0.0.53"]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Prometheus needs a specific version of cosl, so we should reflect that in pydeps.