### PR TITLE
fix: deepcopy the generic alert groups in cos-proxy library

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 51
+LIBPATCH = 52
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -1884,7 +1884,8 @@ class MetricsEndpointAggregator(Object):
             alert_rules.add_path(self.path_to_own_alert_rules, recursive=True)
         # Add generic alert rules
         alert_rules.add(
-            generic_alert_groups.application_rules, group_name_prefix=self.topology.identifier
+            copy.deepcopy(generic_alert_groups.application_rules),
+            group_name_prefix=self.topology.identifier,
         )
         groups.extend(alert_rules.as_dict()["groups"])
 


### PR DESCRIPTION
## Issue
`cos-proxy` is failing unit tests because of this line.

## Context
This PR is needed because the failing unit tests are blocking the migration to CI v1 for cos-proxy.