### PR TITLE
feat(terraform): add module for charm deployment

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,40 @@
+# Terraform module for `prometheus-k8s`
+
+
+This is a Terraform module facilitating the deployment of the `prometheus-k8s` charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+
+## Requirements
+
+This module requires a Juju model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+
+The module offers the following configurable inputs:
+
+| Name          | Type     | Description                                     | Default     |
+|---------------|----------|-------------------------------------------------|-------------|
+| `app_name`    | string   | Application name                                | prometheus  |
+| `channel`     | string   | Channel that the charm is deployed from         | latest/edge |
+| `config`      | map(any) | Map of the charm configuration options          | {}          |
+| `constraints` | string   | Constraints for the Juju deployment             | ""          |
+| `model_name`  | string   | Name of the model that the charm is deployed on |             |
+| `revision`    | number   | Revision number of the charm name               | null        |
+| `units`       | number   | Number of units to deploy                       | 1           |
+
+### Outputs
+
+Upon applied, the module exports the following outputs:
+
+| Name       | Description                 |
+|------------|-----------------------------|
+| `app_name` | Application name            |
+| `requires` | Map of `requires` endpoints |
+
+## Usage
+
+Users should ensure that Terraform is aware of the `juju_model` dependency of the charm module.
+
+To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>"`

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,7 @@
 resource "juju_application" "prometheus" {
-  name = var.app_name
+  name  = var.app_name
   model = var.model_name
-  
+
   trust = true # We always need this variable to be true in order to be able to apply resources limits. 
 
   charm {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,15 @@
+resource "juju_application" "prometheus" {
+  name = var.app_name
+  model = var.model_name
+  
+  trust = true # We always need this variable to be true in order to be able to apply resources limits. 
+
+  charm {
+    name     = "prometheus-k8s"
+    channel  = var.channel
+    revision = var.revision
+  }
+
+  units  = var.units
+  config = var.config
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,26 @@
+output "app_name" {
+  value = juju_application.prometheus.name
+}
+
+output "endpoints" {
+  value = {
+    # Requires
+
+    metrics_endpoint      = "metrics-endpoint"
+    alertmanager          = "alertmanager"
+    ingress               = "ingress"
+    catalogue             = "catalogue"
+    certificates          = "certificates"
+    charm_tracing         = "charm-tracing"
+    workload_tracing      = "workload-tracing"
+
+    # Provides
+
+    self_metrics_endpoint = "self-metrics-endpoint"
+    grafana_source        = "grafana-source"
+    grafana_dashboard     = "grafana-dashboard"
+    receive_remote_write  = "receive-remote-write"
+    send_datasource       = "send-datasource"
+    prometheus_api        = "prometheus-api"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -6,13 +6,13 @@ output "endpoints" {
   value = {
     # Requires
 
-    metrics_endpoint      = "metrics-endpoint"
-    alertmanager          = "alertmanager"
-    ingress               = "ingress"
-    catalogue             = "catalogue"
-    certificates          = "certificates"
-    charm_tracing         = "charm-tracing"
-    workload_tracing      = "workload-tracing"
+    metrics_endpoint = "metrics-endpoint"
+    alertmanager     = "alertmanager"
+    ingress          = "ingress"
+    catalogue        = "catalogue"
+    certificates     = "certificates"
+    charm_tracing    = "charm-tracing"
+    workload_tracing = "workload-tracing"
 
     # Provides
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,42 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "config" {
+  description = "Config options as in the ones we pass in juju config"
+  type        = map(string)
+  default     = {}
+}
+
+# We use constraints to set AntiAffinity in K8s
+# https://discourse.charmhub.io/t/pod-priority-and-affinity-in-juju-charms/4091/13?u=jose
+variable "constraints" {
+  description = "Constraints to be applied"
+  type        = string
+  default     = ""
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  nullable    = true
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units"
+  type        = number
+  default     = 1
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14"
+    }
+  }
+}


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
There is currently no terraform module available for deploying Prometheus.

## Solution
<!-- A summary of the solution addressing the above issue -->
Add a terraform module

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Clone repo
2. `terraform init`
3. `terraform apply -var="model_name=<MODEL_NAME>"`

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
Add terraform module for COS Lite flavor of Prometheus