### PR TITLE
fix: Failing test on main

### DIFF
--- a/tests/unit/test_endpoint_aggregator.py
+++ b/tests/unit/test_endpoint_aggregator.py
@@ -600,7 +600,13 @@ class TestEndpointAggregator(unittest.TestCase):
         groups = alert_rules.get("groups", [])
         # THEN the relation data contains only the generic alerts
         self.assertEqual(len(groups), len(generic_alert_groups.application_rules))
-        self.assertListEqual(groups, generic_alert_groups.application_rules["groups"])
+        alert_rules_generic = [r["alert"] for g in groups for r in g["rules"]]
+        alert_rules_labeled = [
+            r["alert"]
+            for g in generic_alert_groups.application_rules["groups"]
+            for r in g["rules"]
+        ]
+        self.assertEqual(alert_rules_generic, alert_rules_labeled)
 
 
 class TestEndpointAggregatorWithRelabeling(unittest.TestCase):


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This test is failing on main because 

```
{'name': 'testmodel_12de4fae_aggregator_tester_HostHealth_alerts',
 'rules': [{'alert': 'HostDown',
            'annotations': {'description': "Host '{{ $labels.instance }}' is "
                                           'down, failed to scrape.\n'
                                           '                            VALUE '
                                           '= {{ $value }}\n'
                                           '                            LABELS '
                                           '= {{ $labels }}',
                            'summary': "Host '{{ $labels.instance }}' is "
                                       'down.'},
            'expr': 'up{juju_application="aggregator-tester",juju_model="testmodel",juju_model_uuid="12de4fae-06cc-4ceb-9089-567be09fec78"} '
                    '< 1',
            'for': '5m',
            'labels': {'juju_application': 'aggregator-tester',
                       'juju_charm': 'aggregator-tester',
                       'juju_model': 'testmodel',
                       'juju_model_uuid': '12de4fae-06cc-4ceb-9089-567be09fec78',
                       'severity': 'critical'}},
           {'alert': 'HostMetricsMissing',
            'annotations': {'description': "Metrics not received from host '{{ "
                                           "$labels.instance }}', failed to "
                                           'remote write.\n'
                                           '                            VALUE '
                                           '= {{ $value }}\n'
                                           '                            LABELS '
                                           '= {{ $labels }}',
                            'summary': "Metrics not received from host '{{ "
                                       "$labels.instance }}', failed to remote "
                                       'write.'},
            'expr': 'absent(up{juju_application="aggregator-tester",juju_model="testmodel",juju_model_uuid="12de4fae-06cc-4ceb-9089-567be09fec78"})',
            'for': '5m',
            'labels': {'juju_application': 'aggregator-tester',
                       'juju_charm': 'aggregator-tester',
                       'juju_model': 'testmodel',
                       'juju_model_uuid': '12de4fae-06cc-4ceb-9089-567be09fec78',
                       'severity': 'critical'}}]}

```
Versus the one from the COS Lib variable
```
{'name': 'HostHealth',
 'rules': [{'alert': 'HostDown',
            'annotations': {'description': "Host '{{ $labels.instance }}' is "
                                           'down, failed to scrape.\n'
                                           '                            VALUE '
                                           '= {{ $value }}\n'
                                           '                            LABELS '
                                           '= {{ $labels }}',
                            'summary': "Host '{{ $labels.instance }}' is "
                                       'down.'},
            'expr': 'up < 1',
            'for': '5m',
            'labels': {'severity': 'critical'}},
           {'alert': 'HostMetricsMissing',
            'annotations': {'description': "Metrics not received from host '{{ "
                                           "$labels.instance }}', failed to "
                                           'remote write.\n'
                                           '                            VALUE '
                                           '= {{ $value }}\n'
                                           '                            LABELS '
                                           '= {{ $labels }}',
                            'summary': "Metrics not received from host '{{ "
                                       "$labels.instance }}', failed to remote "
                                       'write.'},
            'expr': 'absent(up)',
            'for': '5m',
            'labels': {'severity': 'critical'}}]}

```

## Solution
<!-- A summary of the solution addressing the above issue -->
Iterate through both of their alert rule names and compare equality.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
`tox -e unit -- tests/unit/test_endpoint_aggregator.py`


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
