### PR TITLE
fix: Handle ops unit databag more safely

### DIFF
--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -529,17 +529,17 @@ class PrometheusRemoteWriteConsumer(Object):
                 if unit.app is self._charm.app:
                     # This is a peer unit
                     continue
+                if not (unit_databag := relation.data.get(unit)):
+                    continue
+                if not (remote_write := unit_databag.get("remote_write")):
+                    continue
 
-                unit_databag = relation.data.get(unit)
-                if unit_databag:
-                    remote_write = unit_databag.get("remote_write")
-                    if remote_write:
-                        deserialized_remote_write = json.loads(remote_write)
-                        endpoints.append(
-                            {
-                                "url": deserialized_remote_write["url"],
-                            }
-                        )
+                deserialized_remote_write = json.loads(remote_write)
+                endpoints.append(
+                    {
+                        "url": deserialized_remote_write["url"],
+                    }
+                )
 
         # When multiple units of the remote-write server are behind an ingress
         # (e.g. mimir), relation data would end up with the same ingress url


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Sometimes the relation.unit does not exist. We need to ensure it does before handling the unit's databag.
