### PR TITLE
feat: block Prometheus charm when available disk space is insufficient

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -590,6 +590,7 @@ class PrometheusCharm(CharmBase):
             database_storage = self.model.storages.get('database', [])
             if database_storage and shutil.disk_usage(database_storage[0].location).free < 1e9: # type: ignore
                 self._stored.status["disk_space"] = to_tuple(BlockedStatus("Less than 1 Gi remaining in storage"))
+
         # If this check is done before storage is attached, we don't want the charm to go error state
         except FileNotFoundError:
             self.unit.status = BlockedStatus("Storage not available")

--- a/src/charm.py
+++ b/src/charm.py
@@ -752,7 +752,7 @@ class PrometheusCharm(CharmBase):
             self._configure(event)
         try:
             database_storage = self.model.storages.get('database', [])
-            if database_storage and shutil.disk_usage(database_storage.location).free < 1e9:
+            if database_storage and shutil.disk_usage(database_storage.location).free < 1e9: # type: ignore
                 self._stored.status["config"] = to_tuple(BlockedStatus("Less than 1 Gi remaining in storage"))
         # If this check is done before storage is attached, we don't want the charm to go error state
         except FileNotFoundError:

--- a/src/charm.py
+++ b/src/charm.py
@@ -129,6 +129,7 @@ def to_status(tpl: Tuple[str, str]) -> StatusBase:
     name, message = tpl
     return StatusBase.from_name(name, message)
 
+
 @dataclass
 class TLSConfig:
     """TLS configuration received by the charm over the `certificates` relation."""
@@ -136,6 +137,7 @@ class TLSConfig:
     server_cert: str
     ca_cert: str
     private_key: str
+
 
 @trace_charm(
     tracing_endpoint="charm_tracing_endpoint",
@@ -269,7 +271,9 @@ class PrometheusCharm(CharmBase):
         self.framework.observe(self.on.update_status, self._update_status)
         self.framework.observe(self.ingress.on.ready_for_unit, self._on_ingress_ready)
         self.framework.observe(self.ingress.on.revoked_for_unit, self._on_ingress_revoked)
-        self.framework.observe(self._cert_requirer.on.certificate_available, self._on_certificate_available)
+        self.framework.observe(
+            self._cert_requirer.on.certificate_available, self._on_certificate_available
+        )
         self.framework.observe(self.remote_write_provider.on.alert_rules_changed, self._configure)
         self.framework.observe(self.remote_write_provider.on.consumers_changed, self._configure)
         self.framework.observe(self.metrics_consumer.on.targets_changed, self._configure)
@@ -573,7 +577,9 @@ class PrometheusCharm(CharmBase):
 
             # Repeat for the charm container. We need it there for prometheus client requests.
             ca_cert_path.parent.mkdir(exist_ok=True, parents=True)
-            ca_cert_path.write_text(tls_config.ca_cert,)  # pyright: ignore
+            ca_cert_path.write_text(
+                tls_config.ca_cert,
+            )  # pyright: ignore
         else:
             self.container.remove_path(CERT_PATH, recursive=True)
             self.container.remove_path(KEY_PATH, recursive=True)
@@ -587,10 +593,12 @@ class PrometheusCharm(CharmBase):
 
     def _check_disk_space(self):
         try:
-            #database_storage = self.model.storages.get('database', []) #self.model.storages["database"]
+            # database_storage = self.model.storages.get('database', []) #self.model.storages["database"]
             database_storage = self.model.storages["database"]
-            if database_storage and shutil.disk_usage(database_storage[0].location).free < 1024**3: # type: ignore
-                self._stored.status["disk_space"] = to_tuple(BlockedStatus("<1 GiB disk space remaining"))
+            if database_storage and shutil.disk_usage(database_storage[0].location).free < 1024**3:  # type: ignore
+                self._stored.status["disk_space"] = to_tuple(
+                    BlockedStatus("<1 GiB disk space remaining")
+                )
             else:
                 self._stored.status["disk_space"] = to_tuple(ActiveStatus())
         # If this check is done before storage is attached, we don't want the charm to go error state
@@ -743,6 +751,7 @@ class PrometheusCharm(CharmBase):
                 "Cannot set workload version at this time: could not get Prometheus version."
             )
         self._check_disk_space()
+
     def _update_layer(self) -> bool:
         current_planned_services = self.container.get_plan().services
         new_layer = self._prometheus_layer
@@ -908,9 +917,9 @@ class PrometheusCharm(CharmBase):
         # Assuming the storage name is "database" (must match metadata.yaml).
         # This assertion would be picked up by every integration test so no concern this would
         # reach production.
-        assert (
-            "database" in self.model.storages
-        ), "The 'database' storage is no longer in metadata: must update literals in charm code."
+        assert "database" in self.model.storages, (
+            "The 'database' storage is no longer in metadata: must update literals in charm code."
+        )
 
         # Get PVC capacity from kubernetes
         client = Client()  # pyright: ignore

--- a/src/charm.py
+++ b/src/charm.py
@@ -594,18 +594,20 @@ class PrometheusCharm(CharmBase):
     def _check_disk_space(self):
         try:
             database_storage = self.model.storages["database"]
-            if database_storage:
-                # NOTE: we measure the disk space from the charm container because it shares the same storage as the workload container
-                free_disk_space = shutil.disk_usage(database_storage[0].location).free
-                if free_disk_space < 1024**3:
-                    self._stored.status["disk_space"] = to_tuple(
-                        BlockedStatus("<1 GiB disk space remaining")
-                    )
-                else:
-                    self._stored.status["disk_space"] = to_tuple(ActiveStatus())
+
+            # NOTE: we measure the disk space from the charm container because it shares the same storage as the workload container
+            free_disk_space = shutil.disk_usage(database_storage[0].location).free
+
         # If this check is done before storage is attached, we don't want the charm to go error state
         except FileNotFoundError:
             self._stored.status["disk_space"] = MaintenanceStatus("Storage not available")
+        else:
+            if free_disk_space < 1024**3:
+                self._stored.status["disk_space"] = to_tuple(
+                    BlockedStatus("<1 GiB disk space remaining")
+                )
+            else:
+                self._stored.status["disk_space"] = to_tuple(ActiveStatus())
 
     def _configure(self, _):
         """Reconfigure and either reload or restart Prometheus.

--- a/src/charm.py
+++ b/src/charm.py
@@ -587,7 +587,8 @@ class PrometheusCharm(CharmBase):
 
     def _check_disk_space(self):
         try:
-            database_storage = self.model.storages.get('database', [])
+            #database_storage = self.model.storages.get('database', []) #self.model.storages["database"]
+            database_storage = self.model.storages["database"]
             if database_storage and shutil.disk_usage(database_storage[0].location).free < 1024**3: # type: ignore
                 self._stored.status["disk_space"] = to_tuple(BlockedStatus("<1 GiB disk space remaining"))
             else:
@@ -904,7 +905,7 @@ class PrometheusCharm(CharmBase):
         This may need to be handled differently once Juju supports multiple storage instances
         for k8s (https://bugs.launchpad.net/juju/+bug/1977775).
         """
-        # Assuming the storage name is "databases" (must match metadata.yaml).
+        # Assuming the storage name is "database" (must match metadata.yaml).
         # This assertion would be picked up by every integration test so no concern this would
         # reach production.
         assert (

--- a/src/charm.py
+++ b/src/charm.py
@@ -593,14 +593,16 @@ class PrometheusCharm(CharmBase):
 
     def _check_disk_space(self):
         try:
-            # database_storage = self.model.storages.get('database', []) #self.model.storages["database"]
             database_storage = self.model.storages["database"]
-            if database_storage and shutil.disk_usage(database_storage[0].location).free < 1024**3:  # type: ignore
-                self._stored.status["disk_space"] = to_tuple(
-                    BlockedStatus("<1 GiB disk space remaining")
-                )
-            else:
-                self._stored.status["disk_space"] = to_tuple(ActiveStatus())
+            if database_storage:
+                # NOTE: we measure the disk space from the charm container because it shares the same storage as the workload container
+                free_disk_space = shutil.disk_usage(database_storage[0].location).free
+                if free_disk_space < 1024**3:
+                    self._stored.status["disk_space"] = to_tuple(
+                        BlockedStatus("<1 GiB disk space remaining")
+                    )
+                else:
+                    self._stored.status["disk_space"] = to_tuple(ActiveStatus())
         # If this check is done before storage is attached, we don't want the charm to go error state
         except FileNotFoundError:
             self._stored.status["disk_space"] = MaintenanceStatus("Storage not available")

--- a/tests/integration/prometheus-tester/lib/charms/observability_libs/v0/juju_topology.py
+++ b/tests/integration/prometheus-tester/lib/charms/observability_libs/v0/juju_topology.py
@@ -202,7 +202,8 @@ class JujuTopology:
 
         if remapped_keys:
             ret = OrderedDict(
-                (remapped_keys.get(k), v) if remapped_keys.get(k) else (k, v) for k, v in ret.items()  # type: ignore
+                (remapped_keys.get(k), v) if remapped_keys.get(k) else (k, v)
+                for k, v in ret.items()  # type: ignore
             )
 
         return ret

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -12,7 +12,7 @@ from charms.prometheus_k8s.v0.prometheus_scrape import CosTool as _CosTool_scrap
 from charms.prometheus_k8s.v1.prometheus_remote_write import (
     CosTool as _CosTool_remote_write,
 )
-from scenario import Container, Context, Exec, PeerRelation, Relation, State
+from scenario import Container, Context, Exec, PeerRelation, Relation, State, Storage
 
 PROJECT_DIR = Path(__file__).resolve().parent.parent.parent
 UNITTEST_DIR = Path(__file__).resolve().parent
@@ -93,7 +93,9 @@ def begin_with_initial_hooks_isolated(context: Context, *, leader: bool = True) 
         can_connect=False,
         execs={Exec(["update-ca-certificates", "--fresh"], return_code=0, stdout="")},
     )
-    state = State(containers=[container])
+    storage = Storage(name="database")
+    state = State(containers=[container], storages=[storage])
+
     peer_rel = PeerRelation("prometheus-peers")
 
     state = context.run(context.on.install(), state)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -28,6 +28,7 @@ SCRAPE_METADATA = {
     "charm_name": "provider-charm",
 }
 
+
 @prom_multipatch
 class TestCharm(unittest.TestCase):
     @k8s_resource_multipatch
@@ -248,6 +249,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config({"evaluation_interval": "1234m"})
         self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, MaintenanceStatus)
+
 
 def alerting_config(config):
     config_yaml = config[1]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -249,18 +249,14 @@ class TestCharm(unittest.TestCase):
         self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, MaintenanceStatus)
 
-    '''def test_blocked_state_when_insufficient_space(self):
+    def test_blocked_state_when_insufficient_space(self):
         # Patch the function used in _check_disk_space
         with patch("shutil.disk_usage") as mock_disk_usage:
-            # Set the return value of the mock to simulate insufficient space
             mock_disk_usage.return_value.free = 1e8
-
-            # Call the method you want to test
             self.harness.charm._check_disk_space()
 
-            # Assert the expected behavior, e.g., check the status
             self.harness.evaluate_status()
-            self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)'''
+            self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
 
 def alerting_config(config):
     config_yaml = config[1]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,7 +6,7 @@ import logging
 import socket
 import unittest
 import uuid
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import ops
 import yaml
@@ -248,21 +248,6 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config({"evaluation_interval": "1234m"})
         self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, MaintenanceStatus)
-
-    def test_check_disk_space(self):
-        test_cases = [
-            (1024**3, ActiveStatus),
-            (1024**3 - 1, BlockedStatus),
-        ]
-        for disk_space, expected_status in test_cases:
-            with self.subTest(disk_space=disk_space, expected_status=expected_status), \
-                patch("shutil.disk_usage") as mock_disk_usage, \
-                patch.object(self.harness.model.storages, 'get', return_value=[MagicMock(location="/foo/bar")]):
-
-                mock_disk_usage.return_value.free = disk_space
-                self.harness.charm._check_disk_space()
-                self.harness.evaluate_status()
-                self.assertIsInstance(self.harness.model.unit.status, expected_status)
 
 def alerting_config(config):
     config_yaml = config[1]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -251,7 +251,7 @@ class TestCharm(unittest.TestCase):
 
     def test_check_disk_space(self):
         test_cases = [
-            (1e10, ActiveStatus),  
+            (1e10, ActiveStatus),
             (1e8, BlockedStatus),
         ]
         # Patch the function used in _check_disk_space

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -45,6 +45,7 @@ class TestCharm(unittest.TestCase):
         self.mock_capacity.return_value = "1Gi"
         self.harness.container_pebble_ready("prometheus")
         self.harness.handle_exec("prometheus", ["update-ca-certificates"], result=0)
+        self.harness.add_storage("database")
         self.harness.begin_with_initial_hooks()
 
     def test_grafana_is_provided_port_and_source(self):
@@ -282,6 +283,7 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
         patcher = patch.object(PrometheusCharm, "_get_pvc_capacity")
         self.mock_capacity = patcher.start()
         self.addCleanup(patcher.stop)
+        self.harness.add_storage("database")
 
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
@@ -456,6 +458,7 @@ class TestAlertsFilename(unittest.TestCase):
         self.mock_capacity.return_value = "1Gi"
         self.harness.container_pebble_ready("prometheus")
         self.harness.handle_exec("prometheus", ["update-ca-certificates"], result=0)
+        self.harness.add_storage("database")
         self.harness.begin_with_initial_hooks()
 
         self.rel_id = self.harness.add_relation(RELATION_NAME, "remote-app")
@@ -581,6 +584,7 @@ class TestPebblePlan(unittest.TestCase):
         self.mock_capacity.return_value = "1Gi"
         self.harness.container_pebble_ready("prometheus")
         self.harness.handle_exec("prometheus", ["update-ca-certificates"], result=0)
+        self.harness.add_storage("database")
         self.harness.begin_with_initial_hooks()
 
         self.container_name = self.harness.charm._name
@@ -679,6 +683,7 @@ class TestTlsConfig(unittest.TestCase):
         self.mock_capacity.return_value = "1Gi"
         self.harness.container_pebble_ready("prometheus")
         self.harness.handle_exec("prometheus", ["update-ca-certificates"], result=0)
+        self.harness.add_storage("database")
         self.harness.begin_with_initial_hooks()
 
     @k8s_resource_multipatch

--- a/tests/unit/test_charm_status.py
+++ b/tests/unit/test_charm_status.py
@@ -46,6 +46,8 @@ class TestActiveStatus(unittest.TestCase):
         self.mock_capacity.return_value = "1Gi"
         self.addCleanup(patcher.stop)
 
+        self.harness.add_storage("database")
+
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
     def test_unit_is_active_if_deployed_without_relations_or_config(self, *unused):

--- a/tests/unit/test_check_disk_space.py
+++ b/tests/unit/test_check_disk_space.py
@@ -8,17 +8,25 @@ import pytest
 from ops.testing import ActiveStatus, BlockedStatus, State, Storage
 
 
-@pytest.mark.parametrize("disk_space,expected_status",
-             [(1024**4, ActiveStatus()),
-              (1024**3, ActiveStatus()),
-              (1024**3-1, BlockedStatus('<1 GiB disk space remaining')),
-              (0, BlockedStatus('<1 GiB disk space remaining')),
-              (-1, BlockedStatus('<1 GiB disk space remaining'))])
+@pytest.mark.parametrize(
+    "disk_space,expected_status",
+    [
+        (1024**4, ActiveStatus()),
+        (1024**3, ActiveStatus()),
+        (1024**3 - 1, BlockedStatus("<1 GiB disk space remaining")),
+        (0, BlockedStatus("<1 GiB disk space remaining")),
+        (-1, BlockedStatus("<1 GiB disk space remaining")),
+    ],
+)
 def test_datasource_send(context, prometheus_container, disk_space, expected_status):
-    state = State(containers=[prometheus_container], storages=[Storage(name="database")],leader=True)
-    with patch("shutil.disk_usage") as mock_disk_usage, patch("charm.PrometheusCharm._get_pvc_capacity") as get_pvc_mock:
+    state = State(
+        containers=[prometheus_container], storages=[Storage(name="database")], leader=True
+    )
+    with patch("shutil.disk_usage") as mock_disk_usage, patch(
+        "charm.PrometheusCharm._get_pvc_capacity"
+    ) as get_pvc_mock:
         mock_disk_usage.return_value.free = disk_space
-        get_pvc_mock.return_value="1Gi"
+        get_pvc_mock.return_value = "1Gi"
 
         state_out = context.run(context.on.update_status(), state)
         assert state_out.unit_status == expected_status

--- a/tests/unit/test_check_disk_space.py
+++ b/tests/unit/test_check_disk_space.py
@@ -1,0 +1,24 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+from unittest.mock import patch
+
+import pytest
+from ops.testing import ActiveStatus, BlockedStatus, State, Storage
+
+
+@pytest.mark.parametrize("disk_space,expected_status",
+             [(1024**4, ActiveStatus()),
+              (1024**3, ActiveStatus()),
+              (1024**3-1, BlockedStatus('<1 GiB disk space remaining')),
+              (0, BlockedStatus('<1 GiB disk space remaining')),
+              (-1, BlockedStatus('<1 GiB disk space remaining'))])
+def test_datasource_send(context, prometheus_container, disk_space, expected_status):
+    state = State(containers=[prometheus_container], storages=[Storage(name="database")],leader=True)
+    with patch("shutil.disk_usage") as mock_disk_usage, patch("charm.PrometheusCharm._get_pvc_capacity") as get_pvc_mock:
+        mock_disk_usage.return_value.free = disk_space
+        get_pvc_mock.return_value="1Gi"
+
+        state_out = context.run(context.on.update_status(), state)
+        assert state_out.unit_status == expected_status

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -241,6 +241,7 @@ class TestRemoteWriteProvider(unittest.TestCase):
         self.mock_capacity = patcher.start()
         self.mock_capacity.return_value = "1Gi"
         self.addCleanup(patcher.stop)
+        self.harness.add_storage("database")
 
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")

--- a/tests/unit/test_server_scheme.py
+++ b/tests/unit/test_server_scheme.py
@@ -43,7 +43,7 @@ class TestServerScheme:
 
             yield state  # keep the patch active for so long as this fixture is needed
 
-    def test_initial_state_has_http_scheme_in_pebble_layer(self, context, initial_state, fqdn):
+    def test_initial_state_has_http_scheme_in_pebble_layer(self, initial_state, fqdn):
         # THEN the pebble command has 'http' and the correct hostname in the 'web.external-url' arg
         container = initial_state.get_container("prometheus")
         command = container.layers["prometheus"].services["prometheus"].command

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -26,6 +26,7 @@ class TestTls(unittest.TestCase):
         self.mock_capacity = patcher.start()
         self.mock_capacity.return_value = "1Gi"
         self.addCleanup(patcher.stop)
+        self.harness.add_storage("database")
 
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ commands =
 [testenv:fmt]
 description = "Format the code"
 commands =
-    uv run {[vars]uv_flags} ruff check --fix-only {[vars]all_path}
+    uv run {[vars]uv_flags} ruff format {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This PR fixes #717, fixes #715.

PR #720 should be merged into this PR before this is merged into `main`.

## Solution
<!-- A summary of the solution addressing the above issue -->
On the `update_status` hook and `pebble_ready`, it checks the disk space left for Prometheus' database storage. If less than 1 GiB (to be exact, 1024**3) remains, the charm state is set to blocked, along with a message that says `<1 GiB disk space remaining`.

Note that this PR touches some extra files due to the switch to `ruff format` in `tox.ini` as recommended by @lucabello.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Unless the user uses an overlay when deploying Prometheus, by default they get 1 GiB of storage. This is insufficient in most cases as it tends to run out quickly. As a result of this PR, the charm will always get set to blocked when not deployed with an overlay, until we start setting a higher disk space for this charm in its `charmcraft.yaml`.

## Testing Instructions

You can rely on the unit tests for testing.


