### PR TITLE
chore: add storage to unit tests

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -601,8 +601,6 @@ class PrometheusCharm(CharmBase):
         # If this check is done before storage is attached, we don't want the charm to go error state
         except FileNotFoundError:
             self._stored.status["disk_space"] = MaintenanceStatus("Storage not available")
-        except KeyError:
-            self._stored.status["disk_space"] = to_tuple(BlockedStatus("Unable to locate storage"))
         else:
             if free_disk_space < 1024**3:
                 self._stored.status["disk_space"] = to_tuple(

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -12,7 +12,7 @@ from charms.prometheus_k8s.v0.prometheus_scrape import CosTool as _CosTool_scrap
 from charms.prometheus_k8s.v1.prometheus_remote_write import (
     CosTool as _CosTool_remote_write,
 )
-from scenario import Container, Context, Exec, PeerRelation, Relation, State
+from scenario import Container, Context, Exec, PeerRelation, Relation, State, Storage
 
 PROJECT_DIR = Path(__file__).resolve().parent.parent.parent
 UNITTEST_DIR = Path(__file__).resolve().parent
@@ -93,7 +93,9 @@ def begin_with_initial_hooks_isolated(context: Context, *, leader: bool = True) 
         can_connect=False,
         execs={Exec(["update-ca-certificates", "--fresh"], return_code=0, stdout="")},
     )
-    state = State(containers=[container])
+    storage = Storage(name="database")
+    state = State(containers=[container], storages=[storage])
+
     peer_rel = PeerRelation("prometheus-peers")
 
     state = context.run(context.on.install(), state)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -45,6 +45,7 @@ class TestCharm(unittest.TestCase):
         self.mock_capacity.return_value = "1Gi"
         self.harness.container_pebble_ready("prometheus")
         self.harness.handle_exec("prometheus", ["update-ca-certificates"], result=0)
+        self.harness.add_storage("database")
         self.harness.begin_with_initial_hooks()
 
     def test_grafana_is_provided_port_and_source(self):
@@ -282,6 +283,7 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
         patcher = patch.object(PrometheusCharm, "_get_pvc_capacity")
         self.mock_capacity = patcher.start()
         self.addCleanup(patcher.stop)
+        self.harness.add_storage("database")
 
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
@@ -456,6 +458,7 @@ class TestAlertsFilename(unittest.TestCase):
         self.mock_capacity.return_value = "1Gi"
         self.harness.container_pebble_ready("prometheus")
         self.harness.handle_exec("prometheus", ["update-ca-certificates"], result=0)
+        self.harness.add_storage("database")
         self.harness.begin_with_initial_hooks()
 
         self.rel_id = self.harness.add_relation(RELATION_NAME, "remote-app")
@@ -581,6 +584,7 @@ class TestPebblePlan(unittest.TestCase):
         self.mock_capacity.return_value = "1Gi"
         self.harness.container_pebble_ready("prometheus")
         self.harness.handle_exec("prometheus", ["update-ca-certificates"], result=0)
+        self.harness.add_storage("database")
         self.harness.begin_with_initial_hooks()
 
         self.container_name = self.harness.charm._name
@@ -679,6 +683,7 @@ class TestTlsConfig(unittest.TestCase):
         self.mock_capacity.return_value = "1Gi"
         self.harness.container_pebble_ready("prometheus")
         self.harness.handle_exec("prometheus", ["update-ca-certificates"], result=0)
+        self.harness.add_storage("database")
         self.harness.begin_with_initial_hooks()
 
     @k8s_resource_multipatch

--- a/tests/unit/test_charm_status.py
+++ b/tests/unit/test_charm_status.py
@@ -46,6 +46,8 @@ class TestActiveStatus(unittest.TestCase):
         self.mock_capacity.return_value = "1Gi"
         self.addCleanup(patcher.stop)
 
+        self.harness.add_storage("database")
+
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
     def test_unit_is_active_if_deployed_without_relations_or_config(self, *unused):

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -241,6 +241,7 @@ class TestRemoteWriteProvider(unittest.TestCase):
         self.mock_capacity = patcher.start()
         self.mock_capacity.return_value = "1Gi"
         self.addCleanup(patcher.stop)
+        self.harness.add_storage("database")
 
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")

--- a/tests/unit/test_server_scheme.py
+++ b/tests/unit/test_server_scheme.py
@@ -43,7 +43,7 @@ class TestServerScheme:
 
             yield state  # keep the patch active for so long as this fixture is needed
 
-    def test_initial_state_has_http_scheme_in_pebble_layer(self, context, initial_state, fqdn):
+    def test_initial_state_has_http_scheme_in_pebble_layer(self, initial_state, fqdn):
         # THEN the pebble command has 'http' and the correct hostname in the 'web.external-url' arg
         container = initial_state.get_container("prometheus")
         command = container.layers["prometheus"].services["prometheus"].command

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -26,6 +26,7 @@ class TestTls(unittest.TestCase):
         self.mock_capacity = patcher.start()
         self.mock_capacity.return_value = "1Gi"
         self.addCleanup(patcher.stop)
+        self.harness.add_storage("database")
 
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
PR #719 attempts to block the charm when the disk space is below 1 GiB. For this purpose, it adds checks in the `pebble_ready` and `update_status` hooks which get the database location and use `shutil` to get its remaining disk size. However, the older unit tests which rely on Harness do not add a storage during test setup and as a result, they fail.

## Solution
<!-- A summary of the solution addressing the above issue -->
This PR uses the `harness.add_storage()` method to add a storage to the PrometheusCharm under test.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
`tox -e unit` should pass (and it does).

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
