### PR TITLE
chore: change status message when blocked due to invalid retention size

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -22,7 +22,7 @@ links:
 
 assumes:
   - k8s-api
-  - juju >= 3.6 
+  - juju >= 3.6
 
 platforms:
   ubuntu@24.04:amd64:
@@ -91,7 +91,7 @@ provides:
     interface: prometheus_api
     optional: true
     description: |
-      The integration point for other charms to consume Prometheus's API, for example so they can query the database. 
+      The integration point for other charms to consume Prometheus's API, for example so they can query the database.
 
 requires:
   metrics-endpoint:
@@ -187,6 +187,7 @@ config:
         "80%").
         The percentage value is then converted to bytes and passed to prometheus with the
         `--storage.tsdb.retention.size` argument.
+        If this field is set to an invalid value, the `--storage.tsdb.retention.size` argument is dropped. In such cases, retention is only determined by `metrics_retention_time`. 
         Default is 80%.
       type: string
       default: "80%"

--- a/src/charm.py
+++ b/src/charm.py
@@ -830,7 +830,7 @@ class PrometheusCharm(CharmBase):
         except ValueError as e:
             logger.warning(e)
             self._stored.status["retention_size"] = to_tuple(
-                BlockedStatus(f"Invalid retention size: {e}")
+                BlockedStatus(f"Invalid retention size: {e}, using metrics_retention_time")
             )
 
         else:
@@ -972,7 +972,7 @@ class PrometheusCharm(CharmBase):
             ValueError, if the percentage string is invalid or not within range.
         """
         if not percentage.endswith("%"):
-            raise ValueError("Percentage string must be a number followed by '%', e.g. '80%'")
+            raise ValueError("Must be a number followed by '%', e.g. '80%'")
         value = float(percentage[:-1]) / 100.0
         if value < 0 or value > 1:
             raise ValueError("Percentage value must be in the range 0-100.")

--- a/src/charm.py
+++ b/src/charm.py
@@ -830,7 +830,7 @@ class PrometheusCharm(CharmBase):
         except ValueError as e:
             logger.warning(e)
             self._stored.status["retention_size"] = to_tuple(
-                BlockedStatus(f"Invalid retention size: {e}, using metrics_retention_time")
+                BlockedStatus(f"Invalid retention size: {e}, only metrics_retention_time is in effect")
             )
 
         else:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -352,6 +352,15 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
         self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
 
+        # AND WHEN the config option is set to another invalid string
+        self.harness.update_config({"maximum_retention_size": "4GiB"})
+
+        # THEN cli arg is unspecified and the unit is blocked
+        plan = self.harness.get_container_pebble_plan("prometheus")
+        self.assertIsNone(cli_arg(plan, "--storage.tsdb.retention.size"))
+        self.harness.evaluate_status()
+        self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
+
         # AND WHEN the config option is corrected
         self.harness.update_config({"maximum_retention_size": "42%"})
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
There is sometimes confusion when data is retained for longer than intended in scenarios where the config value for `maximum_retention_size` is invalid, such as when it's not a percentage. In such cases, if there is a valid config value for `metrics_retention_time`, then that is applied.

## Solution
<!-- A summary of the solution addressing the above issue -->
Based on feedback receives by support:
- Makes this more clear in the charm configs
- Clarifies this in the status message: `Invalid retention size: Must be a number followed by '%', e.g. '80%', using retention time now`. To avoid having an overly long message, it changes the previous message from `Invalid retention size: Percentage string must be a number followed by '%', e.g. '80%'` to `Invalid retention size: Must be a number followed by '%', e.g. '80%', using retention time now`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
