### PR TITLE
chore: bump cosl and import is_valid_timespec

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "cosl"
-version = "1.0.0"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ops" },
@@ -1049,9 +1049,9 @@ dependencies = [
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/13/ca147298721702679f2a286022184fd12b9d5236124308bf363e7184e5b5/cosl-1.0.0.tar.gz", hash = "sha256:5cef884faac1313ae6d234fcd6f40db0cbdd44bcdacfd9a6e9ecf9cede219359", size = 40818, upload-time = "2025-05-22T13:26:16.284Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/23/a683e493a84f60a3c516ecc3c7a498007f7f84883b34ed4f96659cbe3637/cosl-1.2.0.tar.gz", hash = "sha256:7aea30d1ee3a34e4a04d75646a55f94f9dd7482354950f01d81a918448d5e9a9", size = 44828, upload-time = "2025-09-23T14:03:34.747Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/58/e80bd8436e2a6bb80b62b0317711d48ef1cab4b38e0e9f1efe73d13c0187/cosl-1.0.0-py3-none-any.whl", hash = "sha256:4ed54e818a5614a5164011253c12441cd0bffacfd99c8bd6b5b9740a397e482d", size = 33525, upload-time = "2025-05-22T13:26:14.804Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d9/5ebff004d5febfdd1255ae5096f59488ec4d859baafaa383f2b52ed5abd7/cosl-1.2.0-py3-none-any.whl", hash = "sha256:527a5c960f4d098a718ae849684f355132d69021094c48a72ec7212074e6682c", size = 36128, upload-time = "2025-09-23T14:03:33.443Z" },
 ]
 
 [[package]]
@@ -1364,7 +1364,7 @@ version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
[A recent PR](https://github.com/canonical/cos-lib/pull/154) in `cosl` added a timespec validation check which was released in version 1.2.0. This PR bumps the version of `cosl` to 1.2.0 and imports the check.

## Solution
<!-- A summary of the solution addressing the above issue -->
The imported check replaces the `_is_valid_timespec` check that the Prometheus charm currently implements.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
