### PR TITLE
fix: Remove minor version pin

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.14"
+      version = ">= 0.20.0"
     }
   }
 }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Partially fixes:
- https://github.com/canonical/observability-stack/issues/97

## Solution
<!-- A summary of the solution addressing the above issue -->
Update the pin so that we do not force the provider to a specific minor version `0.14`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
I updated the Prometheus TF module from this branch in the COS Lite TF module and ran `terraform validate` to ensure it is compatible.

```hcl
module "prometheus" {
  source             = "git::https://github.com/canonical/prometheus-k8s-operator//terraform?ref=fix/tf-pin"
  # snip ...
}
```

```shell
observability-stack/terraform/cos-lite
❯ terraform providers

Providers required by configuration:
.
├── provider[registry.terraform.io/juju/juju] >= 0.20.0
├── module.ssc
│   └── provider[registry.terraform.io/juju/juju] >= 0.20.0
├── module.traefik
│   └── provider[registry.terraform.io/juju/juju] >= 0.14.0
├── module.alertmanager
│   └── provider[registry.terraform.io/juju/juju] >= 0.14.0
├── module.catalogue
│   └── provider[registry.terraform.io/juju/juju] >= 0.14.0
├── module.grafana
│   └── provider[registry.terraform.io/juju/juju] >= 0.14.0
├── module.loki
│   └── provider[registry.terraform.io/juju/juju] >= 0.20.0
└── module.prometheus
    └── provider[registry.terraform.io/juju/juju] >= 0.20.0

observability-stack/terraform/cos-lite
❯ tfv
                      
Success! The configuration is valid.
```

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
