### PR TITLE
fix: Prometheus should accept CA certs from root store when scraping

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1132,13 +1132,7 @@ class PrometheusCharm(CharmBase):
             # prometheus and all scrape jobs are signed by the same CA.
 
             ca_file = tls_config.get("ca_file")
-            if not ca_file and self._tls_config:
-                ca_file = self._tls_config.ca_cert
-
             if ca_file:
-                # TODO we shouldn't be passing CA certs over relation data, because that
-                #  reduces to self-signed certs. Both parties need to separately trust the CA
-                #  instead.
                 filename = f"{PROMETHEUS_DIR}/{job['job_name']}-ca.crt"
                 certs[filename] = ca_file
                 job["tls_config"] = {**tls_config, **{"ca_file": filename}}


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Prometheus should accept CA certs from root store when scraping IFF the target does not provide its own CA file.

<img width="513" height="589" alt="image" src="https://github.com/user-attachments/assets/a54698e4-564e-4cc2-a7a4-1ad31eff0e05" />

## Solution
<!-- A summary of the solution addressing the above issue -->
Do not write Prometheus' CA file (which Prom gets from its CA when it is serving via TLS) to the scrape configs. This then means that only that CA file can be used for scraping that target. This is not always the case, and we want to support using the CA certs from the root CA store, e.g. when `receive-ca-cert` relation exists.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Related:
- https://github.com/canonical/prometheus-k8s-operator/pull/750

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Deploy COS Lite via TF with `full TLS`:
	- https://documentation.ubuntu.com/observability/latest/how-to/configure-tls-encryption/
2. Open the Prom UI and check the targets, which should fail to scrape Grafana since we need to trust the CA which signed Grafana's ingress.
3. Refresh Prometheus with the locally packed charm
Scraping now passes.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
