### PR TITLE
fix: add `juju_unit` label to non-wildcard scrape targets when unit can be identified

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1227,9 +1227,9 @@ class MetricsEndpointConsumer(Object):
 
         Returns:
             A dict mapping each unit name to a ``(address, path, fqdn)`` tuple. The
-            ``fqdn`` element may be an empty string when the FQDN is not known; when
-            present, it may either be distinct from or equal to ``address`` (for
-            example, when the unit address itself is already a hostname).
+            ``fqdn`` element may be an empty string when the FQDN is not known. When
+            present, it may either be distinct from, or equal to ``address``. For
+            example, when the unit address itself is already a hostname.
         """
         hosts = {}
         for unit in relation.units:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -555,7 +555,8 @@ class PrometheusConfig:
                 continue
 
             # Accumulates non-wildcard targets that could not be matched to any known unit.
-            # These are kept in a single job without juju_unit, preserving original behaviour.
+            # These are kept in a single job with topology-only labels (no juju_unit):
+            # fully-qualified targets that predate this feature are unaffected.
             unmatched_static_configs = []
 
             for static_config in static_configs:
@@ -582,7 +583,7 @@ class PrometheusConfig:
 
                 # Non-wildcard targets: try to match each target's host against known unit
                 # addresses. Matched targets get a per-unit job with juju_unit; unmatched
-                # targets fall back to the previous behaviour (no juju_unit label).
+                # targets get topology-only labels with no per-unit expansion.
                 if non_wildcard_targets:
                     unmatched_targets = []
                     matched_by_unit: Dict[str, List[str]] = {}
@@ -598,7 +599,8 @@ class PrometheusConfig:
                         else:
                             unmatched_targets.append(target)
 
-                    # Unmatched targets: no unit mapping found — preserve original behaviour.
+                    # Unmatched targets: no unit mapping found — kept with topology-only
+                    # labels and no per-unit expansion (juju_unit is not added).
                     if unmatched_targets:
                         unmatched_static_config = static_config.copy()
                         unmatched_static_config["targets"] = unmatched_targets

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -513,15 +513,17 @@ class PrometheusConfig:
     ) -> List[dict]:
         """Extract wildcard hosts from the given scrape_configs list into separate jobs.
 
-        For wildcard targets (e.g. "*:9093"), one job per unit is created with the
-        corresponding ``juju_unit`` topology label.
+        For wildcard targets (e.g. "*:9093"), one job per unit is created. When
+        ``topology`` is provided, the ``juju_unit`` label is injected into each
+        per-unit job; without ``topology`` the per-unit jobs are created but no
+        topology labels are added.
 
         For non-wildcard targets (fully qualified hostnames/IPs), the host portion of
         each target is matched against the known unit addresses in ``hosts``. Targets
-        whose address matches a known unit are expanded into a per-unit job with the
-        ``juju_unit`` label, mirroring the wildcard behaviour. Targets with no match
-        (e.g. external services) are kept in a single job without ``juju_unit``,
-        preserving the previous behaviour.
+        whose address matches a known unit are expanded into a per-unit job (with
+        ``juju_unit`` when ``topology`` is provided), mirroring the wildcard behaviour.
+        Targets with no match (e.g. external services) are kept in a single job without
+        ``juju_unit``, preserving the previous behaviour.
 
         Args:
             scrape_jobs: list of scrape jobs.
@@ -529,6 +531,8 @@ class PrometheusConfig:
                 all units of the relation for which this job configuration must be
                 constructed.
             topology: optional arg for adding topology labels to scrape targets.
+                When ``None``, per-unit jobs are still created for wildcard and matched
+                non-wildcard targets, but no ``juju_unit`` or topology labels are added.
         """
         # Reverse lookup: both unit address and FQDN → unit name, so that non-wildcard
         # targets specified as either IP or FQDN can be matched to their Juju unit.
@@ -1220,9 +1224,10 @@ class MetricsEndpointConsumer(Object):
             relation: the relation to read unit data from.
 
         Returns:
-            A dict mapping each unit name to a ``(address, path, fqdn)`` tuple, where
-            ``fqdn`` is an empty string when the unit address is already a hostname
-            (e.g. when ``external_url`` is set) or when the FQDN is not available.
+            A dict mapping each unit name to a ``(address, path, fqdn)`` tuple. The
+            ``fqdn`` element may be an empty string when the FQDN is not known; when
+            present, it may either be distinct from or equal to ``address`` (for
+            example, when the unit address itself is already a hostname).
         """
         hosts = {}
         for unit in relation.units:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1634,12 +1634,12 @@ class MetricsEndpointProvider(Object):
                 unit_fqdn = unit_address
                 path = ""
 
-            relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = unit_address
-            relation.data[self._charm.unit]["prometheus_scrape_unit_path"] = path
-            relation.data[self._charm.unit]["prometheus_scrape_unit_name"] = str(
-                self._charm.model.unit.name
-            )
-            relation.data[self._charm.unit]["prometheus_scrape_unit_fqdn"] = unit_fqdn
+            relation.data[self._charm.unit].update({
+                "prometheus_scrape_unit_address": unit_address,
+                "prometheus_scrape_unit_path": path,
+                "prometheus_scrape_unit_name": str(self._charm.model.unit.name),
+                "prometheus_scrape_unit_fqdn": unit_fqdn,
+            })
 
     def _is_valid_unit_address(self, address: str) -> bool:
         """Validate a unit address.

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -488,21 +488,20 @@ class PrometheusConfig:
         unit_num = unit_name.split("/")[-1]
         new_static = static_config.copy()
         new_static["targets"] = targets
+        new_job = job.copy()
+        new_job["job_name"] = new_job.get("job_name", "unnamed-job") + "-" + unit_num
+        new_job["metrics_path"] = unit_path + (new_job.get("metrics_path") or "/metrics")
         if topology:
             new_static["labels"] = {
                 **topology.label_matcher_dict,
                 "juju_unit": unit_name,
                 **new_static.get("labels", {}),
             }
-        new_job = job.copy()
-        new_job["job_name"] = new_job.get("job_name", "unnamed-job") + "-" + unit_num
-        new_job["metrics_path"] = unit_path + (new_job.get("metrics_path") or "/metrics")
-        new_job["static_configs"] = [new_static]
-        if topology:
             # Instance relabeling for topology should be last in order.
             new_job["relabel_configs"] = new_job.get("relabel_configs", []) + [
                 PrometheusConfig.topology_relabel_config_wildcard
             ]
+        new_job["static_configs"] = [new_static]
         return new_job
 
     @staticmethod

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -535,9 +535,10 @@ class PrometheusConfig:
                 is skipped entirely (all non-wildcard targets are kept in a single job),
                 since matching only serves the purpose of injecting ``juju_unit`` labels.
         """
-        # Reverse lookup: both unit address and FQDN → unit name, so that non-wildcard
-        # targets specified as either IP or FQDN can be matched to their Juju unit.
-        # {addr, fqdn} deduplicates in the case where address is already a FQDN.
+        # Build a reverse lookup: {address: unit_name, fqdn: unit_name, ...}
+        # so that non-wildcard targets can be matched whether specified as IP or FQDN.
+        # The set subtraction {addr, fqdn} - {""} drops empty strings (absent FQDN)
+        # and deduplicates when addr == fqdn (non-IP bind address).
         host_to_unit: Dict[str, str] = (
             {
                 identifier: unit_name

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -531,8 +531,10 @@ class PrometheusConfig:
                 all units of the relation for which this job configuration must be
                 constructed.
             topology: optional arg for adding topology labels to scrape targets.
-                When ``None``, per-unit jobs are still created for wildcard and matched
-                non-wildcard targets, but no ``juju_unit`` or topology labels are added.
+                When ``None``, wildcard targets are still expanded into per-unit jobs but
+                no ``juju_unit`` or topology labels are added. Non-wildcard target matching
+                is skipped entirely (all non-wildcard targets are kept in a single job),
+                since matching only serves the purpose of injecting ``juju_unit`` labels.
         """
         # Reverse lookup: both unit address and FQDN → unit name, so that non-wildcard
         # targets specified as either IP or FQDN can be matched to their Juju unit.

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -361,7 +361,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 56
+LIBPATCH = 57
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -462,21 +462,86 @@ class PrometheusConfig:
         return modified_scrape_configs
 
     @staticmethod
+    def _build_per_unit_job(
+        job: dict,
+        static_config: dict,
+        targets: List[str],
+        unit_name: str,
+        unit_path: str,
+        topology: Optional[JujuTopology],
+    ) -> dict:
+        """Build a single per-unit scrape job with topology labels and relabeling rules.
+
+        Used for both wildcard and matched non-wildcard targets to avoid duplication.
+
+        Args:
+            job: the original scrape job dict to base the new job on.
+            static_config: the original static_config dict to copy labels from.
+            targets: the resolved target addresses for this unit.
+            unit_name: the Juju unit name (e.g. "alertmanager/0").
+            unit_path: path prefix to prepend to the metrics path (from external URL, may be "").
+            topology: optional topology for adding Juju labels.
+
+        Returns:
+            A new scrape job dict for this unit.
+        """
+        unit_num = unit_name.split("/")[-1]
+        new_static = static_config.copy()
+        new_static["targets"] = targets
+        if topology:
+            new_static["labels"] = {
+                **topology.label_matcher_dict,
+                "juju_unit": unit_name,
+                **new_static.get("labels", {}),
+            }
+        new_job = job.copy()
+        new_job["job_name"] = new_job.get("job_name", "unnamed-job") + "-" + unit_num
+        new_job["metrics_path"] = unit_path + (new_job.get("metrics_path") or "/metrics")
+        new_job["static_configs"] = [new_static]
+        if topology:
+            # Instance relabeling for topology should be last in order.
+            new_job["relabel_configs"] = new_job.get("relabel_configs", []) + [
+                PrometheusConfig.topology_relabel_config_wildcard
+            ]
+        return new_job
+
+    @staticmethod
     def expand_wildcard_targets_into_individual_jobs(
         scrape_jobs: List[dict],
-        hosts: Dict[str, Tuple[str, str]],
+        hosts: Dict[str, Tuple[str, str, str]],
         topology: Optional[JujuTopology] = None,
     ) -> List[dict]:
         """Extract wildcard hosts from the given scrape_configs list into separate jobs.
 
+        For wildcard targets (e.g. "*:9093"), one job per unit is created with the
+        corresponding ``juju_unit`` topology label.
+
+        For non-wildcard targets (fully qualified hostnames/IPs), the host portion of
+        each target is matched against the known unit addresses in ``hosts``. Targets
+        whose address matches a known unit are expanded into a per-unit job with the
+        ``juju_unit`` label, mirroring the wildcard behaviour. Targets with no match
+        (e.g. external services) are kept in a single job without ``juju_unit``,
+        preserving the previous behaviour.
+
         Args:
             scrape_jobs: list of scrape jobs.
-            hosts: a dictionary mapping host names to host address for
-                all units of the relation for which this job configuration
-                must be constructed.
+            hosts: a dictionary mapping unit names to ``(address, path, fqdn)`` tuples for
+                all units of the relation for which this job configuration must be
+                constructed.
             topology: optional arg for adding topology labels to scrape targets.
         """
-        # hosts = self._relation_hosts(relation)
+        # Reverse lookup: both unit address and FQDN → unit name, so that non-wildcard
+        # targets specified as either IP or FQDN can be matched to their Juju unit.
+        # {addr, fqdn} deduplicates in the case where address is already a FQDN.
+        host_to_unit: Dict[str, str] = (
+            {
+                identifier: unit_name
+                for unit_name, (addr, _, fqdn) in hosts.items()
+                for identifier in {addr, fqdn} - {""}
+            }
+            if topology
+            else {}
+        )
 
         modified_scrape_jobs = []
         for job in scrape_jobs:
@@ -484,9 +549,9 @@ class PrometheusConfig:
             if not static_configs:
                 continue
 
-            # When a single unit specified more than one wildcard target, then they are expanded
-            # into a static_config per target
-            non_wildcard_static_configs = []
+            # Accumulates non-wildcard targets that could not be matched to any known unit.
+            # These are kept in a single job without juju_unit, preserving original behaviour.
+            unmatched_static_configs = []
 
             for static_config in static_configs:
                 targets = static_config.get("targets")
@@ -510,58 +575,55 @@ class PrometheusConfig:
                         # This is not a wildcard target. Copy it over into its own static_config.
                         non_wildcard_targets.append(target)
 
-                # All non-wildcard targets remain in the same static_config
+                # Non-wildcard targets: try to match each target's host against known unit
+                # addresses. Matched targets get a per-unit job with juju_unit; unmatched
+                # targets fall back to the previous behaviour (no juju_unit label).
                 if non_wildcard_targets:
-                    non_wildcard_static_config = static_config.copy()
-                    non_wildcard_static_config["targets"] = non_wildcard_targets
+                    unmatched_targets = []
+                    matched_by_unit: Dict[str, List[str]] = {}
 
-                    if topology:
-                        # When non-wildcard targets (aka fully qualified hostnames) are specified,
-                        # there is no reliable way to determine the name (Juju topology unit name)
-                        # for such a target. Therefore labeling with Juju topology, excluding the
-                        # unit name.
-                        non_wildcard_static_config["labels"] = {
-                            **topology.label_matcher_dict,
-                            **non_wildcard_static_config.get("labels", {}),
-                        }
+                    for target in non_wildcard_targets:
+                        target_host = target.split(":")[0]
+                        matched_unit = host_to_unit.get(target_host)
+                        if matched_unit:
+                            matched_by_unit.setdefault(matched_unit, []).append(target)
+                        else:
+                            unmatched_targets.append(target)
 
-                    non_wildcard_static_configs.append(non_wildcard_static_config)
+                    # Unmatched targets: no unit mapping found — preserve original behaviour.
+                    if unmatched_targets:
+                        unmatched_static_config = static_config.copy()
+                        unmatched_static_config["targets"] = unmatched_targets
+                        if topology:
+                            unmatched_static_config["labels"] = {
+                                **topology.label_matcher_dict,
+                                **unmatched_static_config.get("labels", {}),
+                            }
+                        unmatched_static_configs.append(unmatched_static_config)
+
+                    # Matched targets: one per-unit job with juju_unit label.
+                    for unit_name, unit_targets_list in matched_by_unit.items():
+                        modified_scrape_jobs.append(
+                            PrometheusConfig._build_per_unit_job(
+                                job, static_config, unit_targets_list, unit_name, "", topology
+                            )
+                        )
 
                 # Extract wildcard targets into individual jobs
                 if wildcard_targets:
-                    for unit_name, (unit_hostname, unit_path) in hosts.items():
-                        modified_job = job.copy()
-                        modified_job["static_configs"] = [static_config.copy()]
-                        modified_static_config = modified_job["static_configs"][0]
-                        modified_static_config["targets"] = [
+                    for unit_name, (unit_hostname, unit_path, _unit_fqdn) in hosts.items():
+                        resolved_targets = [
                             target.replace("*", unit_hostname) for target in wildcard_targets
                         ]
-
-                        unit_num = unit_name.split("/")[-1]
-                        job_name = modified_job.get("job_name", "unnamed-job") + "-" + unit_num
-                        modified_job["job_name"] = job_name
-                        modified_job["metrics_path"] = unit_path + (
-                            job.get("metrics_path") or "/metrics"
+                        modified_scrape_jobs.append(
+                            PrometheusConfig._build_per_unit_job(
+                                job, static_config, resolved_targets, unit_name, unit_path, topology
+                            )
                         )
 
-                        if topology:
-                            # Add topology labels
-                            modified_static_config["labels"] = {
-                                **topology.label_matcher_dict,
-                                **{"juju_unit": unit_name},
-                                **modified_static_config.get("labels", {}),
-                            }
-
-                            # Instance relabeling for topology should be last in order.
-                            modified_job["relabel_configs"] = modified_job.get(
-                                "relabel_configs", []
-                            ) + [PrometheusConfig.topology_relabel_config_wildcard]
-
-                        modified_scrape_jobs.append(modified_job)
-
-            if non_wildcard_static_configs:
+            if unmatched_static_configs:
                 modified_job = job.copy()
-                modified_job["static_configs"] = non_wildcard_static_configs
+                modified_job["static_configs"] = unmatched_static_configs
                 modified_job["metrics_path"] = modified_job.get("metrics_path") or "/metrics"
 
                 if topology:
@@ -1147,8 +1209,17 @@ class MetricsEndpointConsumer(Object):
         # are expected to be made available by the charm via the `update-ca-certificates` mechanism.
         return scrape_configs
 
-    def _relation_hosts(self, relation: Relation) -> Dict[str, Tuple[str, str]]:
-        """Returns a mapping from unit names to (address, path) tuples, for the given relation."""
+    def _relation_hosts(self, relation: Relation) -> Dict[str, Tuple[str, str, str]]:
+        """Returns a mapping from unit names to (address, path, fqdn) tuples.
+
+        Args:
+            relation: the relation to read unit data from.
+
+        Returns:
+            A dict mapping each unit name to a ``(address, path, fqdn)`` tuple, where
+            ``fqdn`` is an empty string when the unit address is already a hostname
+            (e.g. when ``external_url`` is set) or when the FQDN is not available.
+        """
         hosts = {}
         for unit in relation.units:
             if not (unit_databag := relation.data.get(unit)):
@@ -1161,11 +1232,12 @@ class MetricsEndpointConsumer(Object):
             unit_address = unit_databag.get("prometheus_scrape_unit_address") or unit_databag.get(
                 "prometheus_scrape_host"
             )
+            unit_fqdn = unit_databag.get("prometheus_scrape_unit_fqdn", "")
 
             if not (unit_name and unit_address):
                 continue
 
-            hosts.update({unit_name: (unit_address, unit_path)})
+            hosts.update({unit_name: (unit_address, unit_path, unit_fqdn)})
 
         return hosts
 
@@ -1540,11 +1612,14 @@ class MetricsEndpointProvider(Object):
                 parsed = urlparse(self.external_url)
                 unit_address = parsed.hostname
                 path = parsed.path
+                unit_fqdn = ""
             elif self._is_valid_unit_address(unit_ip):
                 unit_address = unit_ip
+                unit_fqdn = socket.getfqdn()
                 path = ""
             else:
                 unit_address = socket.getfqdn()
+                unit_fqdn = unit_address
                 path = ""
 
             relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = unit_address
@@ -1552,6 +1627,7 @@ class MetricsEndpointProvider(Object):
             relation.data[self._charm.unit]["prometheus_scrape_unit_name"] = str(
                 self._charm.model.unit.name
             )
+            relation.data[self._charm.unit]["prometheus_scrape_unit_fqdn"] = unit_fqdn
 
     def _is_valid_unit_address(self, address: str) -> bool:
         """Validate a unit address.

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -583,7 +583,10 @@ class PrometheusConfig:
                     matched_by_unit: Dict[str, List[str]] = {}
 
                     for target in non_wildcard_targets:
-                        target_host = target.split(":")[0]
+                        # Use urlparse to correctly handle IPv6 addresses (e.g. [::1]:9093)
+                        # as well as plain host:port and bare hostnames.
+                        parsed = urlparse(f"//{target}")
+                        target_host = parsed.hostname or target.split(":", 1)[0]
                         matched_unit = host_to_unit.get(target_host)
                         if matched_unit:
                             matched_by_unit.setdefault(matched_unit, []).append(target)
@@ -603,9 +606,10 @@ class PrometheusConfig:
 
                     # Matched targets: one per-unit job with juju_unit label.
                     for unit_name, unit_targets_list in matched_by_unit.items():
+                        _, unit_path, _ = hosts.get(unit_name, ("", "", ""))
                         modified_scrape_jobs.append(
                             PrometheusConfig._build_per_unit_job(
-                                job, static_config, unit_targets_list, unit_name, "", topology
+                                job, static_config, unit_targets_list, unit_name, unit_path, topology
                             )
                         )
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -462,6 +462,77 @@ class PrometheusConfig:
         return modified_scrape_configs
 
     @staticmethod
+    def _build_host_to_unit(
+        hosts: Dict[str, Tuple[str, str, str]],
+        topology: Optional[JujuTopology],
+    ) -> Dict[str, str]:
+        """Build a reverse lookup dict: {address: unit_name, fqdn: unit_name, ...}.
+
+        Maps each known unit identifier (IP address and/or FQDN) to its unit name,
+        so that non-wildcard targets can be matched whether specified as IP or FQDN.
+
+        Returns an empty dict when ``topology`` is None, since matching only serves
+        the purpose of injecting ``juju_unit`` labels.
+
+        The set subtraction ``{addr, fqdn} - {""}`` drops empty strings (absent FQDN,
+        e.g. when external_url is set) and deduplicates when addr == fqdn (non-IP
+        bind address).
+        """
+        if not topology:
+            return {}
+        return {
+            identifier: unit_name
+            for unit_name, (addr, _, fqdn) in hosts.items()
+            for identifier in {addr, fqdn} - {""}
+        }
+
+    @staticmethod
+    def _classify_targets(targets: List[str]) -> Tuple[List[str], List[str]]:
+        """Split a list of targets into wildcard and non-wildcard targets.
+
+        Returns:
+            A ``(wildcard_targets, non_wildcard_targets)`` tuple.
+        """
+        wildcard_targets = []
+        non_wildcard_targets = []
+        wildcard_re = re.compile(r"\*(?:(:\d+))?")
+        for target in targets:
+            if wildcard_re.match(target):
+                wildcard_targets.append(target)
+            else:
+                non_wildcard_targets.append(target)
+        return wildcard_targets, non_wildcard_targets
+
+    @staticmethod
+    def _match_non_wildcard_targets(
+        targets: List[str],
+        host_to_unit: Dict[str, str],
+    ) -> Tuple[Dict[str, List[str]], List[str]]:
+        """Match non-wildcard targets against known unit addresses.
+
+        Parses the host portion of each target (handling IPv6 bracket notation) and
+        looks it up in ``host_to_unit``.
+
+        Returns:
+            A ``(matched_by_unit, unmatched_targets)`` tuple where ``matched_by_unit``
+            maps each matched unit name to the list of targets belonging to it, and
+            ``unmatched_targets`` contains targets with no unit match.
+        """
+        matched_by_unit: Dict[str, List[str]] = {}
+        unmatched_targets: List[str] = []
+        for target in targets:
+            # urlparse correctly handles IPv6 (e.g. [::1]:9093), host:port, and
+            # bare hostnames — unlike a naive split(":")[0].
+            parsed = urlparse(f"//{target}")
+            target_host = parsed.hostname or target.split(":", 1)[0]
+            matched_unit = host_to_unit.get(target_host)
+            if matched_unit:
+                matched_by_unit.setdefault(matched_unit, []).append(target)
+            else:
+                unmatched_targets.append(target)
+        return matched_by_unit, unmatched_targets
+
+    @staticmethod
     def _build_per_unit_job(
         job: dict,
         static_config: dict,
@@ -539,15 +610,7 @@ class PrometheusConfig:
         # so that non-wildcard targets can be matched whether specified as IP or FQDN.
         # The set subtraction {addr, fqdn} - {""} drops empty strings (absent FQDN)
         # and deduplicates when addr == fqdn (non-IP bind address).
-        host_to_unit: Dict[str, str] = (
-            {
-                identifier: unit_name
-                for unit_name, (addr, _, fqdn) in hosts.items()
-                for identifier in {addr, fqdn} - {""}
-            }
-            if topology
-            else {}
-        )
+        host_to_unit = PrometheusConfig._build_host_to_unit(hosts, topology)
 
         modified_scrape_jobs = []
         for job in scrape_jobs:
@@ -565,40 +628,19 @@ class PrometheusConfig:
                 if not targets:
                     continue
 
-                # All non-wildcard targets remain in the same static_config
-                non_wildcard_targets = []
-
-                # All wildcard targets are extracted to a job per unit. If multiple wildcard
-                # targets are specified, they remain in the same static_config (per unit).
-                wildcard_targets = []
-
-                for target in targets:
-                    match = re.compile(r"\*(?:(:\d+))?").match(target)
-                    if match:
-                        # This is a wildcard target.
-                        # Need to expand into separate jobs and remove it from this job here
-                        wildcard_targets.append(target)
-                    else:
-                        # This is not a wildcard target. Copy it over into its own static_config.
-                        non_wildcard_targets.append(target)
+                wildcard_targets, non_wildcard_targets = PrometheusConfig._classify_targets(
+                    targets
+                )
 
                 # Non-wildcard targets: try to match each target's host against known unit
                 # addresses. Matched targets get a per-unit job with juju_unit; unmatched
                 # targets get topology-only labels with no per-unit expansion.
                 if non_wildcard_targets:
-                    unmatched_targets = []
-                    matched_by_unit: Dict[str, List[str]] = {}
-
-                    for target in non_wildcard_targets:
-                        # Use urlparse to correctly handle IPv6 addresses (e.g. [::1]:9093)
-                        # as well as plain host:port and bare hostnames.
-                        parsed = urlparse(f"//{target}")
-                        target_host = parsed.hostname or target.split(":", 1)[0]
-                        matched_unit = host_to_unit.get(target_host)
-                        if matched_unit:
-                            matched_by_unit.setdefault(matched_unit, []).append(target)
-                        else:
-                            unmatched_targets.append(target)
+                    matched_by_unit, unmatched_targets = (
+                        PrometheusConfig._match_non_wildcard_targets(
+                            non_wildcard_targets, host_to_unit
+                        )
+                    )
 
                     # Unmatched targets: no unit mapping found — kept with topology-only
                     # labels and no per-unit expansion (juju_unit is not added).
@@ -621,7 +663,7 @@ class PrometheusConfig:
                             )
                         )
 
-                # Extract wildcard targets into individual jobs
+                # Wildcard targets: one per-unit job per host, replacing "*" with the unit address.
                 if wildcard_targets:
                     for unit_name, (unit_hostname, unit_path, _unit_fqdn) in hosts.items():
                         resolved_targets = [

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -4,7 +4,7 @@ import dataclasses
 import logging
 from functools import wraps
 from pathlib import Path
-from typing import Callable
+from typing import Callable, List
 from unittest.mock import patch
 
 import requests
@@ -141,3 +141,14 @@ def add_relation_sequence(context: Context, state: State, relation: Relation):
         context.on.relation_changed(relation_2), state_after_relation_joined
     )
     return state_after_relation_changed
+
+def jobs_factory(targets: List):
+
+    return  [
+            {
+                "job_name": "job",
+                "static_configs": [
+                    {"targets": targets}
+                ],
+            }
+    ]

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -77,18 +77,20 @@ class EndpointProviderCharm(CharmBase):
         )
 
 
-class EndpointProviderCharmExternalUrl(CharmBase):
-    _stored = StoredState()
+def make_endpoint_provider_charm_with_external_url(external_url: str) -> type:
+    """Return a CharmBase subclass whose MetricsEndpointProvider uses the given external_url."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args)
+    class _Charm(CharmBase):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args)
+            self.provider = MetricsEndpointProvider(
+                self,
+                jobs=JOBS,
+                alert_rules_path=str(UNITTEST_DIR / "prometheus_alert_rules"),
+                external_url=external_url,
+            )
 
-        self.provider = MetricsEndpointProvider(
-            self,
-            jobs=JOBS,
-            alert_rules_path=str(UNITTEST_DIR / "prometheus_alert_rules"),
-            external_url="9.12.20.18",
-        )
+    return _Charm
 
 
 class EndpointProviderCharmWithMultipleEvents(CharmBase):
@@ -234,9 +236,10 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertIn("prometheus_scrape_unit_address", data)
         self.assertEqual(data["prometheus_scrape_unit_address"], "10.1.157.116")
         self.assertIn("prometheus_scrape_unit_name", data)
+        self.assertEqual(data.get("prometheus_scrape_unit_path", ""), "")
 
     def test_provider_sets_external_url(self):
-        harness = Harness(EndpointProviderCharmExternalUrl, meta=PROVIDER_META)
+        harness = Harness(make_endpoint_provider_charm_with_external_url("9.12.20.18"), meta=PROVIDER_META)
         harness.set_model_name("MyUUID")
         harness.set_leader(True)
         harness.begin()
@@ -298,6 +301,7 @@ class TestEndpointProvider(unittest.TestCase):
         data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
         self.assertEqual(data["prometheus_scrape_unit_address"], "some.host")
         self.assertEqual(data["prometheus_scrape_unit_fqdn"], "some.host")
+        self.assertEqual(data.get("prometheus_scrape_unit_path", ""), "")
 
     @patch("socket.getfqdn", new=lambda *args: "unit-0.svc.cluster.local")
     def test_provider_unit_sets_fqdn_from_getfqdn_when_bind_address_is_valid_ip(self):
@@ -313,6 +317,7 @@ class TestEndpointProvider(unittest.TestCase):
         data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
         self.assertEqual(data["prometheus_scrape_unit_address"], "10.1.157.116")
         self.assertEqual(data["prometheus_scrape_unit_fqdn"], "unit-0.svc.cluster.local")
+        self.assertEqual(data.get("prometheus_scrape_unit_path", ""), "")
 
     def test_provider_unit_sets_empty_fqdn_when_external_url_is_set(self):
         """When external_url is set, fqdn is always empty (the URL hostname is the address).
@@ -320,7 +325,7 @@ class TestEndpointProvider(unittest.TestCase):
         Juju (and the ops Harness) treats empty-string relation data as unset, so
         the key will not appear in the relation data dict.
         """
-        harness = Harness(EndpointProviderCharmExternalUrl, meta=PROVIDER_META)
+        harness = Harness(make_endpoint_provider_charm_with_external_url("9.12.20.18"), meta=PROVIDER_META)
         harness.set_model_name("MyUUID")
         harness.set_leader(True)
         harness.begin()
@@ -333,6 +338,25 @@ class TestEndpointProvider(unittest.TestCase):
 
         data = harness.get_relation_data(rel_id, harness.charm.unit.name)
         # Empty string is treated as unset in Juju relation data; absence == empty fqdn.
+        self.assertEqual(data.get("prometheus_scrape_unit_fqdn", ""), "")
+        self.assertEqual(data.get("prometheus_scrape_unit_path", ""), "")
+
+    def test_provider_unit_sets_path_from_external_url(self):
+        """When external_url includes a path prefix, it is published as the unit path."""
+        harness = Harness(make_endpoint_provider_charm_with_external_url("http://9.12.20.18/some/prefix"), meta=PROVIDER_META)
+        harness.set_model_name("MyUUID")
+        harness.set_leader(True)
+        harness.begin()
+        rel_id = harness.add_relation(RELATION_NAME, "provider")
+        harness.add_relation_unit(rel_id, "provider/0")
+
+        # Ugly re-init workaround: manually call `set_scrape_job_spec`
+        # https://github.com/canonical/operator/issues/736
+        harness.charm.provider.set_scrape_job_spec()
+
+        data = harness.get_relation_data(rel_id, harness.charm.unit.name)
+        self.assertEqual(data["prometheus_scrape_unit_address"], "9.12.20.18")
+        self.assertEqual(data["prometheus_scrape_unit_path"], "/some/prefix")
         self.assertEqual(data.get("prometheus_scrape_unit_fqdn", ""), "")
 
     def test_provider_supports_multiple_jobs(self):

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -284,6 +284,57 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertEqual(data["prometheus_scrape_unit_address"], "some.host")
         self.assertIn("prometheus_scrape_unit_name", data)
 
+    @patch("socket.getfqdn", new=lambda *args: "some.host")
+    @patch("ops.Network.bind_address", new="not-an-ip")
+    def test_provider_unit_sets_fqdn_equal_to_address_when_bind_address_is_not_ip(self):
+        """When bind_address is not an IP, fqdn is set to the same value as address."""
+        rel_id = self.harness.add_relation(RELATION_NAME, "provider")
+        self.harness.add_relation_unit(rel_id, "provider/0")
+
+        # Ugly re-init workaround: manually call `set_scrape_job_spec`
+        # https://github.com/canonical/operator/issues/736
+        self.harness.charm.provider.set_scrape_job_spec()
+
+        data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertEqual(data["prometheus_scrape_unit_address"], "some.host")
+        self.assertEqual(data["prometheus_scrape_unit_fqdn"], "some.host")
+
+    @patch("socket.getfqdn", new=lambda *args: "unit-0.svc.cluster.local")
+    def test_provider_unit_sets_fqdn_from_getfqdn_when_bind_address_is_valid_ip(self):
+        """When bind_address is a valid IP, fqdn is populated via socket.getfqdn()."""
+        self.harness.add_network("10.1.157.116")
+        rel_id = self.harness.add_relation(RELATION_NAME, "provider")
+        self.harness.add_relation_unit(rel_id, "provider/0")
+
+        # Ugly re-init workaround: manually call `set_scrape_job_spec`
+        # https://github.com/canonical/operator/issues/736
+        self.harness.charm.provider.set_scrape_job_spec()
+
+        data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertEqual(data["prometheus_scrape_unit_address"], "10.1.157.116")
+        self.assertEqual(data["prometheus_scrape_unit_fqdn"], "unit-0.svc.cluster.local")
+
+    def test_provider_unit_sets_empty_fqdn_when_external_url_is_set(self):
+        """When external_url is set, fqdn is always empty (the URL hostname is the address).
+
+        Juju (and the ops Harness) treats empty-string relation data as unset, so
+        the key will not appear in the relation data dict.
+        """
+        harness = Harness(EndpointProviderCharmExternalUrl, meta=PROVIDER_META)
+        harness.set_model_name("MyUUID")
+        harness.set_leader(True)
+        harness.begin()
+        rel_id = harness.add_relation(RELATION_NAME, "provider")
+        harness.add_relation_unit(rel_id, "provider/0")
+
+        # Ugly re-init workaround: manually call `set_scrape_job_spec`
+        # https://github.com/canonical/operator/issues/736
+        harness.charm.provider.set_scrape_job_spec()
+
+        data = harness.get_relation_data(rel_id, harness.charm.unit.name)
+        # Empty string is treated as unset in Juju relation data; absence == empty fqdn.
+        self.assertEqual(data.get("prometheus_scrape_unit_fqdn", ""), "")
+
     def test_provider_supports_multiple_jobs(self):
         rel_id = self.harness.add_relation(RELATION_NAME, "provider")
         self.harness.add_relation_unit(rel_id, "provider/0")

--- a/tests/unit/test_prometheus_config.py
+++ b/tests/unit/test_prometheus_config.py
@@ -322,6 +322,16 @@ class TestWildcardExpansionWithTopology(unittest.TestCase):
             ],
         )
 
+
+
+class TestNonWildcardExpansionWithTopology(unittest.TestCase):
+    """Tests for juju_unit label injection on non-wildcard (fully-qualified) targets.
+
+    When a non-wildcard target's host matches a known unit's address or FQDN,
+    it is expanded into a per-unit job with the juju_unit label — mirroring the
+    behaviour of wildcard targets.
+    """
+
     def test_non_wildcard_target_matching_unit_ip_gets_juju_unit_label(self):
         # GIVEN a non-wildcard target whose host matches a known unit's IP address
         jobs = [

--- a/tests/unit/test_prometheus_config.py
+++ b/tests/unit/test_prometheus_config.py
@@ -22,8 +22,8 @@ class TestWildcardExpansion(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", ""),
-            "unit/1": ("11.11.11.11", ""),
+            "unit/0": ("10.10.10.10", "", ""),
+            "unit/1": ("11.11.11.11", "", ""),
         }
 
         # WHEN the jobs are processed
@@ -59,8 +59,8 @@ class TestWildcardExpansion(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", ""),
-            "unit/1": ("11.11.11.11", ""),
+            "unit/0": ("10.10.10.10", "", ""),
+            "unit/1": ("11.11.11.11", "", ""),
         }
 
         # WHEN the jobs are processed
@@ -97,8 +97,8 @@ class TestWildcardExpansion(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", ""),
-            "unit/1": ("11.11.11.11", ""),
+            "unit/0": ("10.10.10.10", "", ""),
+            "unit/1": ("11.11.11.11", "", ""),
         }
 
         # WHEN the jobs are processed
@@ -140,8 +140,8 @@ class TestWildcardExpansion(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", ""),
-            "unit/1": ("11.11.11.11", ""),
+            "unit/0": ("10.10.10.10", "", ""),
+            "unit/1": ("11.11.11.11", "", ""),
         }
 
         # WHEN the jobs are processed
@@ -182,8 +182,8 @@ class TestWildcardExpansion(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", ""),
-            "unit/1": ("11.11.11.11", ""),
+            "unit/0": ("10.10.10.10", "", ""),
+            "unit/1": ("11.11.11.11", "", ""),
         }
 
         # WHEN the jobs are processed
@@ -264,8 +264,8 @@ class TestWildcardExpansionWithTopology(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", ""),
-            "unit/1": ("11.11.11.11", ""),
+            "unit/0": ("10.10.10.10", "", ""),
+            "unit/1": ("11.11.11.11", "", ""),
         }
 
         # AND some topology
@@ -322,6 +322,149 @@ class TestWildcardExpansionWithTopology(unittest.TestCase):
             ],
         )
 
+    def test_non_wildcard_target_matching_unit_ip_gets_juju_unit_label(self):
+        # GIVEN a non-wildcard target whose host matches a known unit's IP address
+        jobs = [
+            {
+                "job_name": "job",
+                "static_configs": [{"targets": ["10.10.10.10:9093"]}],
+            }
+        ]
+
+        # AND hosts dict with 3-tuples (address, path, fqdn)
+        topology = JujuTopology(
+            model="model",
+            model_uuid=str(uuid.uuid4()),
+            application="app",
+            charm_name="charm",
+        )
+        hosts = {
+            "unit/0": ("10.10.10.10", "", "unit-0.svc.cluster.local"),
+        }
+
+        # WHEN the jobs are processed
+        expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
+            jobs, hosts, topology
+        )
+
+        # THEN the non-wildcard target is expanded into a per-unit job
+        # AND juju_unit label is included because the IP matched a known unit
+        # AND topology_relabel_config_wildcard is used (includes juju_unit in instance)
+        self.assertEqual(len(expanded), 1)
+        job = expanded[0]
+        self.assertEqual(job["job_name"], "job-0")
+        labels = job["static_configs"][0]["labels"]
+        self.assertEqual(labels.get("juju_unit"), "unit/0")
+        self.assertIn(PrometheusConfig.topology_relabel_config_wildcard, job["relabel_configs"])
+
+    def test_non_wildcard_target_matching_unit_fqdn_gets_juju_unit_label(self):
+        # GIVEN a non-wildcard target whose host matches a known unit's FQDN
+        # (this is the alertmanager self-scrape use case: targets are FQDNs, not IPs)
+        jobs = [
+            {
+                "job_name": "job",
+                "static_configs": [{"targets": ["unit-0.svc.cluster.local:9093"]}],
+            }
+        ]
+
+        topology = JujuTopology(
+            model="model",
+            model_uuid=str(uuid.uuid4()),
+            application="app",
+            charm_name="charm",
+        )
+        # AND the unit publishes its pod IP as address and FQDN separately
+        hosts = {
+            "unit/0": ("10.10.10.10", "", "unit-0.svc.cluster.local"),
+        }
+
+        # WHEN the jobs are processed
+        expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
+            jobs, hosts, topology
+        )
+
+        # THEN the non-wildcard FQDN target is expanded into a per-unit job
+        # AND juju_unit label is included because the FQDN matched a known unit
+        self.assertEqual(len(expanded), 1)
+        job = expanded[0]
+        self.assertEqual(job["job_name"], "job-0")
+        labels = job["static_configs"][0]["labels"]
+        self.assertEqual(labels.get("juju_unit"), "unit/0")
+        self.assertIn(PrometheusConfig.topology_relabel_config_wildcard, job["relabel_configs"])
+
+    def test_non_wildcard_target_not_matching_any_unit_has_no_juju_unit_label(self):
+        # GIVEN a non-wildcard target pointing to an external service (not a Juju unit)
+        jobs = [
+            {
+                "job_name": "job",
+                "static_configs": [{"targets": ["99.99.99.99:9093"]}],
+            }
+        ]
+
+        topology = JujuTopology(
+            model="model",
+            model_uuid=str(uuid.uuid4()),
+            application="app",
+            charm_name="charm",
+        )
+        hosts = {
+            "unit/0": ("10.10.10.10", "", "unit-0.svc.cluster.local"),
+        }
+
+        # WHEN the jobs are processed
+        expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
+            jobs, hosts, topology
+        )
+
+        # THEN the target is kept in a single job without juju_unit (original behaviour)
+        self.assertEqual(len(expanded), 1)
+        job = expanded[0]
+        self.assertEqual(job["job_name"], "job")
+        labels = job["static_configs"][0].get("labels", {})
+        self.assertNotIn("juju_unit", labels)
+        self.assertIn(PrometheusConfig.topology_relabel_config, job["relabel_configs"])
+
+    def test_mixed_non_wildcard_targets_matched_and_unmatched(self):
+        # GIVEN a job with two non-wildcard targets: one matching a known unit, one external
+        jobs = [
+            {
+                "job_name": "job",
+                "static_configs": [
+                    {"targets": ["10.10.10.10:9093", "99.99.99.99:9093"]}
+                ],
+            }
+        ]
+
+        topology = JujuTopology(
+            model="model",
+            model_uuid=str(uuid.uuid4()),
+            application="app",
+            charm_name="charm",
+        )
+        hosts = {
+            "unit/0": ("10.10.10.10", "", "unit-0.svc.cluster.local"),
+        }
+
+        # WHEN the jobs are processed
+        expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
+            jobs, hosts, topology
+        )
+
+        # THEN the matched target becomes a per-unit job with juju_unit
+        # AND the unmatched target stays in its own job without juju_unit
+        self.assertEqual(len(expanded), 2)
+
+        per_unit_jobs = [j for j in expanded if j["job_name"] == "job-0"]
+        unmatched_jobs = [j for j in expanded if j["job_name"] == "job"]
+
+        self.assertEqual(len(per_unit_jobs), 1)
+        self.assertEqual(per_unit_jobs[0]["static_configs"][0]["targets"], ["10.10.10.10:9093"])
+        self.assertEqual(per_unit_jobs[0]["static_configs"][0]["labels"]["juju_unit"], "unit/0")
+
+        self.assertEqual(len(unmatched_jobs), 1)
+        self.assertEqual(unmatched_jobs[0]["static_configs"][0]["targets"], ["99.99.99.99:9093"])
+        self.assertNotIn("juju_unit", unmatched_jobs[0]["static_configs"][0].get("labels", {}))
+
 
 class TestWildcardExpansionWithPathPrefix(unittest.TestCase):
     """Similar to `TestWildcardExpansion`, but with path prefix."""
@@ -336,8 +479,8 @@ class TestWildcardExpansionWithPathPrefix(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", "/model-unit-0"),
-            "unit/1": ("11.11.11.11", "/model-unit-1"),
+            "unit/0": ("10.10.10.10", "/model-unit-0", ""),
+            "unit/1": ("11.11.11.11", "/model-unit-1", ""),
         }
 
         # WHEN the jobs are processed
@@ -379,8 +522,8 @@ class TestWildcardExpansionWithPathPrefix(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", "/model-unit-0"),
-            "unit/1": ("11.11.11.11", "/model-unit-1"),
+            "unit/0": ("10.10.10.10", "/model-unit-0", ""),
+            "unit/1": ("11.11.11.11", "/model-unit-1", ""),
         }
 
         # WHEN the jobs are processed

--- a/tests/unit/test_prometheus_config.py
+++ b/tests/unit/test_prometheus_config.py
@@ -465,6 +465,70 @@ class TestWildcardExpansionWithTopology(unittest.TestCase):
         self.assertEqual(unmatched_jobs[0]["static_configs"][0]["targets"], ["99.99.99.99:9093"])
         self.assertNotIn("juju_unit", unmatched_jobs[0]["static_configs"][0].get("labels", {}))
 
+    def test_non_wildcard_target_matching_unit_ipv6_gets_juju_unit_label(self):
+        # GIVEN a non-wildcard target using IPv6 notation
+        jobs = [
+            {
+                "job_name": "job",
+                "static_configs": [{"targets": ["[2001:db8::1]:9093"]}],
+            }
+        ]
+
+        topology = JujuTopology(
+            model="model",
+            model_uuid=str(uuid.uuid4()),
+            application="app",
+            charm_name="charm",
+        )
+        # AND the unit's address is the same IPv6 address
+        hosts = {
+            "unit/0": ("2001:db8::1", "", ""),
+        }
+
+        # WHEN the jobs are processed
+        expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
+            jobs, hosts, topology
+        )
+
+        # THEN the IPv6 target is correctly parsed and matched to the unit
+        # AND juju_unit label is included
+        self.assertEqual(len(expanded), 1)
+        job = expanded[0]
+        self.assertEqual(job["job_name"], "job-0")
+        self.assertEqual(job["static_configs"][0]["labels"]["juju_unit"], "unit/0")
+
+    def test_non_wildcard_target_matching_unit_uses_unit_path(self):
+        # GIVEN a non-wildcard target matching a unit that has a per-unit path prefix
+        # (e.g., the unit is behind a per-unit ingress)
+        jobs = [
+            {
+                "job_name": "job",
+                "static_configs": [{"targets": ["10.10.10.10:9093"]}],
+            }
+        ]
+
+        topology = JujuTopology(
+            model="model",
+            model_uuid=str(uuid.uuid4()),
+            application="app",
+            charm_name="charm",
+        )
+        hosts = {
+            "unit/0": ("10.10.10.10", "/model-unit-0", ""),
+        }
+
+        # WHEN the jobs are processed
+        expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
+            jobs, hosts, topology
+        )
+
+        # THEN the per-unit path prefix is applied to the metrics path
+        self.assertEqual(len(expanded), 1)
+        job = expanded[0]
+        self.assertEqual(job["job_name"], "job-0")
+        self.assertEqual(job["metrics_path"], "/model-unit-0/metrics")
+        self.assertEqual(job["static_configs"][0]["labels"]["juju_unit"], "unit/0")
+
 
 class TestWildcardExpansionWithPathPrefix(unittest.TestCase):
     """Similar to `TestWildcardExpansion`, but with path prefix."""

--- a/tests/unit/test_prometheus_config.py
+++ b/tests/unit/test_prometheus_config.py
@@ -7,6 +7,7 @@ import uuid
 
 from charms.prometheus_k8s.v0.prometheus_scrape import PrometheusConfig
 from cosl import JujuTopology
+from helpers import jobs_factory
 
 logger = logging.getLogger(__name__)
 
@@ -332,6 +333,14 @@ class TestNonWildcardExpansionWithTopology(unittest.TestCase):
     behaviour of wildcard targets.
     """
 
+    def setUp(self):
+        self.topology = JujuTopology(
+            model="model",
+            model_uuid="ac2bcddf-4c37-42d4-8ac6-5e7f922c2437",
+            application="app",
+            charm_name="charm",
+        )
+
     def test_non_wildcard_target_matching_unit_ip_gets_juju_unit_label(self):
         # GIVEN a non-wildcard target whose host matches a known unit's IP address
         jobs = [
@@ -434,91 +443,68 @@ class TestNonWildcardExpansionWithTopology(unittest.TestCase):
         self.assertNotIn("juju_unit", labels)
         self.assertIn(PrometheusConfig.topology_relabel_config, job["relabel_configs"])
 
-    def test_mixed_non_wildcard_targets_matched_and_unmatched(self):
-        # GIVEN a job with two non-wildcard targets: one matching a known unit, one external
-        jobs = [
-            {
-                "job_name": "job",
-                "static_configs": [
-                    {"targets": ["10.10.10.10:9093", "99.99.99.99:9093"]}
-                ],
-            }
-        ]
 
-        model_uuid = str(uuid.uuid4())
-        topology = JujuTopology(
-            model="model",
-            model_uuid=model_uuid,
-            application="app",
-            charm_name="charm",
-        )
+    def test_mixed_non_wildcard_targets_matched_and_unmatched(self):
+        # GIVEN a jobs list with some targets and partial fqdn translation
+        jobs = jobs_factory(["10.10.10.10:9093", "99.99.99.99:9093"])
         hosts = {
             "unit/0": ("10.10.10.10", "", "unit-0.svc.cluster.local"),
         }
-
         # WHEN the jobs are processed
         expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
-            jobs, hosts, topology
+            jobs, hosts, self.topology
         )
-
-        expected_matched = {
-            'job_name': 'job-0',
-            'static_configs': [
-                {
-                    'targets': ['10.10.10.10:9093'],
-                    'labels': {
-                        'juju_model': 'model',
-                        'juju_model_uuid': model_uuid,
-                        'juju_application': 'app',
-                        'juju_charm': 'charm',
-                        'juju_unit': 'unit/0'
-                    }
-                }
-            ],
-            'metrics_path': '/metrics',
-            'relabel_configs': [
-                {
-                    'source_labels': ['juju_model', 'juju_model_uuid', 'juju_application', 'juju_unit'],
-                    'separator': '_',
-                    'target_label': 'instance',
-                    'regex': '(.*)'
-                    }
-            ]
-        }
-        expected_unmatched = {
-            'job_name': 'job',
-            'static_configs': [
-                {
-                    'targets': ['99.99.99.99:9093'],
-                    'labels': {
-                        'juju_model': 'model',
-                        'juju_model_uuid': model_uuid,
-                        'juju_application': 'app',
-                        'juju_charm': 'charm'
-                    }
-                }
-            ],
-            'metrics_path': '/metrics',
-            'relabel_configs': [
-                {
-                    'source_labels': ['juju_model', 'juju_model_uuid', 'juju_application'],
-                    'separator': '_',
-                    'target_label': 'instance',
-                    'regex': '(.*)'
-                }
-            ]
-        }
-
-
         # THEN the matched target becomes a per-unit job with juju_unit
-        # AND the unmatched target stays in its own job without juju_unit
-        per_unit_jobs = [j for j in expanded if j["job_name"] == "job-0"]
-        unmatched_jobs = [j for j in expanded if j["job_name"] == "job"]
+        self.assertEqual(expanded, [
+            {
+                'job_name': 'job-0',
+                'static_configs': [
+                    {
+                        'targets': ['10.10.10.10:9093'],
+                        'labels': {
+                            'juju_model': self.topology.model,
+                            'juju_model_uuid': self.topology.model_uuid,
+                            'juju_application': self.topology.application,
+                            'juju_charm': self.topology.charm_name,
+                            'juju_unit': 'unit/0'
+                        }
+                    }
+                ],
+                'metrics_path': '/metrics',
+                'relabel_configs': [
+                    {
+                        'source_labels': ['juju_model', 'juju_model_uuid', 'juju_application', 'juju_unit'],
+                        'separator': '_',
+                        'target_label': 'instance',
+                        'regex': '(.*)'
+                        }
+                ]
+            },
+            {
+                'job_name': 'job',
+                'static_configs': [
+                    {
+                        'targets': ['99.99.99.99:9093'],
+                        'labels': {
+                            'juju_model': self.topology.model,
+                            'juju_model_uuid': self.topology.model_uuid,
+                            'juju_application': self.topology.application,
+                            'juju_charm': self.topology.charm_name,
+                        }
+                    }
+                ],
+                'metrics_path': '/metrics',
+                'relabel_configs': [
+                    {
+                        'source_labels': ['juju_model', 'juju_model_uuid', 'juju_application'],
+                        'separator': '_',
+                        'target_label': 'instance',
+                        'regex': '(.*)'
+                    }
+                ]
+            }
+        ])
 
-        self.assertEqual(len(per_unit_jobs), 1)
-        self.assertEqual(len(unmatched_jobs), 1)
-        self.assertDictEqual(per_unit_jobs[0], expected_matched)
-        self.assertDictEqual(unmatched_jobs[0], expected_unmatched)
 
     def test_non_wildcard_target_matching_unit_ipv6_gets_juju_unit_label(self):
         # GIVEN a non-wildcard target using IPv6 notation

--- a/tests/unit/test_prometheus_config.py
+++ b/tests/unit/test_prometheus_config.py
@@ -445,9 +445,10 @@ class TestNonWildcardExpansionWithTopology(unittest.TestCase):
             }
         ]
 
+        model_uuid = str(uuid.uuid4())
         topology = JujuTopology(
             model="model",
-            model_uuid=str(uuid.uuid4()),
+            model_uuid=model_uuid,
             application="app",
             charm_name="charm",
         )
@@ -460,20 +461,64 @@ class TestNonWildcardExpansionWithTopology(unittest.TestCase):
             jobs, hosts, topology
         )
 
+        expected_matched = {
+            'job_name': 'job-0',
+            'static_configs': [
+                {
+                    'targets': ['10.10.10.10:9093'],
+                    'labels': {
+                        'juju_model': 'model',
+                        'juju_model_uuid': model_uuid,
+                        'juju_application': 'app',
+                        'juju_charm': 'charm',
+                        'juju_unit': 'unit/0'
+                    }
+                }
+            ],
+            'metrics_path': '/metrics',
+            'relabel_configs': [
+                {
+                    'source_labels': ['juju_model', 'juju_model_uuid', 'juju_application', 'juju_unit'],
+                    'separator': '_',
+                    'target_label': 'instance',
+                    'regex': '(.*)'
+                    }
+            ]
+        }
+        expected_unmatched = {
+            'job_name': 'job',
+            'static_configs': [
+                {
+                    'targets': ['99.99.99.99:9093'],
+                    'labels': {
+                        'juju_model': 'model',
+                        'juju_model_uuid': model_uuid,
+                        'juju_application': 'app',
+                        'juju_charm': 'charm'
+                    }
+                }
+            ],
+            'metrics_path': '/metrics',
+            'relabel_configs': [
+                {
+                    'source_labels': ['juju_model', 'juju_model_uuid', 'juju_application'],
+                    'separator': '_',
+                    'target_label': 'instance',
+                    'regex': '(.*)'
+                }
+            ]
+        }
+
+
         # THEN the matched target becomes a per-unit job with juju_unit
         # AND the unmatched target stays in its own job without juju_unit
-        self.assertEqual(len(expanded), 2)
-
         per_unit_jobs = [j for j in expanded if j["job_name"] == "job-0"]
         unmatched_jobs = [j for j in expanded if j["job_name"] == "job"]
 
         self.assertEqual(len(per_unit_jobs), 1)
-        self.assertEqual(per_unit_jobs[0]["static_configs"][0]["targets"], ["10.10.10.10:9093"])
-        self.assertEqual(per_unit_jobs[0]["static_configs"][0]["labels"]["juju_unit"], "unit/0")
-
         self.assertEqual(len(unmatched_jobs), 1)
-        self.assertEqual(unmatched_jobs[0]["static_configs"][0]["targets"], ["99.99.99.99:9093"])
-        self.assertNotIn("juju_unit", unmatched_jobs[0]["static_configs"][0].get("labels", {}))
+        self.assertDictEqual(per_unit_jobs[0], expected_matched)
+        self.assertDictEqual(unmatched_jobs[0], expected_unmatched)
 
     def test_non_wildcard_target_matching_unit_ipv6_gets_juju_unit_label(self):
         # GIVEN a non-wildcard target using IPv6 notation

--- a/tests/unit/test_prometheus_config.py
+++ b/tests/unit/test_prometheus_config.py
@@ -342,39 +342,34 @@ class TestNonWildcardExpansionWithTopology(unittest.TestCase):
         )
 
     def test_non_wildcard_target_matching_unit_ip_gets_juju_unit_label(self):
-        # GIVEN a non-wildcard target whose host matches a known unit's IP address
-        jobs = [
-            {
-                "job_name": "job",
-                "static_configs": [{"targets": ["10.10.10.10:9093"]}],
-            }
+        # GIVEN non-wildcard targets whose host matches a known unit's address —
+        # both plain IPv4 and bracket-notation IPv6 must be parsed and matched correctly.
+        cases = [
+            ("IPv4", "10.10.10.10:9093", "10.10.10.10", "unit-0.svc.cluster.local"),
+            ("IPv6", "[2001:db8::1]:9093", "2001:db8::1", ""),
         ]
 
-        # AND hosts dict with 3-tuples (address, path, fqdn)
-        topology = JujuTopology(
-            model="model",
-            model_uuid=str(uuid.uuid4()),
-            application="app",
-            charm_name="charm",
-        )
-        hosts = {
-            "unit/0": ("10.10.10.10", "", "unit-0.svc.cluster.local"),
-        }
+        for label, target, unit_addr, unit_fqdn in cases:
+            with self.subTest(label):
+                # AND a job targeting that address
+                jobs = [{"job_name": "job", "static_configs": [{"targets": [target]}]}]
+                hosts = {"unit/0": (unit_addr, "", unit_fqdn)}
 
-        # WHEN the jobs are processed
-        expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
-            jobs, hosts, topology
-        )
+                # WHEN the jobs are processed
+                expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
+                    jobs, hosts, self.topology
+                )
 
-        # THEN the non-wildcard target is expanded into a per-unit job
-        # AND juju_unit label is included because the IP matched a known unit
-        # AND topology_relabel_config_wildcard is used (includes juju_unit in instance)
-        self.assertEqual(len(expanded), 1)
-        job = expanded[0]
-        self.assertEqual(job["job_name"], "job-0")
-        labels = job["static_configs"][0]["labels"]
-        self.assertEqual(labels.get("juju_unit"), "unit/0")
-        self.assertIn(PrometheusConfig.topology_relabel_config_wildcard, job["relabel_configs"])
+                # THEN the target is expanded into a per-unit job with juju_unit
+                # AND topology_relabel_config_wildcard is used (includes juju_unit in instance)
+                self.assertEqual(len(expanded), 1)
+                job = expanded[0]
+                self.assertEqual(job["job_name"], "job-0")
+                labels = job["static_configs"][0]["labels"]
+                self.assertEqual(labels.get("juju_unit"), "unit/0")
+                self.assertIn(
+                    PrometheusConfig.topology_relabel_config_wildcard, job["relabel_configs"]
+                )
 
     def test_non_wildcard_target_matching_unit_fqdn_gets_juju_unit_label(self):
         # GIVEN a non-wildcard target whose host matches a known unit's FQDN
@@ -386,12 +381,6 @@ class TestNonWildcardExpansionWithTopology(unittest.TestCase):
             }
         ]
 
-        topology = JujuTopology(
-            model="model",
-            model_uuid=str(uuid.uuid4()),
-            application="app",
-            charm_name="charm",
-        )
         # AND the unit publishes its pod IP as address and FQDN separately
         hosts = {
             "unit/0": ("10.10.10.10", "", "unit-0.svc.cluster.local"),
@@ -399,7 +388,7 @@ class TestNonWildcardExpansionWithTopology(unittest.TestCase):
 
         # WHEN the jobs are processed
         expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
-            jobs, hosts, topology
+            jobs, hosts, self.topology
         )
 
         # THEN the non-wildcard FQDN target is expanded into a per-unit job
@@ -444,100 +433,6 @@ class TestNonWildcardExpansionWithTopology(unittest.TestCase):
         self.assertIn(PrometheusConfig.topology_relabel_config, job["relabel_configs"])
 
 
-    def test_mixed_non_wildcard_targets_matched_and_unmatched(self):
-        # GIVEN a jobs list with some targets and partial fqdn translation
-        jobs = jobs_factory(["10.10.10.10:9093", "99.99.99.99:9093"])
-        hosts = {
-            "unit/0": ("10.10.10.10", "", "unit-0.svc.cluster.local"),
-        }
-        # WHEN the jobs are processed
-        expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
-            jobs, hosts, self.topology
-        )
-        # THEN the matched target becomes a per-unit job with juju_unit
-        self.assertEqual(expanded, [
-            {
-                'job_name': 'job-0',
-                'static_configs': [
-                    {
-                        'targets': ['10.10.10.10:9093'],
-                        'labels': {
-                            'juju_model': self.topology.model,
-                            'juju_model_uuid': self.topology.model_uuid,
-                            'juju_application': self.topology.application,
-                            'juju_charm': self.topology.charm_name,
-                            'juju_unit': 'unit/0'
-                        }
-                    }
-                ],
-                'metrics_path': '/metrics',
-                'relabel_configs': [
-                    {
-                        'source_labels': ['juju_model', 'juju_model_uuid', 'juju_application', 'juju_unit'],
-                        'separator': '_',
-                        'target_label': 'instance',
-                        'regex': '(.*)'
-                        }
-                ]
-            },
-            {
-                'job_name': 'job',
-                'static_configs': [
-                    {
-                        'targets': ['99.99.99.99:9093'],
-                        'labels': {
-                            'juju_model': self.topology.model,
-                            'juju_model_uuid': self.topology.model_uuid,
-                            'juju_application': self.topology.application,
-                            'juju_charm': self.topology.charm_name,
-                        }
-                    }
-                ],
-                'metrics_path': '/metrics',
-                'relabel_configs': [
-                    {
-                        'source_labels': ['juju_model', 'juju_model_uuid', 'juju_application'],
-                        'separator': '_',
-                        'target_label': 'instance',
-                        'regex': '(.*)'
-                    }
-                ]
-            }
-        ])
-
-
-    def test_non_wildcard_target_matching_unit_ipv6_gets_juju_unit_label(self):
-        # GIVEN a non-wildcard target using IPv6 notation
-        jobs = [
-            {
-                "job_name": "job",
-                "static_configs": [{"targets": ["[2001:db8::1]:9093"]}],
-            }
-        ]
-
-        topology = JujuTopology(
-            model="model",
-            model_uuid=str(uuid.uuid4()),
-            application="app",
-            charm_name="charm",
-        )
-        # AND the unit's address is the same IPv6 address
-        hosts = {
-            "unit/0": ("2001:db8::1", "", ""),
-        }
-
-        # WHEN the jobs are processed
-        expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
-            jobs, hosts, topology
-        )
-
-        # THEN the IPv6 target is correctly parsed and matched to the unit
-        # AND juju_unit label is included
-        self.assertEqual(len(expanded), 1)
-        job = expanded[0]
-        self.assertEqual(job["job_name"], "job-0")
-        self.assertEqual(job["static_configs"][0]["labels"]["juju_unit"], "unit/0")
-
     def test_non_wildcard_target_matching_unit_uses_unit_path(self):
         # GIVEN a non-wildcard target matching a unit that has a per-unit path prefix
         # (e.g., the unit is behind a per-unit ingress)
@@ -547,20 +442,13 @@ class TestNonWildcardExpansionWithTopology(unittest.TestCase):
                 "static_configs": [{"targets": ["10.10.10.10:9093"]}],
             }
         ]
-
-        topology = JujuTopology(
-            model="model",
-            model_uuid=str(uuid.uuid4()),
-            application="app",
-            charm_name="charm",
-        )
         hosts = {
             "unit/0": ("10.10.10.10", "/model-unit-0", ""),
         }
 
         # WHEN the jobs are processed
         expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
-            jobs, hosts, topology
+            jobs, hosts, self.topology
         )
 
         # THEN the per-unit path prefix is applied to the metrics path

--- a/tests/unit/test_prometheus_config.py
+++ b/tests/unit/test_prometheus_config.py
@@ -15,13 +15,7 @@ logger = logging.getLogger(__name__)
 class TestWildcardExpansion(unittest.TestCase):
     def test_single_wildcard_target(self):
         # GIVEN scrape_configs (aka jobs) with only one, wildcard, target
-        jobs = [
-            {
-                "job_name": "job",
-                "static_configs": [{"targets": ["*:1234"]}],
-            }
-        ]
-
+        jobs = jobs_factory(["*:1234"])
         hosts = {
             "unit/0": ("10.10.10.10", "", ""),
             "unit/1": ("11.11.11.11", "", ""),
@@ -88,15 +82,7 @@ class TestWildcardExpansion(unittest.TestCase):
 
     def test_mixed_targets_in_same_list(self):
         # GIVEN scrape_configs with both wildcard and non-wildcard targets in the same list
-        jobs = [
-            {
-                "job_name": "job",
-                "static_configs": [
-                    {"targets": ["*:1234", "*:5678", "1.1.1.1:1111", "2.2.2.2:2222"]}
-                ],
-            }
-        ]
-
+        jobs = jobs_factory(["*:1234", "*:5678", "1.1.1.1:1111", "2.2.2.2:2222"])
         hosts = {
             "unit/0": ("10.10.10.10", "", ""),
             "unit/1": ("11.11.11.11", "", ""),
@@ -133,13 +119,7 @@ class TestWildcardExpansion(unittest.TestCase):
 
     def test_mixed_targets_in_same_list_without_port_number(self):
         # GIVEN scrape_configs with mixed target types in the same list, and without port numbers
-        jobs = [
-            {
-                "job_name": "job",
-                "static_configs": [{"targets": ["*", "1.1.1.1"]}],
-            }
-        ]
-
+        jobs = jobs_factory(["*", "1.1.1.1"])
         hosts = {
             "unit/0": ("10.10.10.10", "", ""),
             "unit/1": ("11.11.11.11", "", ""),
@@ -257,13 +237,7 @@ class TestWildcardExpansionWithTopology(unittest.TestCase):
 
     def test_mixed_targets_with_topology(self):
         # GIVEN scrape_configs with mixed target types in the same list, and without port numbers
-        jobs = [
-            {
-                "job_name": "job",
-                "static_configs": [{"targets": ["*", "1.1.1.1"]}],
-            }
-        ]
-
+        jobs = jobs_factory(["*", "1.1.1.1"])
         hosts = {
             "unit/0": ("10.10.10.10", "", ""),
             "unit/1": ("11.11.11.11", "", ""),
@@ -352,7 +326,7 @@ class TestNonWildcardExpansionWithTopology(unittest.TestCase):
         for label, target, unit_addr, unit_fqdn in cases:
             with self.subTest(label):
                 # AND a job targeting that address
-                jobs = [{"job_name": "job", "static_configs": [{"targets": [target]}]}]
+                jobs = jobs_factory([target])
                 hosts = {"unit/0": (unit_addr, "", unit_fqdn)}
 
                 # WHEN the jobs are processed
@@ -374,12 +348,7 @@ class TestNonWildcardExpansionWithTopology(unittest.TestCase):
     def test_non_wildcard_target_matching_unit_fqdn_gets_juju_unit_label(self):
         # GIVEN a non-wildcard target whose host matches a known unit's FQDN
         # (this is the alertmanager self-scrape use case: targets are FQDNs, not IPs)
-        jobs = [
-            {
-                "job_name": "job",
-                "static_configs": [{"targets": ["unit-0.svc.cluster.local:9093"]}],
-            }
-        ]
+        jobs = jobs_factory(["unit-0.svc.cluster.local:9093"])
 
         # AND the unit publishes its pod IP as address and FQDN separately
         hosts = {
@@ -402,26 +371,14 @@ class TestNonWildcardExpansionWithTopology(unittest.TestCase):
 
     def test_non_wildcard_target_not_matching_any_unit_has_no_juju_unit_label(self):
         # GIVEN a non-wildcard target pointing to an external service (not a Juju unit)
-        jobs = [
-            {
-                "job_name": "job",
-                "static_configs": [{"targets": ["99.99.99.99:9093"]}],
-            }
-        ]
-
-        topology = JujuTopology(
-            model="model",
-            model_uuid=str(uuid.uuid4()),
-            application="app",
-            charm_name="charm",
-        )
+        jobs = jobs_factory(["99.99.99.99:9093"])
         hosts = {
             "unit/0": ("10.10.10.10", "", "unit-0.svc.cluster.local"),
         }
 
         # WHEN the jobs are processed
         expanded = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
-            jobs, hosts, topology
+            jobs, hosts, self.topology
         )
 
         # THEN the target is kept in a single job without juju_unit (original behaviour)
@@ -436,12 +393,7 @@ class TestNonWildcardExpansionWithTopology(unittest.TestCase):
     def test_non_wildcard_target_matching_unit_uses_unit_path(self):
         # GIVEN a non-wildcard target matching a unit that has a per-unit path prefix
         # (e.g., the unit is behind a per-unit ingress)
-        jobs = [
-            {
-                "job_name": "job",
-                "static_configs": [{"targets": ["10.10.10.10:9093"]}],
-            }
-        ]
+        jobs = jobs_factory(["10.10.10.10:9093"])
         hosts = {
             "unit/0": ("10.10.10.10", "/model-unit-0", ""),
         }
@@ -464,13 +416,7 @@ class TestWildcardExpansionWithPathPrefix(unittest.TestCase):
 
     def test_default_metrics_endpoint_with_ingress_per_unit(self):
         # GIVEN scrape_configs and per-unit path prefix
-        jobs = [
-            {
-                "job_name": "job",
-                "static_configs": [{"targets": ["*", "1.1.1.1"]}],
-            }
-        ]
-
+        jobs = jobs_factory(["*", "1.1.1.1"])
         hosts = {
             "unit/0": ("10.10.10.10", "/model-unit-0", ""),
             "unit/1": ("11.11.11.11", "/model-unit-1", ""),


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Charms that register their self-scrape job using fully-qualified hostnames or IP addresses (non-wildcard targets) were missing the `juju_unit` label in the final Prometheus scrape job. This affected `alertmanager-k8s` and any other charm that builds its scrape targets from peer FQDNs rather than using the `*:port` wildcard notation.

Reported in:
- canonical/alertmanager-k8s-operator#395
  - canonical/alertmanager-k8s-operator#272
- canonical/loki-k8s-operator/issues/570
- canonical/grafana-k8s-operator/issues/514


In tandem with:

- https://github.com/canonical/alertmanager-k8s-operator/pull/397
- https://github.com/canonical/loki-k8s-operator/pull/579
- https://github.com/canonical/grafana-k8s-operator/pull/523
- canonical/observability-stack/pull/245

## Root cause

`MetricsEndpointConsumer` has two code paths in `expand_wildcard_targets_into_individual_jobs()`:

- **Wildcard targets** (`*:9093`): the library expands each target into a per-unit job and explicitly adds `juju_unit` because the unit–address mapping is known at expansion time.
- **Non-wildcard targets** (`10.0.0.5:9093` or a FQDN): the library had no way to map the target back to a Juju unit, so it used `label_matcher_dict` which intentionally excludes `unit`. All non-wildcard targets ended up in a single job without `juju_unit`.


## Solution
<!-- A summary of the solution addressing the above issue -->

The information needed to resolve the mapping was already available: each provider unit publishes its address in unit-level relation data via `prometheus_scrape_unit_address`. The fix has three parts:

### 1. Publish the unit FQDN alongside the pod IP (`MetricsEndpointProvider`)

`_set_unit_ip()` now also writes `prometheus_scrape_unit_fqdn` to the unit relation data bag. When the bind address is a valid IP (the common K8s case), the FQDN is obtained from `socket.getfqdn()`. When the address is already a hostname, `fqdn` is set to the same value to avoid a redundant lookup.


<img width="1307" height="878" alt="image" src="https://github.com/user-attachments/assets/5713719d-7d20-4d34-ba29-474dd0d3b313" />


### 2. Read the FQDN in `_relation_hosts()` (`MetricsEndpointConsumer`)

`_relation_hosts()` now returns a 3-tuple `(address, path, fqdn)` instead of `(address, path)`. The `fqdn` field is empty string for provider units that have not yet published it (old library version), which preserves full backwards compatibility.

### 3. Reverse-lookup in `expand_wildcard_targets_into_individual_jobs()`

Before processing jobs, a reverse-lookup dict is built:

```python
host_to_unit = {
    identifier: unit_name
    for unit_name, (addr, _, fqdn) in hosts.items()
    for identifier in {addr, fqdn} - {""}
}
```

Both the IP and the FQDN of each known unit are mapped to the unit name.
Non-wildcard targets are then classified:

- **Matched** (target host found in `host_to_unit`): expanded into a per-unit job with `juju_unit` and `topology_relabel_config_wildcard`, identical to how wildcard targets are handled.
- **Unmatched** (external service, not a known Juju unit): kept in a single job without `juju_unit`, preserving the original behaviour.

Additionally, the matched-target expansion logic was factored out into a new private helper `_build_per_unit_job()` to eliminate the duplication between the wildcard and non-wildcard matched paths.


<img width="989" height="493" alt="image" src="https://github.com/user-attachments/assets/528fdad1-5445-43d1-8d36-71528343217a" />
<img width="754" height="424" alt="image" src="https://github.com/user-attachments/assets/e2a55a44-3d2e-4d4d-ae1c-917617314689" />






## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Four new test cases added to `TestWildcardExpansionWithTopology` in
`tests/unit/test_prometheus_config.py`:

- `test_non_wildcard_target_matching_unit_ip_gets_juju_unit_label` — target IP
  matches a known unit's pod IP
- `test_non_wildcard_target_matching_unit_fqdn_gets_juju_unit_label` — target FQDN
  matches a known unit's FQDN (the alertmanager use case)
- `test_non_wildcard_target_not_matching_any_unit_has_no_juju_unit_label` — external
  target, no match → original behaviour preserved
- `test_mixed_non_wildcard_targets_matched_and_unmatched` — one matched + one
  unmatched target in the same job → each ends up in the correct path



## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
### Backwards compatibility

| Scenario | Result |
|---|---|
| Old provider + new consumer | ✅ `fqdn` is empty string → only IP matching active → no regression |
| New provider + old consumer | ✅ Extra relation data key ignored → identical behaviour |
| Both updated | ✅ Non-wildcard targets now get `juju_unit` where resolvable |