### PR TITLE
fix: use blocked status on invalid log_level (#662)

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -217,7 +217,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 48
+LIBPATCH = 49
 
 PYDEPS = ["cosl >= 0.0.50"]
 
@@ -1013,7 +1013,7 @@ class CharmedDashboard:
 
         dashboard_templates = {}
 
-        for path in filter(_is_dashboard, Path(dashboards_path).glob("*")):
+        for path in filter(_is_dashboard, Path(dashboards_path).glob("**/*")):
             try:
                 dashboard_dict = json.loads(path.read_bytes())
             except json.JSONDecodeError as e:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -335,7 +335,7 @@ import subprocess
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import yaml
@@ -361,7 +361,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 57
+LIBPATCH = 58
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -398,6 +398,14 @@ DEFAULT_RELATION_NAME = "metrics-endpoint"
 RELATION_INTERFACE_NAME = "prometheus_scrape"
 
 DEFAULT_ALERT_RULES_RELATIVE_PATH = "./src/prometheus_alert_rules"
+
+FallbackScrapeProtocol = Literal[
+    "PrometheusProto",
+    "OpenMetricsText0.0.1",
+    "OpenMetricsText1.0.0",
+    "PrometheusText0.0.4",
+    "PrometheusText1.0.0",
+]
 
 
 class PrometheusConfig:
@@ -939,7 +947,12 @@ class MetricsEndpointConsumer(Object):
 
     on = MonitoringEvents()  # pyright: ignore
 
-    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        fallback_scrape_protocol: Optional[FallbackScrapeProtocol] = None,
+    ):
         """A Prometheus based Monitoring service.
 
         Args:
@@ -950,6 +963,17 @@ class MetricsEndpointConsumer(Object):
                 It is strongly advised not to change the default, so that people
                 deploying your charm will have a consistent experience with all
                 other charms that consume metrics endpoints.
+            fallback_scrape_protocol: an optional fallback protocol to use when the
+                Content-Type header of a scrape response is missing or invalid. Supported
+                values: "PrometheusProto", "OpenMetricsText0.0.1", "OpenMetricsText1.0.0",
+                "PrometheusText0.0.4", "PrometheusText1.0.0". Ref:
+                https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config.
+                This had to be added after we bumped to Prometheus workload major version 3. Starting in major 3,
+                Prometheus no longer defaults to the Prometheus text format (PrometheusText0.0.4)
+                when the Content-Type header is missing or invalid, and instead fails the scrape with an error.
+                This parameter should only be used by MetricsEndpointConsumers that use Prometheus 3 and above, as setting
+                this key in the scrape configs of Prometheus 2 will result in the error:
+                "field fallback_scrape_protocol not found in type config.ScrapeConfig".
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -968,6 +992,7 @@ class MetricsEndpointConsumer(Object):
         super().__init__(charm, relation_name)
         self._charm = charm
         self._relation_name = relation_name
+        self._fallback_scrape_protocol = fallback_scrape_protocol
         self._tool = CosTool(self._charm)
         events = self._charm.on[relation_name]
         self.framework.observe(events.relation_changed, self._on_metrics_provider_relation_changed)
@@ -1261,6 +1286,11 @@ class MetricsEndpointConsumer(Object):
 
         # For https scrape targets we still do not render a `tls_config` section because certs
         # are expected to be made available by the charm via the `update-ca-certificates` mechanism.
+
+        if self._fallback_scrape_protocol:
+            for job in scrape_configs:
+                job["fallback_scrape_protocol"] = self._fallback_scrape_protocol
+
         return scrape_configs
 
     def _relation_hosts(self, relation: Relation) -> Dict[str, Tuple[str, str, str]]:

--- a/src/charm.py
+++ b/src/charm.py
@@ -123,6 +123,7 @@ class CompositeStatus(TypedDict):
     # These are going to go into stored state, so we must use marshallable objects.
     # They are passed to StatusBase.from_name().
     retention_size: Tuple[str, str]
+    log_level: Tuple[str, str]
     k8s_patch: Tuple[str, str]
     config: Tuple[str, str]
 
@@ -171,6 +172,7 @@ class PrometheusCharm(CharmBase):
         self._stored.set_default(
             status=CompositeStatus(
                 retention_size=to_tuple(ActiveStatus()),
+                log_level=to_tuple(ActiveStatus()),
                 k8s_patch=to_tuple(ActiveStatus()),
                 config=to_tuple(ActiveStatus()),
             )
@@ -401,14 +403,18 @@ class PrometheusCharm(CharmBase):
         allowed_log_levels = ["debug", "info", "warn", "error", "fatal"]
         log_level = cast(str, self.model.config["log_level"]).lower()
 
-        if log_level not in allowed_log_levels:
-            logging.warning(
-                "Invalid loglevel: %s given, %s allowed. defaulting to DEBUG loglevel.",
-                log_level,
-                "/".join(allowed_log_levels),
-            )
-            log_level = "debug"
-        return log_level
+        if log_level in allowed_log_levels:
+            self._stored.status["log_level"] = to_tuple(ActiveStatus())
+            return log_level
+
+        log_message = (
+            f"Invalid loglevel: {log_level} given, "
+            f"{'/'.join(allowed_log_levels)} allowed. "
+            f"Defaulting to DEBUG loglevel."
+        )
+        logging.warning(log_message)
+        self._stored.status["log_level"] = to_tuple(BlockedStatus(log_message))
+        return "debug"
 
     @property
     def _default_config(self):
@@ -620,7 +626,6 @@ class PrometheusCharm(CharmBase):
         # Refresh system certs
         self.container.exec(["update-ca-certificates", "--fresh"]).wait()
         self.container.restart("prometheus")
-
 
     def _configure(self, _):
         """Reconfigure and either reload or restart Prometheus.
@@ -1185,7 +1190,6 @@ class PrometheusCharm(CharmBase):
         if exemplars_from_config > 0:
             return max(exemplars_from_config, EXEMPLARS_FLOOR)
         return 0
-
 
     def _pull(self, path) -> Optional[str]:
         """Pull file from container (without raising pebble errors).

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -68,7 +68,7 @@ class TestCharm(unittest.TestCase):
             expected_logs = {
                 "WARNING:root:Invalid loglevel: bad-level given, "
                 "debug/info/warn/error/fatal allowed. "
-                "defaulting to DEBUG loglevel."
+                "Defaulting to DEBUG loglevel."
             }
             self.assertGreaterEqual(set(logger.output), expected_logs)  # type: ignore
 
@@ -369,6 +369,58 @@ class TestConfigMaximumRetentionSize(unittest.TestCase):
         self.assertEqual(cli_arg(plan, "--storage.tsdb.retention.size"), "0.42GB")
         self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
+
+@prom_multipatch
+class TestConfigLogLevel(unittest.TestCase):
+    """Test the charmcraft.yaml option 'log_level'."""
+
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    @prom_multipatch
+    def setUp(self, *unused):
+        self.harness = Harness(PrometheusCharm)
+        self.addCleanup(self.harness.cleanup)
+
+        patcher = patch.object(PrometheusCharm, "_get_pvc_capacity")
+        self.mock_capacity = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.mock_capacity.return_value = "1Gi"
+        self.harness.container_pebble_ready("prometheus")
+        self.harness.handle_exec("prometheus", ["update-ca-certificates"], result=0)
+        self.harness.begin_with_initial_hooks()
+        self.harness.evaluate_status()
+
+    def _check_state(self, expected_log_level, status_class):
+        plan = self.harness.get_container_pebble_plan("prometheus")
+        self.assertEqual(cli_arg(plan, "--log.level"), expected_log_level)
+        self.harness.evaluate_status()
+        self.assertIsInstance(self.harness.model.unit.status, status_class)
+
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    def test_invalid_log_level_config_option_string(self, *unused):
+        # GIVEN a running charm with default values
+        #self.harness.begin_with_initial_hooks()
+        self._check_state("info", ActiveStatus)
+
+        # WHEN the config option is set to an invalid string
+        self.harness.update_config({"log_level": "bad-level"})
+
+        # THEN cli arg defaults to "debug" and the unit is blocked
+        self._check_state("debug", BlockedStatus)
+
+        # AND WHEN the config option is set to another invalid string
+        self.harness.update_config({"log_level": "very-bad-level"})
+
+        # THEN cli arg defaults to "debug" and the unit is blocked
+        self._check_state("debug", BlockedStatus)
+
+        # AND WHEN the config option is corrected
+        self.harness.update_config({"log_level": "error"})
+
+        # THEN cli arg is updated and the unit is goes back to active
+        self._check_state("error", ActiveStatus)
 
 
 @prom_multipatch


### PR DESCRIPTION
## Issue

See #662 

Before this commit, an invalid log_level config value just created a log message. After this commit, it also moves into a blocked state.

## Solution

- move to a blocked state when an invalid log_level is provided instead of just providing a warning
- add the same test scenario as for maximum_retention_size
- fix a small typo

(A similar solution is used for maximum_retention_size.)

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
