### PR TITLE
feat: drop alert labels when label value is empty

### DIFF
--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -537,11 +537,24 @@ class PrometheusRemoteWriteConsumer(Object):
 
     @staticmethod
     def _inject_extra_labels_to_alert_rules(rules: Dict, extra_alert_labels: Dict) -> Dict:
-        """Return a copy of the rules dict with extra labels injected."""
+        """Return a copy of the rules dict with extra labels injected.
+
+        Labels whose value is None or an empty string are removed from every
+        rule rather than being set.  If removing labels leaves the ``labels``
+        dict empty, the key is dropped from the rule entirely.
+        """
         result = copy.deepcopy(rules)
+        labels_to_drop = {k for k, v in extra_alert_labels.items() if v is None or v == ""}
+        labels_to_set = {k: v for k, v in extra_alert_labels.items() if k not in labels_to_drop}
+
         for group in result.get("groups", []):
             for rule in group.get("rules", []):
-                rule.setdefault("labels", {}).update(extra_alert_labels)
+                rule_labels = rule.setdefault("labels", {})
+                rule_labels.update(labels_to_set)
+                for key in labels_to_drop:
+                    rule_labels.pop(key, None)
+                if not rule_labels:
+                    del rule["labels"]
         return result
 
     @property


### PR DESCRIPTION
## Issue
In tiered otelcol setups where different tiers owned by different teams, it could be useful to have some alert labels dropped.

## Solution
Slightly modify the semantics such that empty label values would result with the label being dropped.

Addresses:
- https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/157
- https://github.com/canonical/opentelemetry-collector-operator/issues/150

In tandem with:
- https://github.com/canonical/loki-k8s-operator/pull/606

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
