### PR TITLE
fix: refresh metrics-endpoint unit address on `update_status` and `relation_changed`

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -361,7 +361,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 58
+LIBPATCH = 59
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -1622,8 +1622,22 @@ class MetricsEndpointProvider(Object):
         for ev in refresh_event:
             self.framework.observe(ev, self.set_scrape_job_spec)
 
+        # Always re-evaluate the unit address on `update_status`, regardless of the charm type
+        # (sidecar/pebble or podspec) or any user-provided `refresh_event`. On Kubernetes a pod
+        # can be rescheduled (e.g. node reboot/maintenance) and come back with a new IP without
+        # re-emitting `relation_joined`/`pebble_ready`. Without this, the stale address lingers in
+        # relation data and the consumer keeps scraping a dead IP until the relation is recreated.
+        # `update_status` fires periodically, so the address self-heals within one hook interval.
+        # See https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/270
+        self.framework.observe(self._charm.on.update_status, self._set_unit_ip)
+
     def _on_relation_changed(self, event):
         """Check for alert rule messages in the relation data before moving on."""
+        # Refresh the unit address on every `relation_changed`. This reacts faster than waiting for
+        # the next `update_status` when the pod IP changes, and is a no-op when the address is
+        # unchanged. See https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/270
+        self._set_unit_ip()
+
         if self._charm.unit.is_leader():
             ev = json.loads(event.relation.data[event.app].get("event", "{}"))
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1634,8 +1634,7 @@ class MetricsEndpointProvider(Object):
     def _on_relation_changed(self, event):
         """Check for alert rule messages in the relation data before moving on."""
         # Refresh the unit address on every `relation_changed`. This reacts faster than waiting for
-        # the next `update_status` when the pod IP changes, and is a no-op when the address is
-        # unchanged. See https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/270
+        # the next `update_status` when the pod IP changes, and is safe to call repeatedly.
         self._set_unit_ip()
 
         if self._charm.unit.is_leader():

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -238,6 +238,55 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertIn("prometheus_scrape_unit_name", data)
         self.assertEqual(data.get("prometheus_scrape_unit_path", ""), "")
 
+    def test_provider_unit_refreshes_address_on_update_status(self):
+        """A rescheduled pod (new IP) must refresh its address on update_status.
+
+        Regression test for the scenario where a Kubernetes node maintenance/reboot
+        reschedules the workload pod onto a new IP without re-emitting
+        relation_joined/pebble_ready. Without refreshing on update_status, the stale
+        address would linger in relation data and the consumer would keep scraping a
+        dead IP. See canonical/opentelemetry-collector-k8s-operator#270.
+        """
+        rel_id = self.harness.add_relation(RELATION_NAME, "provider")
+        self.harness.add_relation_unit(rel_id, "provider/0")
+
+        # GIVEN a provider that already published its (old) pod IP
+        with patch("ops.Network.bind_address", new="10.1.157.116"):
+            self.harness.charm.provider.set_scrape_job_spec()
+            data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+            self.assertEqual(data["prometheus_scrape_unit_address"], "10.1.157.116")
+
+            # WHEN the pod is rescheduled onto a new IP and only update_status fires
+            with patch("ops.Network.bind_address", new="10.1.200.42"):
+                self.harness.charm.on.update_status.emit()
+
+        # THEN the published address is refreshed to the new pod IP
+        data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertEqual(data["prometheus_scrape_unit_address"], "10.1.200.42")
+
+    def test_provider_unit_refreshes_address_on_relation_changed(self):
+        """A new pod IP must be reflected on relation_changed as a faster reaction.
+
+        Regression test for canonical/opentelemetry-collector-k8s-operator#270.
+        """
+        rel_id = self.harness.add_relation(RELATION_NAME, "provider")
+        self.harness.add_relation_unit(rel_id, "provider/0")
+
+        # GIVEN a provider that already published its (old) pod IP
+        with patch("ops.Network.bind_address", new="10.1.157.116"):
+            self.harness.charm.provider.set_scrape_job_spec()
+            data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+            self.assertEqual(data["prometheus_scrape_unit_address"], "10.1.157.116")
+
+            # WHEN the pod is rescheduled onto a new IP and relation_changed fires
+            # (triggered here via a remote databag update, which carries the app context)
+            with patch("ops.Network.bind_address", new="10.1.200.42"):
+                self.harness.update_relation_data(rel_id, "provider", {"ping": "pong"})
+
+        # THEN the published address is refreshed to the new pod IP
+        data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertEqual(data["prometheus_scrape_unit_address"], "10.1.200.42")
+
     def test_provider_sets_external_url(self):
         harness = Harness(make_endpoint_provider_charm_with_external_url("9.12.20.18"), meta=PROVIDER_META)
         harness.set_model_name("MyUUID")


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Fixes https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/270

On Kubernetes, a workload pod can be rescheduled (node reboot/maintenance, eviction, etc.) and come back with a **new pod IP**. The `MetricsEndpointProvider` only republished its address (`prometheus_scrape_unit_address`) on `relation_joined` and the configured `refresh_event` — which for a sidecar/pebble charm defaults to `pebble_ready`. None of those events reliably re-fire on a bare IP change, so the **stale IP lingered in relation data**. Any consumer (Prometheus/Mimir directly, or `opentelemetry-collector-k8s` in between) kept scraping a dead IP. The only workaround was to remove and re-add the relation, which does not scale for large deployments (e.g. OpenStack Sunbeam with many related applications).

## Solution
<!-- A summary of the solution addressing the above issue -->

Make address publishing reconcile-friendly so a changed pod IP self-heals without manual intervention. Two observers are added in `MetricsEndpointProvider`, both calling the existing `_set_unit_ip()`:

1. **`update_status`** — observed unconditionally or any user-provided `refresh_event`. Since `update_status` fires periodically, the published address self-heals within one hook interval after a reschedule.
2. **`relation_changed`** — `_set_unit_ip()` now runs at the start of `_on_relation_changed`, giving a faster reaction than waiting for the next `update_status`. It is a no-op when the address is unchanged.

`LIBPATCH` is bumped `58 → 59`. No public API changes; the fix is purely additive
(extra event observers) and writes the same unit-level relation data key as before.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

- The bug is on the **provider** side of `prometheus_scrape`. The consumer (`MetricsEndpointConsumer`) already reads unit relation data live on every reconcile, so it faithfully reflects whatever address the provider last published — it never caches a stale value itself.
- `_set_unit_ip()` writes to **unit** relation data (`relation.data[self._charm.unit]`), so it is correct and safe for every unit to call it (no leadership gating required); each unit publishes its own address.
- Why the old behaviour missed the IP change: `_set_unit_ip()` only ran via `relation_joined` and the `refresh_event`(s). When a charm does not pass an explicit `refresh_event`, the library picks a default for it — and for a typical single-container K8s charm that default is just `[<container>_pebble_ready]`. A pod rescheduled onto a new IP does not necessarily re-emit `pebble_ready`/`relation_joined`, so nothing rewrote the address. 
- This mirrors the intent already documented in `_set_unit_ip`'s docstring ("Each time a metrics provider charm container is restarted it updates its own host address …") — this PR makes that promise hold for IP changes that are not accompanied by a container restart event.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Unit tests (two new regression cases in
`tests/unit/test_endpoint_provider.py::TestEndpointProvider`):

```bash
tox -e unit -- tests/unit/test_endpoint_provider.py tests/unit/test_endpoint_consumer.py
```

New tests:
- `test_provider_unit_refreshes_address_on_update_status` — publishes an initial pod IP, then simulates a reschedule (new `ops.Network.bind_address`) and emits only `update_status`; asserts `prometheus_scrape_unit_address` is updated to the new IP.
- `test_provider_unit_refreshes_address_on_relation_changed` — same setup, but the refresh is driven by a `relation_changed` (via a remote databag update).

To confirm the tests catch the regression, revert only the library and keep the tests:

```bash
git checkout main -- lib/charms/prometheus_k8s/v0/prometheus_scrape.py

tox -e unit -- tests/unit/test_endpoint_provider.py -k refreshes_address_on
# Expected: both new tests FAIL (address stays at the old IP)

git checkout fix/ip-address -- lib/charms/prometheus_k8s/v0/prometheus_scrape.py
```



## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

No action required. Once a provider charm re-fetches `prometheus_scrape` (>= LIBPATCH 59)
and is refreshed, its unit address is refreshed automatically on `update_status` and
`relation_changed`; any already-stale address self-heals within one update-status interval.
The fix is backwards compatible:

| Scenario | Result |
|---|---|
| New provider (>=59) + old consumer | OK — same relation data key, just refreshed more often |
| Old provider (<=58) + any consumer | OK — unchanged behaviour; the stale-IP bug persists until the provider is updated |

Note on scope: the fix lives on the **provider** side, so the benefit lands once the
metrics-providing charms adopt the updated library. `prometheus-k8s` is the source of truth
for this library; after `charmcraft publish-lib`, downstream charms re-fetching the library
pick up the fix.
