### PR TITLE
fix: refresh metrics-endpoint unit address on `update_status` and `relation_changed` - backport to `track/2`

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,6 +6,13 @@ on:
       - main
       - track/**
 
+permissions:
+  # Required for CodeQL security scanning
+  security-events: write
+  # Required for private repositories
+  actions: read
+  contents: read
+
 jobs:
   pull-request:
     name: PR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,7 @@
 name: Release Charm
 
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - main
@@ -11,4 +12,4 @@ jobs:
     uses: canonical/observability/.github/workflows/charm-release.yaml@v1
     secrets: inherit
     with:
-      default-track: 2
+      default-track: dev

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,14 @@ on:
       - main
       - track/**
 
+permissions:
+  # Required for CodeQL security scanning
+  security-events: write
+  # Required for private repositories
+  actions: read
+  # Write permission needed for the reusable workflow to push git tags
+  contents: write
+
 jobs:
   release:
     uses: canonical/observability/.github/workflows/charm-release.yaml@v1

--- a/.wokeignore
+++ b/.wokeignore
@@ -1,0 +1,1 @@
+lib/charms/certificate_transfer_interface

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -55,7 +55,7 @@ resources:
   prometheus-image:
     type: oci-image
     description: Container image for Prometheus
-    upstream-source: ubuntu/prometheus@sha256:e945d24df7b2f591c056a84af143dd13ac9132aa353c14a9bd71bec6faf0b966  # renovate: oci-image tag: 2.53-24.04
+    upstream-source: ubuntu/prometheus@sha256:e14c7d6a46d4c7a8c8e127a5334beeabbe1080b6e4d6f439a59ae564d5bec341  # renovate: oci-image tag: 2.55-24.04
 
 storage:
   database:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -138,6 +138,14 @@ requires:
     limit: 1
     description: |
       Enables sending workload traces (internal Prometheus traces) to a distributed tracing backend such as Tempo.
+  receive-ca-cert:
+    interface: certificate_transfer
+    optional: true
+    description: |
+      For Prometheus to create a trusted (TLS) connection with servers
+      it scrapes, it needs to trust the CA that signed the server it
+      talks to. CA certs forwarded over this relation are installed in
+      the root CA store of the prometheus container.
 
 peers:
   prometheus-peers:

--- a/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v1/certificate_transfer.py
@@ -1,0 +1,681 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the certificate_transfer relation.
+
+This library contains the Requires and Provides classes for handling the
+certificate-transfer interface. It supports both v0 and v1 of the interface.
+
+For requirers, they will set version 1 in their application databag as a hint to
+the provider. They will read the databag from the provider first as v1, and fallback
+to v0 if the format does not match.
+
+For providers, they will check the version in the requirer's application databag,
+and send v1 if that version is set to 1, otherwise it will default to 0 for backwards
+compatibility.
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.certificate_transfer_interface.v1.certificate_transfer
+```
+
+### Provider charm
+The provider charm is the charm providing public certificates to another charm that requires them.
+
+Example:
+```python
+from ops.charm import CharmBase, RelationJoinedEvent
+from ops.main import main
+
+from lib.charms.certificate_transfer_interface.v1.certificate_transfer import (
+    CertificateTransferProvides,
+)
+
+class DummyCertificateTransferProviderCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.certificate_transfer = CertificateTransferProvides(self, "certificates")
+        self.framework.observe(
+            self.on.certificates_relation_joined, self._on_certificates_relation_joined
+        )
+
+    def _on_certificates_relation_joined(self, event: RelationJoinedEvent):
+        certificate = "my certificate"
+        self.certificate_transfer.add_certificates(certificate)
+
+
+if __name__ == "__main__":
+    main(DummyCertificateTransferProviderCharm)
+```
+
+### Requirer charm
+The requirer charm is the charm requiring certificates from another charm that provides them.
+
+Example:
+```python
+import logging
+
+from ops.charm import CharmBase
+from ops.main import main
+
+from lib.charms.certificate_transfer_interface.v1.certificate_transfer import (
+    CertificatesAvailableEvent,
+    CertificatesRemovedEvent,
+    CertificateTransferRequires,
+)
+
+
+class DummyCertificateTransferRequirerCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.certificate_transfer = CertificateTransferRequires(self, "certificates")
+        self.framework.observe(
+            self.certificate_transfer.on.certificate_set_updated, self._on_certificates_available
+        )
+        self.framework.observe(
+            self.certificate_transfer.on.certificates_removed, self._on_certificates_removed
+        )
+
+    def _on_certificates_available(self, event: CertificatesAvailableEvent):
+        logging.info(event.certificates)
+        logging.info(event.relation_id)
+
+    def _on_certificates_removed(self, event: CertificatesRemovedEvent):
+        logging.info(event.relation_id)
+
+
+if __name__ == "__main__":
+    main(DummyCertificateTransferRequirerCharm)
+```
+
+You can integrate both charms by running:
+
+```bash
+juju integrate <certificate_transfer provider charm> <certificate_transfer requirer charm>
+```
+
+"""
+
+import json
+import logging
+from typing import List, MutableMapping, Optional, Set
+
+import pydantic
+from ops import (
+    CharmEvents,
+    EventBase,
+    EventSource,
+    Handle,
+    Relation,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationCreatedEvent,
+)
+from ops.charm import CharmBase
+from ops.framework import Object
+
+# The unique Charmhub library identifier, never change it
+LIBID = "3785165b24a743f2b0c60de52db25c8b"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 13
+
+logger = logging.getLogger(__name__)
+
+PYDEPS = ["pydantic"]
+
+IS_PYDANTIC_V1 = int(pydantic.version.VERSION.split(".")[0]) < 2
+
+
+class TLSCertificatesError(Exception):
+    """Base class for custom errors raised by this library."""
+
+
+class DataValidationError(TLSCertificatesError):
+    """Raised when data validation fails."""
+
+
+class DatabagModel(pydantic.BaseModel):
+    """Base databag model.
+
+    Supports both pydantic v1 and v2.
+    """
+
+    if IS_PYDANTIC_V1:
+
+        class Config:
+            """Pydantic config."""
+
+            # ignore any extra fields in the databag
+            extra = "ignore"
+            """Ignore any extra fields in the databag."""
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+    model_config = pydantic.ConfigDict(
+        # tolerate additional keys in databag
+        extra="ignore",
+        # Allow instantiating this class by field name (instead of forcing alias).
+        populate_by_name=True,
+        # Custom config key: whether to nest the whole datastructure (as json)
+        # under a field or spread it out at the toplevel.
+        _NEST_UNDER=None,
+    )  # type: ignore
+    """Pydantic config."""
+
+    @classmethod
+    def load(cls, databag: MutableMapping):
+        """Load this model from a Juju databag."""
+        if IS_PYDANTIC_V1:
+            return cls._load_v1(databag)
+        nest_under = cls.model_config.get("_NEST_UNDER")
+        if nest_under:
+            return cls.model_validate(json.loads(databag[nest_under]))
+
+        try:
+            data = {
+                k: json.loads(v)
+                for k, v in databag.items()
+                # Don't attempt to parse model-external values
+                if k in {(f.alias or n) for n, f in cls.model_fields.items()}
+            }
+        except json.JSONDecodeError as e:
+            msg = f"invalid databag contents: expecting json. {databag}"
+            logger.error(msg)
+            raise DataValidationError(msg) from e
+
+        try:
+            return cls.model_validate_json(json.dumps(data))
+        except pydantic.ValidationError as e:
+            msg = f"failed to validate databag: {databag}"
+            logger.debug(msg, exc_info=True)
+            raise DataValidationError(msg) from e
+
+    @classmethod
+    def _load_v1(cls, databag: MutableMapping):
+        """Load implementation for pydantic v1."""
+        if cls._NEST_UNDER:
+            return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+        try:
+            data = {
+                k: json.loads(v)
+                for k, v in databag.items()
+                # Don't attempt to parse model-external values
+                if k in {f.alias for f in cls.__fields__.values()}
+            }
+        except json.JSONDecodeError as e:
+            msg = f"invalid databag contents: expecting json. {databag}"
+            logger.error(msg)
+            raise DataValidationError(msg) from e
+
+        try:
+            return cls.parse_raw(json.dumps(data))  # type: ignore
+        except pydantic.ValidationError as e:
+            msg = f"failed to validate databag: {databag}"
+            logger.debug(msg, exc_info=True)
+            raise DataValidationError(msg) from e
+
+    def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+        """Write the contents of this model to Juju databag.
+
+        Args:
+            databag: The databag to write to.
+            clear: Whether to clear the databag before writing.
+
+        Returns:
+            MutableMapping: The databag.
+        """
+        if IS_PYDANTIC_V1:
+            return self._dump_v1(databag, clear)
+        if clear and databag:
+            databag.clear()
+
+        if databag is None:
+            databag = {}
+        nest_under = self.model_config.get("_NEST_UNDER")
+        if nest_under:
+            databag[nest_under] = self.model_dump_json(
+                by_alias=True,
+                # skip keys whose values are default
+                exclude_defaults=True,
+            )
+            return databag
+
+        dct = self.model_dump(mode="json", by_alias=True, exclude_defaults=False)
+        databag.update({k: json.dumps(v) for k, v in dct.items()})
+        return databag
+
+    def _dump_v1(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+        """Dump implementation for pydantic v1."""
+        if clear and databag:
+            databag.clear()
+
+        if databag is None:
+            databag = {}
+
+        if self._NEST_UNDER:
+            databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=False)
+            return databag
+
+        dct = json.loads(self.json(by_alias=True, exclude_defaults=False))
+        databag.update({k: json.dumps(v) for k, v in dct.items()})
+
+        return databag
+
+
+class ProviderApplicationData(DatabagModel):
+    """Provider App databag model."""
+
+    if int(pydantic.version.VERSION.split(".")[0]) < 2:
+        certificates: Set[str] = pydantic.Field(
+            description="The set of certificates that will be transferred to a requirer",
+            default_factory=set,
+        )
+    else:
+        certificates: Set[str] = pydantic.Field(
+            description="The set of certificates that will be transferred to a requirer",
+            default=set(),
+        )
+    version: int = pydantic.Field(
+        description="Version of the interface used in this databag",
+        default=1,
+    )
+
+
+class ProviderUnitDataV0(DatabagModel):
+    """Provider Unit databag v0 model."""
+
+    ca: str
+    certificate: str
+    chain: Optional[List[str]] = None
+    version: int = pydantic.Field(
+        description="Version of the interface used in this databag",
+        default=0,
+    )
+
+
+class RequirerApplicationData(DatabagModel):
+    """Requirer App databag model."""
+
+    version: int = pydantic.Field(
+        description="Version of the interface supported by this requirer",
+        default=1,
+    )
+
+
+class CertificateTransferProvides(Object):
+    """Certificate Transfer provider class to be instantiated by charms sending certificates."""
+
+    def __init__(self, charm: CharmBase, relationship_name: str):
+        super().__init__(charm, relationship_name + "_v1")
+        self.charm = charm
+        self.relationship_name = relationship_name
+
+    def add_certificates(self, certificates: Set[str], relation_id: Optional[int] = None) -> None:
+        """Add certificates from a set to relation data.
+
+        Adds certificate to all relations if relation_id is not provided.
+
+        Args:
+            certificates (Set[str]): A set of certificate strings in PEM format
+            relation_id (int): Juju relation ID
+
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            logger.warning("Only the leader unit can add certificates to this relation")
+            return
+        relations = self._get_active_relations(relation_id)
+        if not relations:
+            if relation_id is not None:
+                logger.warning(
+                    "At least 1 matching relation ID not found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            else:
+                logger.debug(
+                    "No active relations found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            return
+
+        for relation in relations:
+            existing_data = self._get_relation_data(relation)
+            existing_data.update(certificates)
+            self._set_relation_data(relation, existing_data)
+
+    def remove_all_certificates(self, relation_id: Optional[int] = None) -> None:
+        """Remove all certificates from relation data.
+
+        Removes all certificates from all relations if relation_id not given
+
+        Args:
+            relation_id (int): Relation ID
+
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            logger.warning("Only the leader unit can add certificates to this relation")
+            return
+        relations = self._get_active_relations(relation_id)
+        if not relations:
+            if relation_id is not None:
+                logger.warning(
+                    "At least 1 matching relation ID not found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            else:
+                logger.debug(
+                    "No active relations found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            return
+
+        for relation in relations:
+            self._set_relation_data(relation, set())
+
+    def remove_certificate(
+        self,
+        certificate: str,
+        relation_id: Optional[int] = None,
+    ) -> None:
+        """Remove a given certificate from relation data.
+
+        Removes certificate from all relations if relation_id not given
+
+        Args:
+            certificate (str): Certificate in PEM format that's in the list
+            relation_id (int): Relation ID
+
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            logger.warning("Only the leader unit can add certificates to this relation")
+            return
+        relations = self._get_active_relations(relation_id)
+        if not relations:
+            if relation_id is not None:
+                logger.warning(
+                    "At least 1 matching relation ID not found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            else:
+                logger.debug(
+                    "No active relations found with the relation name '%s'",
+                    self.relationship_name,
+                )
+            return
+
+        for relation in relations:
+            existing_data = self._get_relation_data(relation)
+            existing_data.discard(certificate)
+            self._set_relation_data(relation, existing_data)
+
+    def _get_active_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
+        """Get the relation if relation_id is given and the relation is active, all active relations otherwise."""
+        if relation_id is not None:
+            relation = self.model.get_relation(
+                relation_name=self.relationship_name, relation_id=relation_id
+            )
+            if relation and relation.active:
+                return [relation]
+            return []
+
+        return [
+            relation
+            for relation in self.model.relations[self.relationship_name]
+            if relation.active
+        ]
+
+    def _set_relation_data(self, relation: Relation, data: Set[str]) -> None:
+        """Set the given relation data."""
+        if relation.data.get(relation.app, {}).get("version", "0") == "1":
+            databag = relation.data[self.model.app]
+            ProviderApplicationData(certificates=data).dump(databag, True)
+        else:
+            if "version" in relation.data.get(relation.app, {}):
+                logger.warning(
+                    (
+                        "Requirer in relation %d is using version %s of the interface,",
+                        "defaulting to version 0.",
+                        "This is deprecated, please consider upgrading the requirer",
+                        "to version 1 of the library.",
+                    ),
+                    relation.id,
+                    relation.data[relation.app]["version"],
+                )
+            else:
+                logger.warning(
+                    (
+                        "Requirer in relation %d did not provide version field,",
+                        "defaulting to version 0.",
+                        "This is deprecated, please consider upgrading the requirer",
+                        "to version 1 of the library.",
+                    ),
+                    relation.id,
+                )
+
+            databag = relation.data[self.model.unit]
+            if data:
+                certificates = list(data)
+                ProviderUnitDataV0(
+                    ca=certificates[0], certificate=certificates[0], chain=certificates
+                ).dump(databag, True)
+
+    def _get_relation_data(self, relation: Relation) -> Set[str]:
+        """Get the given relation data."""
+        try:
+            if relation.data.get(relation.app, {}).get("version", "0") == "1":
+                databag = relation.data[self.model.app]
+                return ProviderApplicationData().load(databag).certificates
+            else:
+                databag = relation.data[self.model.unit]
+                certs = ProviderUnitDataV0.load(databag).chain
+                if certs is None:
+                    return set()
+                return set(certs)
+        except DataValidationError as e:
+            logger.error(
+                (
+                    "Error parsing relation databag: %s. ",
+                    "Make sure not to interact with the databags "
+                    "except using the public methods in the provider library "
+                    "and use version V1.",
+                ),
+                e.args,
+            )
+            return set()
+
+
+class CertificatesAvailableEvent(EventBase):
+    """Charm Event triggered when the set of provided certificates is updated."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        certificates: Set[str],
+        relation_id: int,
+    ):
+        super().__init__(handle)
+        self.certificates = certificates
+        self.relation_id = relation_id
+
+    def snapshot(self) -> dict:
+        """Return snapshot."""
+        return {
+            "certificates": self.certificates,
+            "relation_id": self.relation_id,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificates = snapshot["certificates"]
+        self.relation_id = snapshot["relation_id"]
+
+
+class CertificatesRemovedEvent(EventBase):
+    """Charm Event triggered when the set of provided certificates is removed."""
+
+    def __init__(self, handle: Handle, relation_id: int):
+        super().__init__(handle)
+        self.relation_id = relation_id
+
+    def snapshot(self) -> dict:
+        """Return snapshot."""
+        return {"relation_id": self.relation_id}
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.relation_id = snapshot["relation_id"]
+
+
+class CertificateTransferRequirerCharmEvents(CharmEvents):
+    """List of events that the Certificate Transfer requirer charm can leverage."""
+
+    certificate_set_updated = EventSource(CertificatesAvailableEvent)
+    certificates_removed = EventSource(CertificatesRemovedEvent)
+
+
+class CertificateTransferRequires(Object):
+    """Certificate transfer requirer class to be instantiated by charms expecting certificates."""
+
+    on = CertificateTransferRequirerCharmEvents()  # type: ignore
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relationship_name: str,
+    ):
+        """Observe events related to the relation.
+
+        Args:
+            charm: Charm object
+            relationship_name: Juju relation name
+        """
+        super().__init__(charm, relationship_name + "_v1")
+        self.relationship_name = relationship_name
+        self.charm = charm
+        self.framework.observe(
+            charm.on[relationship_name].relation_changed, self._on_relation_changed
+        )
+        self.framework.observe(
+            charm.on[relationship_name].relation_broken, self._on_relation_broken
+        )
+        self.framework.observe(
+            charm.on[relationship_name].relation_created, self._on_relation_created
+        )
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Emit certificate set updated event.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        remote_unit_relation_data = self.get_all_certificates(event.relation.id)
+        self.on.certificate_set_updated.emit(
+            certificates=remote_unit_relation_data,
+            relation_id=event.relation.id,
+        )
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handle relation broken event.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        self.on.certificates_removed.emit(relation_id=event.relation.id)
+
+    def _on_relation_created(self, event: RelationCreatedEvent) -> None:
+        """Handle relation created event.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        if not self.model.unit.is_leader():
+            logger.debug("Only leader unit sets the version number in the app databag")
+            return
+        databag = event.relation.data[self.model.app]
+        RequirerApplicationData().dump(databag, False)
+
+    def get_all_certificates(self, relation_id: Optional[int] = None) -> Set[str]:
+        """Get transferred certificates.
+
+        If no relation id is given, certificates from all relations will be
+        provided in a concatenated list.
+
+        Args:
+            relation_id: The id of the relation to get the certificates from.
+        """
+        relations = self._get_active_relations(relation_id)
+        result = set()
+        for relation in relations:
+            data = self._get_relation_data(relation)
+            result = result.union(data)
+        return result
+
+    def is_ready(self, relation: Relation) -> bool:
+        """Check if the relation is ready by checking that it has valid relation data."""
+        databag = relation.data[relation.app]
+        try:
+            ProviderApplicationData().load(databag)
+            return True
+        except DataValidationError:
+            return False
+
+    def _get_relation_data(self, relation: Relation) -> Set[str]:
+        """Get the given relation data."""
+        try:
+            databag = relation.data[relation.app]
+            certificates = ProviderApplicationData().load(databag).certificates
+            if not certificates and relation.units:
+                databag = relation.data.get(relation.units.pop(), {})
+                certs = ProviderUnitDataV0.load(databag).chain
+                if certs is None:
+                    return set()
+                return set(certs)
+            return certificates
+        except DataValidationError as e:
+            logger.error(
+                (
+                    "Error parsing relation databag: %s. ",
+                    "Make sure not to interact with the databags "
+                    "except using the public methods in the provider library "
+                    "and use version V1.",
+                ),
+                e.args,
+            )
+            return set()
+
+    def _get_active_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
+        """Get the active relation if relation_id is given, all active relations otherwise."""
+        if relation_id is not None:
+            if relation := self.model.get_relation(
+                relation_name=self.relationship_name, relation_id=relation_id
+            ):
+                return [relation]
+        return [
+            relation
+            for relation in self.model.relations[self.relationship_name]
+            if relation.active
+        ]

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -187,7 +187,6 @@ import tempfile
 import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
-
 import yaml
 from cosl import DashboardPath40UID, LZMABase64
 from cosl.types import type_convert_stored
@@ -218,7 +217,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 46
+LIBPATCH = 48
 
 PYDEPS = ["cosl >= 0.0.50"]
 
@@ -586,9 +585,19 @@ class CharmedDashboard:
                     datasources[template_value["name"]] = template_value["query"].lower()
 
             # Put our own variables in the template
+            # We only want to inject our own dropdowns IFF they are NOT
+            # already in the template coming over relation data.
+            # We'll store all dropdowns in the template from the provider
+            # in a set. We'll add our own if they are not in this set.
+            existing_names = {
+                item.get("name")
+                for item in dict_content["templating"]["list"]
+            }
+
             for d in template_dropdowns:  # type: ignore
-                if d not in dict_content["templating"]["list"]:
+                if d.get("name") not in existing_names:
                     dict_content["templating"]["list"].insert(0, d)
+                    existing_names.add(d.get("name"))
 
         dict_content = cls._replace_template_fields(dict_content, datasources, existing_templates)
         return json.dumps(dict_content)
@@ -1636,29 +1645,60 @@ class GrafanaDashboardConsumer(Object):
             self.on.dashboards_changed.emit()  # pyright: ignore
 
     def _to_external_object(self, relation_id, dashboard):
+        decompressed = LZMABase64.decompress(dashboard["content"])
+        as_dict = json.loads(decompressed)
+
+        dashboard_title = as_dict.get("title", "")
+        dashboard_uid = as_dict.get("uid", "")
+
+        try:
+            dashboard_version = int(as_dict["version"])
+        except (KeyError, ValueError):
+            logger.warning("Dashboard '%s' (uid '%s') is missing a '.version' field or is invalid (must be integer); using '0' as fallback", dashboard_title, dashboard_uid)
+            dashboard_version = 0
+
         return {
             "id": dashboard["original_id"],
             "relation_id": relation_id,
             "charm": dashboard["template"]["charm"],
-            "content": LZMABase64.decompress(dashboard["content"]),
+            "content": decompressed,
+            "dashboard_uid": dashboard_uid,
+            "dashboard_version": dashboard_version,
+            "dashboard_title": dashboard_title,
         }
 
     @property
     def dashboards(self) -> List[Dict]:
         """Get a list of known dashboards across all instances of the monitored relation.
 
+        Filters out dashboards with the same uid, keeping only the one with the highest version.
+        When more than one dashboard have the same uid and version, keep the first one when
+        sorted by (relation_id, content) in reverse lexicographic order (highest relid first).
+
         Returns: a list of known dashboards. The JSON of each of the dashboards is available
             in the `content` field of the corresponding `dict`.
         """
-        dashboards = []
+        d: Dict[str, dict] = {}
 
         for _, (relation_id, dashboards_for_relation) in enumerate(
             self.get_peer_data("dashboards").items()
         ):
             for dashboard in dashboards_for_relation:
-                dashboards.append(self._to_external_object(relation_id, dashboard))
+                obj = self._to_external_object(relation_id, dashboard)
 
-        return dashboards
+                key = obj.get("dashboard_uid")
+                if key is None or str(key).strip() == "":
+                    # At this point, we assume that a `.uid` is present so we do not render a fallback identifier here. Instead, we omit it.
+                    logger.error("dashboard '%s' from relation id '%s' is missing a '.uid' field; omitted", obj["dashboard_title"], obj["relation_id"])
+                    continue
+
+                if key in d:
+                    d[key] = max(d[key], obj, key=lambda o: (o["dashboard_version"], o["relation_id"], o["content"]))
+                    logger.warning("deduplicate dashboard '%s' (uid '%s') - kept version '%s' from relation id '%s'", d[key]["dashboard_title"], d[key]["dashboard_uid"], d[key]["dashboard_version"], d[key]["relation_id"])
+                else:
+                    d[key] = obj
+
+        return list(d.values())
 
     def _get_stored_dashboards(self, relation_id: int) -> list:
         """Pull stored dashboards out of the peer data bucket."""

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -335,7 +335,7 @@ import subprocess
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import yaml
@@ -361,7 +361,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 56
+LIBPATCH = 59
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -398,6 +398,14 @@ DEFAULT_RELATION_NAME = "metrics-endpoint"
 RELATION_INTERFACE_NAME = "prometheus_scrape"
 
 DEFAULT_ALERT_RULES_RELATIVE_PATH = "./src/prometheus_alert_rules"
+
+FallbackScrapeProtocol = Literal[
+    "PrometheusProto",
+    "OpenMetricsText0.0.1",
+    "OpenMetricsText1.0.0",
+    "PrometheusText0.0.4",
+    "PrometheusText1.0.0",
+]
 
 
 class PrometheusConfig:
@@ -462,21 +470,155 @@ class PrometheusConfig:
         return modified_scrape_configs
 
     @staticmethod
+    def _build_host_to_unit(
+        hosts: Dict[str, Tuple[str, str, str]],
+        topology: Optional[JujuTopology],
+    ) -> Dict[str, str]:
+        """Build a reverse lookup dict: {address: unit_name, fqdn: unit_name, ...}.
+
+        Maps each known unit identifier (IP address and/or FQDN) to its unit name,
+        so that non-wildcard targets can be matched whether specified as IP or FQDN.
+
+        Returns an empty dict when ``topology`` is None, since matching only serves
+        the purpose of injecting ``juju_unit`` labels.
+
+        The set subtraction ``{addr, fqdn} - {""}`` drops empty strings (absent FQDN,
+        e.g. when external_url is set) and deduplicates when addr == fqdn (non-IP
+        bind address).
+        """
+        if not topology:
+            return {}
+        return {
+            identifier: unit_name
+            for unit_name, (addr, _, fqdn) in hosts.items()
+            for identifier in {addr, fqdn} - {""}
+        }
+
+    @staticmethod
+    def _classify_targets(targets: List[str]) -> Tuple[List[str], List[str]]:
+        """Split a list of targets into wildcard and non-wildcard targets.
+
+        Returns:
+            A ``(wildcard_targets, non_wildcard_targets)`` tuple.
+        """
+        wildcard_targets = []
+        non_wildcard_targets = []
+        wildcard_re = re.compile(r"\*(?:(:\d+))?")
+        for target in targets:
+            if wildcard_re.match(target):
+                wildcard_targets.append(target)
+            else:
+                non_wildcard_targets.append(target)
+        return wildcard_targets, non_wildcard_targets
+
+    @staticmethod
+    def _match_non_wildcard_targets(
+        targets: List[str],
+        host_to_unit: Dict[str, str],
+    ) -> Tuple[Dict[str, List[str]], List[str]]:
+        """Match non-wildcard targets against known unit addresses.
+
+        Parses the host portion of each target (handling IPv6 bracket notation) and
+        looks it up in ``host_to_unit``.
+
+        Returns:
+            A ``(matched_by_unit, unmatched_targets)`` tuple where ``matched_by_unit``
+            maps each matched unit name to the list of targets belonging to it, and
+            ``unmatched_targets`` contains targets with no unit match.
+        """
+        matched_by_unit: Dict[str, List[str]] = {}
+        unmatched_targets: List[str] = []
+        for target in targets:
+            # urlparse correctly handles IPv6 (e.g. [::1]:9093), host:port, and
+            # bare hostnames — unlike a naive split(":")[0].
+            parsed = urlparse(f"//{target}")
+            target_host = parsed.hostname or target.split(":", 1)[0]
+            matched_unit = host_to_unit.get(target_host)
+            if matched_unit:
+                matched_by_unit.setdefault(matched_unit, []).append(target)
+            else:
+                unmatched_targets.append(target)
+        return matched_by_unit, unmatched_targets
+
+    @staticmethod
+    def _build_per_unit_job(
+        job: dict,
+        static_config: dict,
+        targets: List[str],
+        unit_name: str,
+        unit_path: str,
+        topology: Optional[JujuTopology],
+    ) -> dict:
+        """Build a single per-unit scrape job with topology labels and relabeling rules.
+
+        Used for both wildcard and matched non-wildcard targets to avoid duplication.
+
+        Args:
+            job: the original scrape job dict to base the new job on.
+            static_config: the original static_config dict to copy labels from.
+            targets: the resolved target addresses for this unit.
+            unit_name: the Juju unit name (e.g. "alertmanager/0").
+            unit_path: path prefix to prepend to the metrics path (from external URL, may be "").
+            topology: optional topology for adding Juju labels.
+
+        Returns:
+            A new scrape job dict for this unit.
+        """
+        unit_num = unit_name.split("/")[-1]
+        new_static = static_config.copy()
+        new_static["targets"] = targets
+        new_job = job.copy()
+        new_job["job_name"] = new_job.get("job_name", "unnamed-job") + "-" + unit_num
+        new_job["metrics_path"] = unit_path + (new_job.get("metrics_path") or "/metrics")
+        if topology:
+            new_static["labels"] = {
+                **topology.label_matcher_dict,
+                "juju_unit": unit_name,
+                **new_static.get("labels", {}),
+            }
+            # Instance relabeling for topology should be last in order.
+            new_job["relabel_configs"] = new_job.get("relabel_configs", []) + [
+                PrometheusConfig.topology_relabel_config_wildcard
+            ]
+        new_job["static_configs"] = [new_static]
+        return new_job
+
+    @staticmethod
     def expand_wildcard_targets_into_individual_jobs(
         scrape_jobs: List[dict],
-        hosts: Dict[str, Tuple[str, str]],
+        hosts: Dict[str, Tuple[str, str, str]],
         topology: Optional[JujuTopology] = None,
     ) -> List[dict]:
         """Extract wildcard hosts from the given scrape_configs list into separate jobs.
 
+        For wildcard targets (e.g. "*:9093"), one job per unit is created. When
+        ``topology`` is provided, the ``juju_unit`` label is injected into each
+        per-unit job; without ``topology`` the per-unit jobs are created but no
+        topology labels are added.
+
+        For non-wildcard targets (fully qualified hostnames/IPs), the host portion of
+        each target is matched against the known unit addresses in ``hosts``. Targets
+        whose address matches a known unit are expanded into a per-unit job (with
+        ``juju_unit`` when ``topology`` is provided), mirroring the wildcard behaviour.
+        Targets with no match (e.g. external services) are kept in a single job without
+        ``juju_unit``, preserving the previous behaviour.
+
         Args:
             scrape_jobs: list of scrape jobs.
-            hosts: a dictionary mapping host names to host address for
-                all units of the relation for which this job configuration
-                must be constructed.
+            hosts: a dictionary mapping unit names to ``(address, path, fqdn)`` tuples for
+                all units of the relation for which this job configuration must be
+                constructed.
             topology: optional arg for adding topology labels to scrape targets.
+                When ``None``, wildcard targets are still expanded into per-unit jobs but
+                no ``juju_unit`` or topology labels are added. Non-wildcard target matching
+                is skipped entirely (all non-wildcard targets are kept in a single job),
+                since matching only serves the purpose of injecting ``juju_unit`` labels.
         """
-        # hosts = self._relation_hosts(relation)
+        # Build a reverse lookup: {address: unit_name, fqdn: unit_name, ...}
+        # so that non-wildcard targets can be matched whether specified as IP or FQDN.
+        # The set subtraction {addr, fqdn} - {""} drops empty strings (absent FQDN)
+        # and deduplicates when addr == fqdn (non-IP bind address).
+        host_to_unit = PrometheusConfig._build_host_to_unit(hosts, topology)
 
         modified_scrape_jobs = []
         for job in scrape_jobs:
@@ -484,84 +626,66 @@ class PrometheusConfig:
             if not static_configs:
                 continue
 
-            # When a single unit specified more than one wildcard target, then they are expanded
-            # into a static_config per target
-            non_wildcard_static_configs = []
+            # Accumulates non-wildcard targets that could not be matched to any known unit.
+            # These are kept in a single job with topology-only labels (no juju_unit):
+            # fully-qualified targets that predate this feature are unaffected.
+            unmatched_static_configs = []
 
             for static_config in static_configs:
                 targets = static_config.get("targets")
                 if not targets:
                     continue
 
-                # All non-wildcard targets remain in the same static_config
-                non_wildcard_targets = []
+                wildcard_targets, non_wildcard_targets = PrometheusConfig._classify_targets(
+                    targets
+                )
 
-                # All wildcard targets are extracted to a job per unit. If multiple wildcard
-                # targets are specified, they remain in the same static_config (per unit).
-                wildcard_targets = []
-
-                for target in targets:
-                    match = re.compile(r"\*(?:(:\d+))?").match(target)
-                    if match:
-                        # This is a wildcard target.
-                        # Need to expand into separate jobs and remove it from this job here
-                        wildcard_targets.append(target)
-                    else:
-                        # This is not a wildcard target. Copy it over into its own static_config.
-                        non_wildcard_targets.append(target)
-
-                # All non-wildcard targets remain in the same static_config
+                # Non-wildcard targets: try to match each target's host against known unit
+                # addresses. Matched targets get a per-unit job with juju_unit; unmatched
+                # targets get topology-only labels with no per-unit expansion.
                 if non_wildcard_targets:
-                    non_wildcard_static_config = static_config.copy()
-                    non_wildcard_static_config["targets"] = non_wildcard_targets
+                    matched_by_unit, unmatched_targets = (
+                        PrometheusConfig._match_non_wildcard_targets(
+                            non_wildcard_targets, host_to_unit
+                        )
+                    )
 
-                    if topology:
-                        # When non-wildcard targets (aka fully qualified hostnames) are specified,
-                        # there is no reliable way to determine the name (Juju topology unit name)
-                        # for such a target. Therefore labeling with Juju topology, excluding the
-                        # unit name.
-                        non_wildcard_static_config["labels"] = {
-                            **topology.label_matcher_dict,
-                            **non_wildcard_static_config.get("labels", {}),
-                        }
+                    # Unmatched targets: no unit mapping found — kept with topology-only
+                    # labels and no per-unit expansion (juju_unit is not added).
+                    if unmatched_targets:
+                        unmatched_static_config = static_config.copy()
+                        unmatched_static_config["targets"] = unmatched_targets
+                        if topology:
+                            unmatched_static_config["labels"] = {
+                                **topology.label_matcher_dict,
+                                **unmatched_static_config.get("labels", {}),
+                            }
+                        unmatched_static_configs.append(unmatched_static_config)
 
-                    non_wildcard_static_configs.append(non_wildcard_static_config)
-
-                # Extract wildcard targets into individual jobs
-                if wildcard_targets:
-                    for unit_name, (unit_hostname, unit_path) in hosts.items():
-                        modified_job = job.copy()
-                        modified_job["static_configs"] = [static_config.copy()]
-                        modified_static_config = modified_job["static_configs"][0]
-                        modified_static_config["targets"] = [
-                            target.replace("*", unit_hostname) for target in wildcard_targets
-                        ]
-
-                        unit_num = unit_name.split("/")[-1]
-                        job_name = modified_job.get("job_name", "unnamed-job") + "-" + unit_num
-                        modified_job["job_name"] = job_name
-                        modified_job["metrics_path"] = unit_path + (
-                            job.get("metrics_path") or "/metrics"
+                    # Matched targets: one per-unit job with juju_unit label.
+                    for unit_name, unit_targets_list in matched_by_unit.items():
+                        _, unit_path, _ = hosts.get(unit_name, ("", "", ""))
+                        modified_scrape_jobs.append(
+                            PrometheusConfig._build_per_unit_job(
+                                job, static_config, unit_targets_list, unit_name, unit_path, topology
+                            )
                         )
 
-                        if topology:
-                            # Add topology labels
-                            modified_static_config["labels"] = {
-                                **topology.label_matcher_dict,
-                                **{"juju_unit": unit_name},
-                                **modified_static_config.get("labels", {}),
-                            }
+                # Wildcard targets: one per-unit job per host, replacing "*" with the unit address.
+                if wildcard_targets:
+                    for unit_name, (unit_hostname, unit_path, _unit_fqdn) in hosts.items():
+                        resolved_targets = [
+                            target.replace("*", unit_hostname) for target in wildcard_targets
+                        ]
+                        modified_scrape_jobs.append(
+                            PrometheusConfig._build_per_unit_job(
+                                job, static_config, resolved_targets, unit_name, unit_path, topology
+                            )
+                        )
 
-                            # Instance relabeling for topology should be last in order.
-                            modified_job["relabel_configs"] = modified_job.get(
-                                "relabel_configs", []
-                            ) + [PrometheusConfig.topology_relabel_config_wildcard]
-
-                        modified_scrape_jobs.append(modified_job)
-
-            if non_wildcard_static_configs:
+            if unmatched_static_configs:
                 modified_job = job.copy()
-                modified_job["static_configs"] = non_wildcard_static_configs
+                modified_job["static_configs"] = unmatched_static_configs
                 modified_job["metrics_path"] = modified_job.get("metrics_path") or "/metrics"
 
                 if topology:
@@ -823,7 +947,12 @@ class MetricsEndpointConsumer(Object):
 
     on = MonitoringEvents()  # pyright: ignore
 
-    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        fallback_scrape_protocol: Optional[FallbackScrapeProtocol] = None,
+    ):
         """A Prometheus based Monitoring service.
 
         Args:
@@ -834,6 +963,17 @@ class MetricsEndpointConsumer(Object):
                 It is strongly advised not to change the default, so that people
                 deploying your charm will have a consistent experience with all
                 other charms that consume metrics endpoints.
+            fallback_scrape_protocol: an optional fallback protocol to use when the
+                Content-Type header of a scrape response is missing or invalid. Supported
+                values: "PrometheusProto", "OpenMetricsText0.0.1", "OpenMetricsText1.0.0",
+                "PrometheusText0.0.4", "PrometheusText1.0.0". Ref:
+                https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config.
+                This had to be added after we bumped to Prometheus workload major version 3. Starting in major 3,
+                Prometheus no longer defaults to the Prometheus text format (PrometheusText0.0.4)
+                when the Content-Type header is missing or invalid, and instead fails the scrape with an error.
+                This parameter should only be used by MetricsEndpointConsumers that use Prometheus 3 and above, as setting
+                this key in the scrape configs of Prometheus 2 will result in the error:
+                "field fallback_scrape_protocol not found in type config.ScrapeConfig".
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -852,6 +992,7 @@ class MetricsEndpointConsumer(Object):
         super().__init__(charm, relation_name)
         self._charm = charm
         self._relation_name = relation_name
+        self._fallback_scrape_protocol = fallback_scrape_protocol
         self._tool = CosTool(self._charm)
         events = self._charm.on[relation_name]
         self.framework.observe(events.relation_changed, self._on_metrics_provider_relation_changed)
@@ -1145,10 +1286,25 @@ class MetricsEndpointConsumer(Object):
 
         # For https scrape targets we still do not render a `tls_config` section because certs
         # are expected to be made available by the charm via the `update-ca-certificates` mechanism.
+
+        if self._fallback_scrape_protocol:
+            for job in scrape_configs:
+                job["fallback_scrape_protocol"] = self._fallback_scrape_protocol
+
         return scrape_configs
 
-    def _relation_hosts(self, relation: Relation) -> Dict[str, Tuple[str, str]]:
-        """Returns a mapping from unit names to (address, path) tuples, for the given relation."""
+    def _relation_hosts(self, relation: Relation) -> Dict[str, Tuple[str, str, str]]:
+        """Returns a mapping from unit names to (address, path, fqdn) tuples.
+
+        Args:
+            relation: the relation to read unit data from.
+
+        Returns:
+            A dict mapping each unit name to a ``(address, path, fqdn)`` tuple. The
+            ``fqdn`` element may be an empty string when the FQDN is not known. When
+            present, it may either be distinct from, or equal to ``address``. For
+            example, when the unit address itself is already a hostname.
+        """
         hosts = {}
         for unit in relation.units:
             if not (unit_databag := relation.data.get(unit)):
@@ -1161,11 +1317,12 @@ class MetricsEndpointConsumer(Object):
             unit_address = unit_databag.get("prometheus_scrape_unit_address") or unit_databag.get(
                 "prometheus_scrape_host"
             )
+            unit_fqdn = unit_databag.get("prometheus_scrape_unit_fqdn", "")
 
             if not (unit_name and unit_address):
                 continue
 
-            hosts.update({unit_name: (unit_address, unit_path)})
+            hosts.update({unit_name: (unit_address, unit_path, unit_fqdn)})
 
         return hosts
 
@@ -1465,8 +1622,22 @@ class MetricsEndpointProvider(Object):
         for ev in refresh_event:
             self.framework.observe(ev, self.set_scrape_job_spec)
 
+        # Always re-evaluate the unit address on `update_status`, regardless of the charm type
+        # (sidecar/pebble or podspec) or any user-provided `refresh_event`. On Kubernetes a pod
+        # can be rescheduled (e.g. node reboot/maintenance) and come back with a new IP without
+        # re-emitting `relation_joined`/`pebble_ready`. Without this, the stale address lingers in
+        # relation data and the consumer keeps scraping a dead IP until the relation is recreated.
+        # `update_status` fires periodically, so the address self-heals within one hook interval.
+        # See https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/270
+        self.framework.observe(self._charm.on.update_status, self._set_unit_ip)
+
     def _on_relation_changed(self, event):
         """Check for alert rule messages in the relation data before moving on."""
+        # Refresh the unit address on every `relation_changed`. This reacts faster than waiting for
+        # the next `update_status` when the pod IP changes, and is a no-op when the address is
+        # unchanged. See https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/270
+        self._set_unit_ip()
+
         if self._charm.unit.is_leader():
             ev = json.loads(event.relation.data[event.app].get("event", "{}"))
 
@@ -1540,18 +1711,22 @@ class MetricsEndpointProvider(Object):
                 parsed = urlparse(self.external_url)
                 unit_address = parsed.hostname
                 path = parsed.path
+                unit_fqdn = ""
             elif self._is_valid_unit_address(unit_ip):
                 unit_address = unit_ip
+                unit_fqdn = socket.getfqdn()
                 path = ""
             else:
                 unit_address = socket.getfqdn()
+                unit_fqdn = unit_address
                 path = ""
 
-            relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = unit_address
-            relation.data[self._charm.unit]["prometheus_scrape_unit_path"] = path
-            relation.data[self._charm.unit]["prometheus_scrape_unit_name"] = str(
-                self._charm.model.unit.name
-            )
+            relation.data[self._charm.unit].update({
+                "prometheus_scrape_unit_address": unit_address,
+                "prometheus_scrape_unit_path": path,
+                "prometheus_scrape_unit_name": str(self._charm.model.unit.name),
+                "prometheus_scrape_unit_fqdn": unit_fqdn,
+            })
 
     def _is_valid_unit_address(self, address: str) -> bool:
         """Validate a unit address.

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -23,11 +23,11 @@ import socket
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import yaml
 from cosl import JujuTopology
-from cosl.rules import AlertRules, generic_alert_groups
+from cosl.rules import HOST_METRICS_MISSING_RULE_NAME, AlertRules, generic_alert_groups
 from ops.charm import (
     CharmBase,
     HookEvent,
@@ -47,7 +47,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 12
 
 PYDEPS = ["cosl"]
 
@@ -404,10 +404,14 @@ class PrometheusRemoteWriteConsumer(Object):
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
         *,
+        peer_relation_name: str,
         forward_alert_rules: bool = True,
         extra_alert_labels: Dict = {},
     ):
         """API to manage a required relation with the `prometheus_remote_write` interface.
+
+        Since remote write consumers need to inject labels into alert expressions, they need
+        to have the cos tool binary available.
 
         Args:
             charm: The charm object that instantiated this class.
@@ -416,6 +420,7 @@ class PrometheusRemoteWriteConsumer(Object):
             alert_rules_path: Path of the directory containing the alert rules.
             refresh_event: an optional bound event or list of bound events which
                 will be observed to re-set alerts data.
+            peer_relation_name: Name of the peer relation containing units of this charm.
             forward_alert_rules: Flag to toggle forwarding of charmed alert rules.
             extra_alert_labels: Dict of extra labels to inject alert rules with.
 
@@ -448,9 +453,9 @@ class PrometheusRemoteWriteConsumer(Object):
         self._alert_rules_path = alert_rules_path
         self._forward_alert_rules = forward_alert_rules
         self._extra_alert_labels = extra_alert_labels
-
+        self._peer_relation_name = peer_relation_name
         self.topology = JujuTopology.from_charm(charm)
-
+        self._tool = CosTool(self._charm)
         on_relation = self._charm.on[self._relation_name]
 
         self.framework.observe(on_relation.relation_joined, self._handle_endpoints_changed)
@@ -498,13 +503,23 @@ class PrometheusRemoteWriteConsumer(Object):
     def _push_alerts_to_relation_databag(self, relation: Relation) -> None:
         if not self._charm.unit.is_leader():
             return
+        peer_relations = self._charm.model.get_relation(self._peer_relation_name)
+        unit_names = (
+            {unit.name for unit in peer_relations.units} if peer_relations else set()
+        ) | {self._charm.unit.name}
 
         alert_rules = AlertRules(query_type="promql", topology=self.topology)
+
         if self._forward_alert_rules:
-            alert_rules.add_path(self._alert_rules_path)
-            alert_rules.add(
-                generic_alert_groups.aggregator_rules, group_name_prefix=self.topology.identifier
+            agg_rules = self._duplicate_rules_per_unit(
+                copy.deepcopy(generic_alert_groups.aggregator_rules),
+                unit_names,
+                rule_names_to_duplicate=[HOST_METRICS_MISSING_RULE_NAME],
+                is_subordinate=self._charm.meta.subordinate,
             )
+            alert_rules.add(agg_rules, group_name_prefix=self.topology.identifier)
+
+            alert_rules.add_path(self._alert_rules_path)
 
         alert_rules_as_dict = alert_rules.as_dict()
 
@@ -514,7 +529,6 @@ class PrometheusRemoteWriteConsumer(Object):
                     alert_rules_as_dict, self._extra_alert_labels
                 )
             )
-
         relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
 
     def reload_alerts(self) -> None:
@@ -569,6 +583,56 @@ class PrometheusRemoteWriteConsumer(Object):
         # back to dictionaries
         deduplicated_endpoints = [dict(t) for t in {tuple(d.items()) for d in endpoints}]
         return deduplicated_endpoints
+
+    def _duplicate_rules_per_unit(
+        self,
+        alert_rules: Dict[str, Any],
+        peer_unit_names: Set[str],
+        rule_names_to_duplicate: List[str],
+        is_subordinate: bool = False,
+    ) -> Dict[str, Any]:
+        """Duplicate alert rule per unit in peer_units list.
+
+        Args:
+            alert_rules: A dictionary where key = "groups" and value is a list of rules.
+            peer_unit_names: A set of unit names (str) representing units of this charm.
+            rule_names_to_duplicate: A list of alert rule names to be duplicated.
+            is_subordinate: A boolean denoting whether the charm duplicating alert rules is a subordinate or not. If yes, the severity of the alerts in duplicate_keys needs to be set to critical.
+
+        Returns:
+            A Dict[str, any] the updated alert rules with the rules specified in rule_names_to_duplicate
+            duplicated per unit. The list is to be assigned to the `groups` attribute of an object of type AlertRules.
+        """
+        updated_alert_rules = copy.deepcopy(alert_rules)
+
+        for group in updated_alert_rules.get("groups", {}):
+            new_rules = []
+            for rule in group["rules"]:
+                if rule.get("alert", "") not in rule_names_to_duplicate:
+                    new_rules.append(rule)
+                else:
+                    for name in peer_unit_names:
+                        juju_unit = name
+                        modified_rule = copy.deepcopy(rule)
+
+                        # Inject juju_unit alert label.
+                        modified_rule["labels"]["juju_unit"] = juju_unit
+
+                        # Inject juju_unit label matcher.
+                        modified_rule["expr"] = self._tool.inject_label_matchers(
+                            re.sub(r"%%juju_unit%%,?", "", modified_rule["expr"]),
+                            {"juju_unit": juju_unit},
+                        )
+
+                        # If the charm is a subordinate, the severity of the alerts need to be bumped to critical.
+                        modified_rule["labels"]["severity"] = (
+                            "critical" if is_subordinate else "warning"
+                        )
+
+                        new_rules.append(modified_rule)
+
+            group["rules"] = new_rules
+        return updated_alert_rules
 
 
 class PrometheusRemoteWriteAlertsChangedEvent(EventBase):

--- a/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
@@ -4,233 +4,11 @@
 
 """This charm library contains utilities to instrument your Charm with opentelemetry tracing data collection.
 
-(yes! charm code, not workload code!)
+WARNING this library is deprecated and will be discontinued in 27.04.
+Instead, please use the new `ops[tracing]` library.
 
-This means that, if your charm is related to, for example, COS' Tempo charm, you will be able to inspect
-in real time from the Grafana dashboard the execution flow of your charm.
-
-# Quickstart
-Fetch the following charm libs:
-
-    charmcraft fetch-lib charms.tempo_coordinator_k8s.v0.tracing
-    charmcraft fetch-lib charms.tempo_coordinator_k8s.v0.charm_tracing
-
-Then edit your charm code to include:
-
-```python
-# import the necessary charm libs
-from charms.tempo_coordinator_k8s.v0.tracing import (
-    TracingEndpointRequirer,
-    charm_tracing_config,
-)
-from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing
-
-
-# decorate your charm class with charm_tracing:
-@charm_tracing(
-    # forward-declare the instance attributes that the instrumentor will look up to obtain the
-    # tempo endpoint and server certificate
-    tracing_endpoint="tracing_endpoint",
-    server_cert="server_cert",
-)
-class MyCharm(CharmBase):
-    _path_to_cert = "/path/to/cert.crt"
-    # path to cert file **in the charm container**. Its presence will be used to determine whether
-    # the charm is ready to use tls for encrypting charm traces. If your charm does not support tls,
-    # you can ignore this and pass None to charm_tracing_config.
-    # If you do support TLS, you'll need to make sure that the server cert is copied to this location
-    # and kept up to date so the instrumentor can use it.
-
-    def __init__(self, framework):
-        # ...
-        self.tracing = TracingEndpointRequirer(self)
-        self.tracing_endpoint, self.server_cert = charm_tracing_config(
-            self.tracing, self._path_to_cert
-        )
-```
-
-# Detailed usage
-To use this library, you need to do two things:
-1) decorate your charm class with
-
-`@trace_charm(tracing_endpoint="my_tracing_endpoint")`
-
-2) add to your charm a "my_tracing_endpoint" (you can name this attribute whatever you like)
-**property**, **method** or **instance attribute** that returns an otlp http/https endpoint url.
-If you are using the ``charms.tempo_coordinator_k8s.v0.tracing.TracingEndpointRequirer`` as
-``self.tracing = TracingEndpointRequirer(self)``, the implementation could be:
-
-```
-    @property
-    def my_tracing_endpoint(self) -> Optional[str]:
-        '''Tempo endpoint for charm tracing'''
-        if self.tracing.is_ready():
-            return self.tracing.get_endpoint("otlp_http")
-        else:
-            return None
-```
-
-At this point your charm will be automatically instrumented so that:
-- charm execution starts a trace, containing
-    - every event as a span (including custom events)
-    - every charm method call (except dunders) as a span
-
-We recommend that you scale up your tracing provider and relate it to an ingress so that your tracing requests
-go through the ingress and get load balanced across all units. Otherwise, if the provider's leader goes down, your tracing goes down.
-
-
-## TLS support
-If your charm integrates with a TLS provider which is also trusted by the tracing provider (the Tempo charm),
-you can configure ``charm_tracing`` to use TLS by passing a ``server_cert`` parameter to the decorator.
-
-If your charm is not trusting the same CA as the Tempo endpoint it is sending traces to,
-you'll need to implement a cert-transfer relation to obtain the CA certificate from the same
-CA that Tempo is using.
-
-For example:
-```
-from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
-@trace_charm(
-    tracing_endpoint="my_tracing_endpoint",
-    server_cert="_server_cert"
-)
-class MyCharm(CharmBase):
-    self._server_cert = "/path/to/server.crt"
-    ...
-
-    def on_tls_changed(self, e) -> Optional[str]:
-        # update the server cert on the charm container for charm tracing
-        Path(self._server_cert).write_text(self.get_server_cert())
-
-    def on_tls_broken(self, e) -> Optional[str]:
-        # remove the server cert so charm_tracing won't try to use tls anymore
-        Path(self._server_cert).unlink()
-```
-
-
-## More fine-grained manual instrumentation
-if you wish to add more spans to the trace, you can do so by getting a hold of the tracer like so:
-```
-import opentelemetry
-...
-def get_tracer(self) -> opentelemetry.trace.Tracer:
-    return opentelemetry.trace.get_tracer(type(self).__name__)
-```
-
-By default, the tracer is named after the charm type. If you wish to override that, you can pass
-a different ``service_name`` argument to ``trace_charm``.
-
-See the official opentelemetry Python SDK documentation for usage:
-https://opentelemetry-python.readthedocs.io/en/latest/
-
-
-## Caching traces
-The `trace_charm` machinery will buffer any traces collected during charm execution and store them
-to a file on the charm container until a tracing backend becomes available. At that point, it will
-flush them to the tracing receiver.
-
-By default, the buffer is configured to start dropping old traces if any of these conditions apply:
-
-- the storage size exceeds 10 MiB
-- the number of buffered events exceeds 100
-
-You can configure this by, for example:
-
-```python
-@trace_charm(
-    tracing_endpoint="my_tracing_endpoint",
-    server_cert="_server_cert",
-    # only cache up to 42 events
-    buffer_max_events=42,
-    # only cache up to 42 MiB
-    buffer_max_size_mib=42,  # minimum 10!
-)
-class MyCharm(CharmBase):
-    ...
-```
-
-Note that setting `buffer_max_events` to 0 will effectively disable the buffer.
-
-The path of the buffer file is by default in the charm's execution root, which for k8s charms means
-that in case of pod churn, the cache will be lost. The recommended solution is to use an existing storage
-(or add a new one) such as:
-
-```yaml
-storage:
-  data:
-    type: filesystem
-    location: /charm-traces
-```
-
-and then configure the `@trace_charm` decorator to use it as path for storing the buffer:
-```python
-@trace_charm(
-    tracing_endpoint="my_tracing_endpoint",
-    server_cert="_server_cert",
-    # store traces to a PVC so they're not lost on pod restart.
-    buffer_path="/charm-traces/buffer.file",
-)
-class MyCharm(CharmBase):
-    ...
-```
-
-## Upgrading from `tempo_k8s.v0`
-
-If you are upgrading from `tempo_k8s.v0.charm_tracing` (note that since then, the charm library moved to
-`tempo_coordinator_k8s.v0.charm_tracing`), you need to take the following steps (assuming you already
-have the newest version of the library in your charm):
-1) If you need the dependency for your tests, add the following dependency to your charm project
-(or, if your project had a dependency on `opentelemetry-exporter-otlp-proto-grpc` only because
-of `charm_tracing` v0, you can replace it with):
-
-`opentelemetry-exporter-otlp-proto-http>=1.21.0`.
-
-2) Update the charm method referenced to from ``@trace`` and ``@trace_charm``,
-to return from ``TracingEndpointRequirer.get_endpoint("otlp_http")`` instead of ``grpc_http``.
-For example:
-
-```
-    from charms.tempo_k8s.v0.charm_tracing import trace_charm
-
-    @trace_charm(
-        tracing_endpoint="my_tracing_endpoint",
-    )
-    class MyCharm(CharmBase):
-
-    ...
-
-        @property
-        def my_tracing_endpoint(self) -> Optional[str]:
-            '''Tempo endpoint for charm tracing'''
-            if self.tracing.is_ready():
-                return self.tracing.otlp_grpc_endpoint() #  OLD API, DEPRECATED.
-            else:
-                return None
-```
-
-needs to be replaced with:
-
-```
-    from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
-
-    @trace_charm(
-        tracing_endpoint="my_tracing_endpoint",
-    )
-    class MyCharm(CharmBase):
-
-    ...
-
-        @property
-        def my_tracing_endpoint(self) -> Optional[str]:
-            '''Tempo endpoint for charm tracing'''
-            if self.tracing.is_ready():
-                return self.tracing.get_endpoint("otlp_http")  # NEW API, use this.
-            else:
-                return None
-```
-
-3) If you were passing a certificate (str) using `server_cert`, you need to change it to
-provide an *absolute* path to the certificate file instead.
+See this migration guide: https://discourse.charmhub.io/t/18076
+See this deprecation announcement: https://discourse.charmhub.io/t/19669
 """
 
 
@@ -341,6 +119,21 @@ from opentelemetry.trace import (
 from ops.charm import CharmBase
 from ops.framework import Framework
 
+
+if os.getenv("CHARM_TRACING_DEPRECATION_NOTICE_DISABLED"):
+    import warnings
+
+    warnings.warn(
+        "The `charm_tracing` library is deprecated and will be discontinued in 27.04. "
+        "Please migrate to the new `ops[tracing]` library. "
+        "See this migration guide: https://discourse.charmhub.io/t/18076 "
+        "See this deprecation announcement: https://discourse.charmhub.io/t/19669 "
+        "To disable this warning, set the CHARM_TRACING_DEPRECATION_NOTICE_DISABLED "
+        "environment variable. ",
+        DeprecationWarning,
+    )
+
+
 # The unique Charmhub library identifier, never change it
 LIBID = "01780f1e588c42c3976d26780fdf9b89"
 
@@ -350,7 +143,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 11
+LIBPATCH = 12
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -77,7 +77,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 26
+LIBPATCH = 27
 
 PYDEPS = [
     "cryptography>=43.0.0",
@@ -367,6 +367,10 @@ class PrivateKey:
             .decode()
             .strip()
         )
+
+    def __hash__(self):
+        """Return the hash of the private key."""
+        return hash(self.raw)
 
     @classmethod
     def from_string(cls, private_key: str) -> "PrivateKey":
@@ -739,6 +743,10 @@ class Certificate:
 
         return cert
 
+    def __hash__(self):
+        """Return the hash of the private key."""
+        return hash(self.raw)
+
 
 class CertificateSigningRequest:
     """A representation of the certificate signing request."""
@@ -892,6 +900,10 @@ class CertificateSigningRequest:
         if not isinstance(other, CertificateSigningRequest):
             return NotImplemented
         return self.raw == other.raw
+
+    def __hash__(self):
+        """Return the hash of the private key."""
+        return hash(self.raw)
 
     def matches_certificate(self, certificate: Certificate) -> bool:
         """Check if this CSR matches a given certificate.

--- a/release-notes/prometheus-2.53.1-to-2.55.1-notes.md
+++ b/release-notes/prometheus-2.53.1-to-2.55.1-notes.md
@@ -1,0 +1,183 @@
+# 2.53.3 / 2024-11-04
+
+Tag: v2.53.3
+URL: https://github.com/prometheus/prometheus/releases/tag/v2.53.3
+
+* [BUGFIX] Scraping: allow multiple samples on same series, with explicit timestamps. #14685, #14740
+
+
+================================================================================
+
+# 2.53.4 / 2025-03-18
+
+Tag: v2.53.4
+URL: https://github.com/prometheus/prometheus/releases/tag/v2.53.4
+
+* [BUGFIX] Runtime: fix GOGC is being set to 0 when installed with empty prometheus.yml file resulting high cpu usage. #16090
+* [BUGFIX] Scrape: fix dropping valid metrics after previous scrape failed. #16220
+
+
+================================================================================
+
+# 2.53.5 / 2025-06-27
+
+Tag: v2.53.5
+URL: https://github.com/prometheus/prometheus/releases/tag/v2.53.5
+
+[LTS patch release]
+
+* [ENHANCEMENT] TSDB: Add backward compatibility with the upcoming TSDB block index v3 #16762
+* [BUGFIX] Top-level: Update GOGC before loading TSDB #16521
+
+
+================================================================================
+
+# 2.54.0 / 2024-08-09
+
+Tag: v2.54.0
+URL: https://github.com/prometheus/prometheus/releases/tag/v2.54.0
+
+Release 2.54 brings a release candidate of a major new version of [Remote Write: 2.0](https://prometheus.io/docs/specs/remote_write_spec_2_0/).
+This is experimental at this time and may still change.
+Remote-write v2 is enabled by default, but can be disabled via feature-flag `web.remote-write-receiver.accepted-protobuf-messages`.
+
+* [CHANGE] Remote-Write: `highest_timestamp_in_seconds` and `queue_highest_sent_timestamp_seconds` metrics now initialized to 0. #14437
+* [CHANGE] API: Split warnings from info annotations in API response. #14327
+* [FEATURE] Remote-Write: Version 2.0 experimental, plus metadata in WAL via feature flag `metadata-wal-records` (defaults on). #14395,#14427,#14444
+* [FEATURE] PromQL: add limitk() and limit_ratio() aggregation operators. #12503
+* [ENHANCEMENT] PromQL: Accept underscores in literal numbers, e.g. 1_000_000 for 1 million. #12821
+* [ENHANCEMENT] PromQL: float literal numbers and durations are now interchangeable (experimental). Example: `time() - my_timestamp > 10m`. #9138
+* [ENHANCEMENT] PromQL: use Kahan summation for sum(). #14074,#14362
+* [ENHANCEMENT] PromQL (experimental native histograms): Optimize `histogram_count` and `histogram_sum` functions. #14097
+* [ENHANCEMENT] TSDB: Better support for out-of-order experimental native histogram samples. #14438
+* [ENHANCEMENT] TSDB: Optimise seek within index. #14393
+* [ENHANCEMENT] TSDB: Optimise deletion of stale series. #14307
+* [ENHANCEMENT] TSDB: Reduce locking to optimise adding and removing series. #13286,#14286
+* [ENHANCEMENT] TSDB: Small optimisation: streamline special handling for out-of-order data. #14396,#14584
+* [ENHANCEMENT] Regexps: Optimize patterns with multiple prefixes. #13843,#14368
+* [ENHANCEMENT] Regexps: Optimize patterns containing multiple literal strings. #14173
+* [ENHANCEMENT] AWS SD: expose Primary IPv6 addresses as __meta_ec2_primary_ipv6_addresses. #14156
+* [ENHANCEMENT] Docker SD: add MatchFirstNetwork for containers with multiple networks. #10490
+* [ENHANCEMENT] OpenStack SD: Use `flavor.original_name` if available. #14312
+* [ENHANCEMENT] UI (experimental native histograms): more accurate representation. #13680,#14430
+* [ENHANCEMENT] Agent: `out_of_order_time_window` config option now applies to agent. #14094
+* [ENHANCEMENT] Notifier: Send any outstanding Alertmanager notifications when shutting down. #14290
+* [ENHANCEMENT] Rules: Add label-matcher support to Rules API. #10194
+* [ENHANCEMENT] HTTP API: Add url to message logged on error while sending response. #14209
+* [BUGFIX] CLI: escape `|` characters when generating docs. #14420
+* [BUGFIX] PromQL (experimental native histograms): Fix some binary operators between native histogram values. #14454
+* [BUGFIX] TSDB: LabelNames API could fail during compaction. #14279
+* [BUGFIX] TSDB: Fix rare issue where pending OOO read can be left dangling if creating querier fails. #14341
+* [BUGFIX] TSDB: fix check for context cancellation in LabelNamesFor. #14302
+* [BUGFIX] Rules: Fix rare panic on reload. #14366
+* [BUGFIX] Config: In YAML marshalling, do not output a regexp field if it was never set. #14004
+* [BUGFIX] Remote-Write: reject samples with future timestamps. #14304
+* [BUGFIX] Remote-Write: Fix data corruption in remote write if max_sample_age is applied. #14078
+* [BUGFIX] Notifier: Fix Alertmanager discovery not updating under heavy load. #14174
+* [BUGFIX] Regexes: some Unicode characters were not matched by case-insensitive comparison. #14170,#14299
+* [BUGFIX] Remote-Read: Resolve occasional segmentation fault on query. #14515
+
+Many thanks to the Prometheus Team and contributors:
+@zenador 
+@jjo 
+@rexagod 
+@darshanime 
+@charleskorn 
+@fpetkovski 
+@carrieedwards 
+@colega  
+@pracucci 
+@akunszt 
+@DrAuYueng 
+@paulojmdias 
+@Maniktherana 
+@rabenhorst  
+@saswatamcode 
+@B1F030 
+@yeya24 
+@rapphil 
+@liam-howe-maersk 
+@jkroepke 
+@FUSAKLA 
+@Ranveer777
+
+
+================================================================================
+
+# 2.54.1 / 2024-08-27
+
+Tag: v2.54.1
+URL: https://github.com/prometheus/prometheus/releases/tag/v2.54.1
+
+* [BUGFIX] Scraping: allow multiple samples on same series, with explicit timestamps. #14685
+* [BUGFIX] Docker SD: fix crash in `match_first_network` mode when container is reconnected to a new network. #14654
+* [BUGFIX] PromQL: fix experimental native histogram counter reset detection on stale samples. #14514
+* [BUGFIX] PromQL: fix experimental native histograms getting corrupted due to vector selector bug in range queries. #14538
+* [BUGFIX] PromQL: fix experimental native histogram memory corruption when using histogram_count or histogram_sum. #14605
+
+**Full Changelog**: https://github.com/prometheus/prometheus/compare/v2.54.0...v2.54.1
+
+
+================================================================================
+
+# 2.55.0 / 2024-10-22
+
+Tag: v2.55.0
+URL: https://github.com/prometheus/prometheus/releases/tag/v2.55.0
+
+## What's Changed
+* [FEATURE] PromQL: Add experimental `info` function. #14495
+* [FEATURE] Support UTF-8 characters in label names - feature flag `utf8-names`. #14482, #14880, #14736, #14727
+* [FEATURE] Scraping: Add the ability to set custom `http_headers` in config. #14817
+* [FEATURE] Scraping: Support feature flag `created-timestamp-zero-ingestion` in OpenMetrics. #14356, #14815
+* [FEATURE] Scraping: `scrape_failure_log_file` option to log failures to a file. #14734
+* [FEATURE] OTLP receiver: Optional promotion of resource attributes to series labels. #14200
+* [FEATURE] Remote-Write: Support Google Cloud Monitoring authorization. #14346
+* [FEATURE] Promtool: `tsdb create-blocks` new option to add labels. #14403
+* [FEATURE] Promtool: `promtool test` adds `--junit` flag to format results. #14506
+* [FEATURE] TSDB: Add `delayed-compaction` feature flag, for people running many Prometheus to randomize timing. #12532
+* [ENHANCEMENT] OTLP receiver: Warn on exponential histograms with zero count and non-zero sum. #14706
+* [ENHANCEMENT] OTLP receiver: Interrupt translation on context cancellation/timeout. #14612
+* [ENHANCEMENT] Remote Read client: Enable streaming remote read if the server supports it. #11379
+* [ENHANCEMENT] Remote-Write: Don't reshard if we haven't successfully sent a sample since last update. #14450
+* [ENHANCEMENT] PromQL: Delay deletion of `__name__` label to the end of the query evaluation. This is **experimental** and enabled under the feature-flag `promql-delayed-name-removal`. #14477
+* [ENHANCEMENT] PromQL: Experimental `sort_by_label` and `sort_by_label_desc` sort by all labels when label is equal. #14655, #14985
+* [ENHANCEMENT] PromQL: Clarify error message logged when Go runtime panic occurs during query evaluation. #14621
+* [ENHANCEMENT] PromQL: Use Kahan summation for better accuracy in `avg` and `avg_over_time`. #14413
+* [ENHANCEMENT] Tracing: Improve PromQL tracing, including showing the operation performed for aggregates, operators, and calls. #14816
+* [ENHANCEMENT] API: Support multiple listening addresses. #14665
+* [ENHANCEMENT] TSDB: Backward compatibility with upcoming index v3. #14934
+* [PERF] TSDB: Query in-order and out-of-order series together. #14354, #14693, #14714, #14831, #14874, #14948, #15120
+* [PERF] TSDB: Streamline reading of overlapping out-of-order head chunks. #14729
+* [BUGFIX] PromQL: make sort_by_label stable. #14985
+* [BUGFIX] SD: Fix dropping targets (with feature flag `new-service-discovery-manager`). #13147
+* [BUGFIX] SD: Stop storing stale targets (with feature flag `new-service-discovery-manager`). #13622
+* [BUGFIX] Scraping: exemplars could be dropped in protobuf scraping. #14810
+* [BUGFIX] Remote-Write: fix metadata sending for experimental Remote-Write V2. #14766
+* [BUGFIX] Remote-Write: Return 4xx not 5xx when timeseries has duplicate label. #14716
+* [BUGFIX] Experimental Native Histograms: many fixes for incorrect results, panics, warnings. #14513, #14575, #14598, #14609, #14611, #14771, #14821
+* [BUGFIX] TSDB: Only count unknown record types in `record_decode_failures_total` metric. #14042
+
+## New Contributors
+* @maxamins made their first contribution in https://github.com/prometheus/prometheus/pull/14346
+* @cuiweiyuan made their first contribution in https://github.com/prometheus/prometheus/pull/14626
+* @harshitasao made their first contribution in https://github.com/prometheus/prometheus/pull/14690
+* @patilsuraj767 made their first contribution in https://github.com/prometheus/prometheus/pull/14403
+* @riskrole made their first contribution in https://github.com/prometheus/prometheus/pull/14751
+* @jcreixell made their first contribution in https://github.com/prometheus/prometheus/pull/14477
+* @kevinrawal made their first contribution in https://github.com/prometheus/prometheus/pull/14765
+* @electron0zero made their first contribution in https://github.com/prometheus/prometheus/pull/14650
+* @shandongzhejiang made their first contribution in https://github.com/prometheus/prometheus/pull/14700
+
+**Full Changelog**: https://github.com/prometheus/prometheus/compare/v2.54.1...v2.55.0
+
+
+================================================================================
+
+# 2.55.1 / 2024-11-04
+
+Tag: v2.55.1
+URL: https://github.com/prometheus/prometheus/releases/tag/v2.55.1
+
+* [BUGFIX] `round()` function did not remove `__name__` label. #15250
+

--- a/src/charm.py
+++ b/src/charm.py
@@ -1132,13 +1132,7 @@ class PrometheusCharm(CharmBase):
             # prometheus and all scrape jobs are signed by the same CA.
 
             ca_file = tls_config.get("ca_file")
-            if not ca_file and self._tls_config:
-                ca_file = self._tls_config.ca_cert
-
             if ca_file:
-                # TODO we shouldn't be passing CA certs over relation data, because that
-                #  reduces to self-signed certs. Both parties need to separately trust the CA
-                #  instead.
                 filename = f"{PROMETHEUS_DIR}/{job['job_name']}-ca.crt"
                 certs[filename] = ca_file
                 job["tls_config"] = {**tls_config, **{"ca_file": filename}}

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2020 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """A Juju charm for Prometheus on Kubernetes."""
@@ -18,6 +18,9 @@ from urllib.parse import urlparse
 import yaml
 from charms.alertmanager_k8s.v1.alertmanager_dispatch import AlertmanagerConsumer
 from charms.catalogue_k8s.v1.catalogue import CatalogueConsumer, CatalogueItem
+from charms.certificate_transfer_interface.v1.certificate_transfer import (
+    CertificateTransferRequires,
+)
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
 from charms.mimir_coordinator_k8s.v0.prometheus_api import (
@@ -86,7 +89,7 @@ ALERTS_HASH_PATH = f"{PROMETHEUS_DIR}/alerts.sha256"
 # These are used to present to clients and to authenticate other servers.
 KEY_PATH = f"{PROMETHEUS_DIR}/server.key"
 CERT_PATH = f"{PROMETHEUS_DIR}/server.cert"
-CA_CERT_PATH = f"{PROMETHEUS_DIR}/ca.cert"
+RECV_CA_CERT_FOLDER_PATH = "/usr/local/share/ca-certificates/juju_receive-ca-cert"
 WEB_CONFIG_PATH = f"{PROMETHEUS_DIR}/prometheus-web-config.yml"
 
 # To get the behaviour consistent with mimir that doesn't allow lower values
@@ -163,7 +166,6 @@ class PrometheusCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self._fqdn = socket.getfqdn()
-
         # Prometheus has a mix of pull and push statuses. We need stored state for push statuses.
         # https://discourse.charmhub.io/t/its-probably-ok-for-a-unit-to-go-into-error-state/13022
         self._stored.set_default(
@@ -197,6 +199,7 @@ class PrometheusCharm(CharmBase):
             relationship_name="certificates",
             certificate_requests=[self._csr_attributes],
         )
+        self._cert_transfer = CertificateTransferRequires(self, "receive-ca-cert")
         # Update certs here in init to avoid code ordering issues
         self._update_cert()
 
@@ -276,6 +279,8 @@ class PrometheusCharm(CharmBase):
         self.framework.observe(self.ingress.on.ready_for_unit, self._on_ingress_ready)
         self.framework.observe(self.ingress.on.revoked_for_unit, self._on_ingress_revoked)
         self.framework.observe(self._cert_requirer.on.certificate_available, self._on_certificate_available)
+        self.framework.observe(self._cert_transfer.on.certificate_set_updated, self._on_receive_ca_certs)
+        self.framework.observe(self._cert_transfer.on.certificates_removed, self._on_receive_ca_certs)
         self.framework.observe(self.remote_write_provider.on.alert_rules_changed, self._configure)
         self.framework.observe(self.remote_write_provider.on.consumers_changed, self._configure)
         self.framework.observe(self.metrics_consumer.on.targets_changed, self._configure)
@@ -452,7 +457,7 @@ class PrometheusCharm(CharmBase):
                 {
                     "scheme": "https",
                     "tls_config": {
-                        "ca_file": CA_CERT_PATH,
+                        "ca_file": self._ca_cert_path,
                     },
                 }
             )
@@ -542,6 +547,9 @@ class PrometheusCharm(CharmBase):
         self._update_cert()
         self._configure(_)
 
+    def _on_receive_ca_certs(self, _):
+        self._update_ca_certs()
+
     # TLS CONFIG
     @property
     def _tls_config(self) -> Optional[TLSConfig]:
@@ -580,13 +588,6 @@ class PrometheusCharm(CharmBase):
                 tls_config.ca_cert,
                 make_dirs=True,
             )
-            # FIXME with the update-ca-certificates machinery prometheus shouldn't need
-            #  CA_CERT_PATH.
-            self.container.push(
-                CA_CERT_PATH,
-                tls_config.ca_cert,
-                make_dirs=True,
-            )
 
             # Repeat for the charm container. We need it there for prometheus client requests.
             ca_cert_path.parent.mkdir(exist_ok=True, parents=True)
@@ -595,12 +596,31 @@ class PrometheusCharm(CharmBase):
             self.container.remove_path(CERT_PATH, recursive=True)
             self.container.remove_path(KEY_PATH, recursive=True)
             self.container.remove_path(ca_cert_path, recursive=True)
-            self.container.remove_path(CA_CERT_PATH, recursive=True)  # TODO: remove (see FIXME ^)
             # Repeat for the charm container.
             ca_cert_path.unlink(missing_ok=True)
 
         self.container.exec(["update-ca-certificates", "--fresh"]).wait()
         subprocess.run(["update-ca-certificates", "--fresh"])
+
+    def _update_ca_certs(self):
+        """Get CA certs from relation data and install them in the workload container's root store."""
+        if not self.container.can_connect():
+            return
+
+        # Obtain certs from relation data
+        ca_certs = self._cert_transfer.get_all_certificates()
+
+        # Clean-up previously existing certs
+        self.container.remove_path(RECV_CA_CERT_FOLDER_PATH, recursive=True)
+
+        # Write current certs
+        for i, cert in enumerate(ca_certs):
+            self.container.push(RECV_CA_CERT_FOLDER_PATH + f"/{i}.crt", cert, make_dirs=True)
+
+        # Refresh system certs
+        self.container.exec(["update-ca-certificates", "--fresh"]).wait()
+        self.container.restart("prometheus")
+
 
     def _configure(self, _):
         """Reconfigure and either reload or restart Prometheus.

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -11,6 +11,7 @@ output "endpoints" {
     ingress          = "ingress"
     catalogue        = "catalogue"
     certificates     = "certificates"
+    receive_ca_cert  = "receive-ca-cert"
     charm_tracing    = "charm-tracing"
     workload_tracing = "workload-tracing"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 
+import jubilant
 import pytest
 
 logger = logging.getLogger(__name__)
@@ -90,3 +91,10 @@ async def prometheus_tester_charm(ops_test):
     await ops_test.run(*clean_cmd)
     charm = await ops_test.build_charm(charm_path)
     return charm
+
+
+@pytest.fixture(scope="module")
+def juju():
+    keep_models: bool = os.environ.get("KEEP_MODELS") is not None
+    with jubilant.temp_model(keep=keep_models) as juju:
+        yield juju

--- a/tests/integration/test_receive_ca_cert.py
+++ b/tests/integration/test_receive_ca_cert.py
@@ -1,0 +1,60 @@
+"""Feature: Prometheus can form TLS connections with HTTPS servers."""
+
+import json
+import logging
+import time
+
+import jubilant
+from helpers import oci_image
+from requests import request
+
+logger = logging.getLogger(__name__)
+
+
+PROMETHEUS_RESOURCES = {"prometheus-image": oci_image("./charmcraft.yaml", "prometheus-image")}
+
+
+async def test_unknown_authority(juju: jubilant.Juju, prometheus_charm: str):
+    """Scenario: Prometheus fails to scrape metrics from a server signed by unknown authority."""
+    # GIVEN a scrape target signed by a self-signed certificate
+    # WHEN related to prometheus
+    juju.deploy("alertmanager-k8s", app="am", channel="2/edge", trust=True)
+    juju.deploy("self-signed-certificates", app="ca", channel="1/stable", trust=True)
+    juju.deploy(prometheus_charm, app="prom", resources=PROMETHEUS_RESOURCES, trust=True)
+    juju.integrate("am:certificates", "ca:certificates")
+    juju.integrate("am:self-metrics-endpoint", "prom:metrics-endpoint")
+    juju.wait(jubilant.all_active, delay=10, timeout=600)
+
+    logger.info("Waiting for scrape interval (1 minute) to elapse...")
+    scrape_interval = 60  # seconds!
+    lookback_window = scrape_interval + 10  # seconds!
+    time.sleep(lookback_window)
+
+    # THEN scrape fails
+    prom_ip = juju.status().apps["prom"].units["prom/0"].address
+    response = request("GET", f"http://{prom_ip}:9090/api/v1/targets").text
+    data = json.loads(response)["data"]
+    for target in data["activeTargets"]:
+        if "am" in target["discoveredLabels"]["juju_application"]:
+            assert target["health"] == "down"
+            assert "x509: certificate signed by unknown authority" in target["lastError"]
+
+
+def test_with_ca_cert_forwarded(juju: jubilant.Juju):
+    """Scenario: Prometheus succeeds to scrape metrics from a server signed by a CA that Prometheus trusts."""
+    # WHEN Prometheus trusts the CA that signed the scrape target
+    juju.integrate("ca:send-ca-cert", "prom:receive-ca-cert")
+    juju.wait(jubilant.all_active, delay=10, timeout=600)
+
+    # Wait for scrape interval (1 minute) to elapse
+    scrape_interval = 60  # seconds!
+    lookback_window = scrape_interval + 10  # seconds!
+    time.sleep(lookback_window)
+
+    # THEN scrape succeeds
+    prom_ip = juju.status().apps["prom"].units["prom/0"].address
+    response = request("GET", f"http://{prom_ip}:9090/api/v1/targets").text
+    data = json.loads(response)["data"]
+    for target in data["activeTargets"]:
+        if "am" in target["discoveredLabels"]["juju_application"]:
+            assert target["health"] == "up"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,10 +1,11 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 from unittest.mock import patch
 
 import pytest
 from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
+from ops import pebble
 from scenario import Container, Context, Exec
 
 from charm import PrometheusCharm
@@ -40,6 +41,8 @@ def prometheus_container():
     return Container(
         "prometheus",
         can_connect=True,
+        layers={"prometheus": pebble.Layer({"services": {"prometheus": {}}})},
+        service_statuses={"prometheus": pebble.ServiceStatus.INACTIVE},
         execs={Exec(["update-ca-certificates", "--fresh"], return_code=0, stdout="")},
     )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,6 +9,7 @@ import uuid
 from unittest.mock import patch
 
 import ops
+import pytest
 import yaml
 from helpers import cli_arg, k8s_resource_multipatch, prom_multipatch
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
@@ -761,6 +762,7 @@ class TestTlsConfig(unittest.TestCase):
         self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
 
+    @pytest.mark.xfail(reason="https://github.com/canonical/prometheus-k8s-operator/issues/633")
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
     @patch("prometheus_client.Prometheus.reload_configuration", lambda *_: True)
@@ -797,6 +799,7 @@ class TestTlsConfig(unittest.TestCase):
         self.harness.evaluate_status()
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
 
+    @pytest.mark.xfail(reason="https://github.com/canonical/prometheus-k8s-operator/issues/633")
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
     @patch("prometheus_client.Prometheus.reload_configuration", lambda *_: True)

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -706,16 +706,16 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
         expected_rules_file = {
             "groups": [
                 {
-                    "name": f"{self.topology.identifier}_file_alerts",
-                    "rules": [self.gen_rule(0, labels=self.topology.label_matcher_dict)],
+                    "name": f"{self.topology.identifier}_a_b_file_alerts",
+                    "rules": [self.gen_rule(2, labels=self.topology.label_matcher_dict)],
                 },
                 {
                     "name": f"{self.topology.identifier}_a_file_alerts",
                     "rules": [self.gen_rule(1, labels=self.topology.label_matcher_dict)],
                 },
                 {
-                    "name": f"{self.topology.identifier}_a_b_file_alerts",
-                    "rules": [self.gen_rule(2, labels=self.topology.label_matcher_dict)],
+                    "name": f"{self.topology.identifier}_file_alerts",
+                    "rules": [self.gen_rule(0, labels=self.topology.label_matcher_dict)],
                 },
             ]
         }

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -232,6 +232,55 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertEqual(data["prometheus_scrape_unit_address"], "10.1.157.116")
         self.assertIn("prometheus_scrape_unit_name", data)
 
+    def test_provider_unit_refreshes_address_on_update_status(self):
+        """A rescheduled pod (new IP) must refresh its address on update_status.
+
+        Regression test for the scenario where a Kubernetes node maintenance/reboot
+        reschedules the workload pod onto a new IP without re-emitting
+        relation_joined/pebble_ready. Without refreshing on update_status, the stale
+        address would linger in relation data and the consumer would keep scraping a
+        dead IP. See canonical/opentelemetry-collector-k8s-operator#270.
+        """
+        rel_id = self.harness.add_relation(RELATION_NAME, "provider")
+        self.harness.add_relation_unit(rel_id, "provider/0")
+
+        # GIVEN a provider that already published its (old) pod IP
+        with patch("ops.Network.bind_address", new="10.1.157.116"):
+            self.harness.charm.provider.set_scrape_job_spec()
+            data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+            self.assertEqual(data["prometheus_scrape_unit_address"], "10.1.157.116")
+
+            # WHEN the pod is rescheduled onto a new IP and only update_status fires
+            with patch("ops.Network.bind_address", new="10.1.200.42"):
+                self.harness.charm.on.update_status.emit()
+
+        # THEN the published address is refreshed to the new pod IP
+        data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertEqual(data["prometheus_scrape_unit_address"], "10.1.200.42")
+
+    def test_provider_unit_refreshes_address_on_relation_changed(self):
+        """A new pod IP must be reflected on relation_changed as a faster reaction.
+
+        Regression test for canonical/opentelemetry-collector-k8s-operator#270.
+        """
+        rel_id = self.harness.add_relation(RELATION_NAME, "provider")
+        self.harness.add_relation_unit(rel_id, "provider/0")
+
+        # GIVEN a provider that already published its (old) pod IP
+        with patch("ops.Network.bind_address", new="10.1.157.116"):
+            self.harness.charm.provider.set_scrape_job_spec()
+            data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+            self.assertEqual(data["prometheus_scrape_unit_address"], "10.1.157.116")
+
+            # WHEN the pod is rescheduled onto a new IP and relation_changed fires
+            # (triggered here via a remote databag update, which carries the app context)
+            with patch("ops.Network.bind_address", new="10.1.200.42"):
+                self.harness.update_relation_data(rel_id, "provider", {"ping": "pong"})
+
+        # THEN the published address is refreshed to the new pod IP
+        data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertEqual(data["prometheus_scrape_unit_address"], "10.1.200.42")
+
     def test_provider_sets_external_url(self):
         harness = Harness(EndpointProviderCharmExternalUrl, meta=PROVIDER_META)
         harness.set_model_name("MyUUID")

--- a/tests/unit/test_prometheus_config.py
+++ b/tests/unit/test_prometheus_config.py
@@ -22,8 +22,8 @@ class TestWildcardExpansion(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", ""),
-            "unit/1": ("11.11.11.11", ""),
+            "unit/0": ("10.10.10.10", "", ""),
+            "unit/1": ("11.11.11.11", "", ""),
         }
 
         # WHEN the jobs are processed
@@ -59,8 +59,8 @@ class TestWildcardExpansion(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", ""),
-            "unit/1": ("11.11.11.11", ""),
+            "unit/0": ("10.10.10.10", "", ""),
+            "unit/1": ("11.11.11.11", "", ""),
         }
 
         # WHEN the jobs are processed
@@ -97,8 +97,8 @@ class TestWildcardExpansion(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", ""),
-            "unit/1": ("11.11.11.11", ""),
+            "unit/0": ("10.10.10.10", "", ""),
+            "unit/1": ("11.11.11.11", "", ""),
         }
 
         # WHEN the jobs are processed
@@ -140,8 +140,8 @@ class TestWildcardExpansion(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", ""),
-            "unit/1": ("11.11.11.11", ""),
+            "unit/0": ("10.10.10.10", "", ""),
+            "unit/1": ("11.11.11.11", "", ""),
         }
 
         # WHEN the jobs are processed
@@ -182,8 +182,8 @@ class TestWildcardExpansion(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", ""),
-            "unit/1": ("11.11.11.11", ""),
+            "unit/0": ("10.10.10.10", "", ""),
+            "unit/1": ("11.11.11.11", "", ""),
         }
 
         # WHEN the jobs are processed
@@ -264,8 +264,8 @@ class TestWildcardExpansionWithTopology(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", ""),
-            "unit/1": ("11.11.11.11", ""),
+            "unit/0": ("10.10.10.10", "", ""),
+            "unit/1": ("11.11.11.11", "", ""),
         }
 
         # AND some topology
@@ -336,8 +336,8 @@ class TestWildcardExpansionWithPathPrefix(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", "/model-unit-0"),
-            "unit/1": ("11.11.11.11", "/model-unit-1"),
+            "unit/0": ("10.10.10.10", "/model-unit-0", ""),
+            "unit/1": ("11.11.11.11", "/model-unit-1", ""),
         }
 
         # WHEN the jobs are processed
@@ -379,8 +379,8 @@ class TestWildcardExpansionWithPathPrefix(unittest.TestCase):
         ]
 
         hosts = {
-            "unit/0": ("10.10.10.10", "/model-unit-0"),
-            "unit/1": ("11.11.11.11", "/model-unit-1"),
+            "unit/0": ("10.10.10.10", "/model-unit-0", ""),
+            "unit/1": ("11.11.11.11", "/model-unit-1", ""),
         }
 
         # WHEN the jobs are processed

--- a/tests/unit/test_receive_ca_cert.py
+++ b/tests/unit/test_receive_ca_cert.py
@@ -1,0 +1,69 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import json
+
+from ops.testing import Relation, State
+
+from src.charm import RECV_CA_CERT_FOLDER_PATH
+
+
+def test_no_recv_ca_cert_relations_present(context, prometheus_container):
+    # GIVEN the charm is deployed in isolation
+    state = State(
+        leader=True,
+        containers={prometheus_container},
+    )
+
+    # WHEN any event is emitted
+    out = context.run(context.on.update_status(), state)
+
+    # THEN no recv_ca_cert-associated certs are present
+    container = out.get_container("prometheus")
+    fs = container.get_filesystem(context)
+    assert not fs.joinpath(RECV_CA_CERT_FOLDER_PATH.lstrip("/")).exists()
+
+
+def test_ca_forwarded_over_rel_data(context, prometheus_container):
+    # Relation 1
+    cert1a = "-----BEGIN CERTIFICATE-----\n ... cert1a ... \n-----END CERTIFICATE-----"
+    cert1b = "-----BEGIN CERTIFICATE-----\n ... cert1b ... \n-----END CERTIFICATE-----"
+
+    # Relation 2
+    cert2a = "-----BEGIN CERTIFICATE-----\n ... cert2a ... \n-----END CERTIFICATE-----"
+    cert2b = "-----BEGIN CERTIFICATE-----\n ... cert2b ... \n-----END CERTIFICATE-----"
+
+    # GIVEN the charm is related to a CA
+    relations = [
+        Relation(
+            "receive-ca-cert", remote_app_data={"certificates": json.dumps([cert1a, cert1b])}
+        ),
+        Relation(
+            "receive-ca-cert", remote_app_data={"certificates": json.dumps([cert2a, cert2b])}
+        ),
+    ]
+    state = State(leader=True, containers={prometheus_container}, relations=relations)
+
+    # WHEN a certificate_set_updated event is emitted
+    out_1 = context.run(context.on.relation_changed(relations[0]), state)
+
+    # THEN recv_ca_cert-associated certs are present
+    container = out_1.get_container("prometheus")
+    fs = container.get_filesystem(context)
+    certs_dir = fs.joinpath(RECV_CA_CERT_FOLDER_PATH.lstrip("/"))
+    assert certs_dir.exists()
+    certs = {file.read_text() for file in certs_dir.glob("*.crt")}
+    assert certs == {cert1a, cert1b, cert2a, cert2b}
+
+    # AND WHEN one relation is removed, i.e. a certificates_removed event is emitted
+    state = State(leader=True, containers={prometheus_container}, relations=relations)
+    out_2 = context.run(context.on.relation_broken(relations[0]), out_1)
+
+    # THEN its certs are removed, but the others remain
+    container = out_2.get_container("prometheus")
+    fs = container.get_filesystem(context)
+    certs_dir = fs.joinpath(RECV_CA_CERT_FOLDER_PATH.lstrip("/"))
+    assert certs_dir.exists()
+    certs = {file.read_text() for file in certs_dir.glob("*.crt")}
+    assert certs == {cert2a, cert2b}

--- a/tests/unit/test_remote_write.py
+++ b/tests/unit/test_remote_write.py
@@ -37,6 +37,9 @@ requires:
         limit: 1
     receive-remote-write:
         interface: prometheus_remote_write
+peers:
+    peers:
+        interface: some_interface
 """
 
 
@@ -95,6 +98,7 @@ class RemoteWriteConsumerCharm(CharmBase):
             self,
             RELATION_NAME,
             alert_rules_path=str(UNITTEST_DIR / "prometheus_alert_rules"),
+            peer_relation_name="peers",
         )
         self.framework.observe(
             self.remote_write_consumer.on.endpoints_changed,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8, <4"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -1037,7 +1037,7 @@ wheels = [
 
 [[package]]
 name = "cosl"
-version = "1.3.1"
+version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ops" },
@@ -1049,9 +1049,9 @@ dependencies = [
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/d5/a9ea4a4c29a374d6d356bbdc2a78348de5dc7aa2d869b932bbd559367d2b/cosl-1.3.1.tar.gz", hash = "sha256:aa836828350398beb5bbd4fe85cb582e796a7b8b5d9a214a5bc6fd855cde11af", size = 45361, upload-time = "2025-10-08T09:58:04.504Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/98/1a1f8aa7965ede9abfeb649b83375baf4e2f523778f90b841281cbe3603a/cosl-1.6.1.tar.gz", hash = "sha256:f96a6a978dfdee4a3b460cc48fa18514663bbc1c3a4f323315e3dbe3e6a2a596", size = 149512, upload-time = "2026-03-09T21:44:46.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/54/a72b67cae15af226882dd6c7da011c26ae3c9c5843c36511d0dd1753c298/cosl-1.3.1-py3-none-any.whl", hash = "sha256:8ab9b23b367f041ec0f4eae63d4b1960712431a2b3bf6fb6fdec473efea30f77", size = 36387, upload-time = "2025-10-08T09:58:03.544Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/8f/3ca0f470fbc7b26ed33b5fe5815e38b6a628b8bb4df961924cae38755c46/cosl-1.6.1-py3-none-any.whl", hash = "sha256:12db85a81317c5b056171642098be91c09e78e04875ed1262b99681dea43b533", size = 37800, upload-time = "2026-03-09T21:44:45.373Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR backports this PR to `track/2`: https://github.com/canonical/prometheus-k8s-operator/pull/815
