### PR TITLE
fix: PrometheusRulesProvider should update relation data when config changes

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -361,7 +361,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 60
+LIBPATCH = 61
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -1822,6 +1822,7 @@ class PrometheusRulesProvider(Object):
             events.relation_changed,
             self._charm.on.leader_elected,
             self._charm.on.upgrade_charm,
+            self._charm.on.config_changed,
         ]
 
         for event_source in event_sources:

--- a/tests/unit/test_prometheus_rules_provider.py
+++ b/tests/unit/test_prometheus_rules_provider.py
@@ -135,3 +135,38 @@ def test_relation_joined_with_empty_rules(tmp_path):
     state_out = context.run(context.on.relation_joined(rel), state)
 
     assert _relation_local_app_alerts(state_out) == NO_ALERTS
+
+
+def test_config_changed_calls_update_relation_data(tmp_path):
+    calls = 0
+
+    class TestPrometheusRulesProvider(PrometheusRulesProvider):
+        """A subclass of PrometheusRulesProvider that counts calls to _update_relation_data."""
+        def _update_relation_data(self, event):
+            nonlocal calls
+            calls += 1
+            return super()._update_relation_data(event)
+
+    class MockCOSConfig(CharmBase):
+        metadata_yaml = textwrap.dedent(
+            """
+            name: mock-cos-config
+            provides:
+                send-remote-write:
+                    interface: prometheus_scrape
+            """
+        )
+
+        def __init__(self, *args):
+            super().__init__(*args)
+            self.rules_provider = TestPrometheusRulesProvider(self, relation_name = "send-remote-write", dir_path=str(tmp_path))
+
+    # GIVEN a mock charm that instantiates a PrometheusRulesProvider such as COS Configuration
+    context = Context(charm_type=MockCOSConfig, meta=yaml.safe_load(MockCOSConfig.metadata_yaml))
+    rel = Relation(endpoint="send-remote-write")
+    state = State(relations={rel}, leader=True)
+    # WHEN a config changed event occurs
+    context.run(context.on.config_changed(), state)
+
+    # THEN COS Config, as PromeheusRulesProvider, should call _update_relation_data to update the relation data with the new alert rules
+    assert calls > 0

--- a/tests/unit/test_prometheus_rules_provider.py
+++ b/tests/unit/test_prometheus_rules_provider.py
@@ -142,10 +142,10 @@ def test_config_changed_calls_update_relation_data(tmp_path):
 
     class TestPrometheusRulesProvider(PrometheusRulesProvider):
         """A subclass of PrometheusRulesProvider that counts calls to _update_relation_data."""
-        def _update_relation_data(self, event):
+        def _update_relation_data(self, _):
             nonlocal calls
             calls += 1
-            return super()._update_relation_data(event)
+            return super()._update_relation_data(_)
 
     class MockCOSConfig(CharmBase):
         metadata_yaml = textwrap.dedent(

--- a/tests/unit/test_prometheus_rules_provider.py
+++ b/tests/unit/test_prometheus_rules_provider.py
@@ -168,5 +168,5 @@ def test_config_changed_calls_update_relation_data(tmp_path):
     # WHEN a config changed event occurs
     context.run(context.on.config_changed(), state)
 
-    # THEN COS Config, as PromeheusRulesProvider, should call _update_relation_data to update the relation data with the new alert rules
+    # THEN COS Config, as a PrometheusRulesProvider, should call _update_relation_data to update the relation data with the new alert rules
     assert calls > 0

--- a/tests/unit/test_prometheus_rules_provider.py
+++ b/tests/unit/test_prometheus_rules_provider.py
@@ -135,38 +135,3 @@ def test_relation_joined_with_empty_rules(tmp_path):
     state_out = context.run(context.on.relation_joined(rel), state)
 
     assert _relation_local_app_alerts(state_out) == NO_ALERTS
-
-
-def test_config_changed_calls_update_relation_data(tmp_path):
-    calls = 0
-
-    class TestPrometheusRulesProvider(PrometheusRulesProvider):
-        """A subclass of PrometheusRulesProvider that counts calls to _update_relation_data."""
-        def _update_relation_data(self, _):
-            nonlocal calls
-            calls += 1
-            return super()._update_relation_data(_)
-
-    class MockCOSConfig(CharmBase):
-        metadata_yaml = textwrap.dedent(
-            """
-            name: mock-cos-config
-            provides:
-                send-remote-write:
-                    interface: prometheus_scrape
-            """
-        )
-
-        def __init__(self, *args):
-            super().__init__(*args)
-            self.rules_provider = TestPrometheusRulesProvider(self, relation_name = "send-remote-write", dir_path=str(tmp_path))
-
-    # GIVEN a mock charm that instantiates a PrometheusRulesProvider such as COS Configuration
-    context = Context(charm_type=MockCOSConfig, meta=yaml.safe_load(MockCOSConfig.metadata_yaml))
-    rel = Relation(endpoint="send-remote-write")
-    state = State(relations={rel}, leader=True)
-    # WHEN a config changed event occurs
-    context.run(context.on.config_changed(), state)
-
-    # THEN COS Config, as a PrometheusRulesProvider, should call _update_relation_data to update the relation data with the new alert rules
-    assert calls > 0


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #825.

## Solution
<!-- A summary of the solution addressing the above issue -->
1. The `PrometheusRulesProvider` now observes the `config_changed` event and calls `update_relation_data` so that COS Config sends alert rules to Prometheus again. This is necessary when, for example, the user changes the config option in COS Config for the Prometheus rules path. Unless we observe that event, the library will not write new alerts to relation data.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Copy the content of the `prometheus_scrape` lib, as changed in this PR, and paste it in a COS Config charm and pack that charm. 
2. Have a deployment that looks like
```yaml
bundle: kubernetes
applications:
  cos-config:
    charm: local:cos-configuration-k8s-6
    base: ubuntu@26.04/stable
    scale: 1
    options:
      git_branch: main
      git_repo: https://github.com/sinapah/cos-config
      prometheus_alert_rules_path: staging/prometheus
    constraints: arch=amd64
    storage:
      content-from-git: kubernetes,1,1024M
    trust: true
  prom:
    charm: prometheus-k8s
    channel: dev/edge
    revision: 296
    resources:
      prometheus-image: 154
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
relations:
- - cos-config:send-remote-write
  - prom:receive-remote-write
```
3. Change the `prometheus_alert_rules_path` of COS Config. For example, do: `juju config cos-config prometheus_alert_rules_path=staging/prometheus`. You should now see the relation data in Prometheus change. For example, do `juju show-unit prom/0`. 
```
- relation-id: 74
    endpoint: receive-remote-write
    related-endpoint: send-remote-write
    application-data:
      alert_rules: '{"groups": [{"name": "invalid_promql_rule_2_rules", "rules": [{"alert":
        "InvalidPromQLRule", "annotations": {"description": "This rule is intentionally
        VERY VERY INVALID FOR TESTING.", "summary": "Invalid PromQL rule 2"}, "expr":
        "sum by (juju_application) (\n  up{juju_application=\"prometheus-k8s\", juju_model=\"observability}
        == 0\n) > 0\n", "for": "15m", "labels": {"severity": "critical", "team": "some-team"}}]}]}'
    related-units:
      cos-config/0:
        in-scope: true
        data:
          egress-subnets: 10.152.183.178/32
          ingress-address: 10.152.183.178
          private-address: 10.152.183.178
  provider-id: prom-0
  address: 10.1.0.149

```
4. Change `prometheus_alert_rules_path` again. For example, do `juju config cos-config prometheus_alert_rules_path=prometheus_alert_rules`. Prometheus should go into `executing`. `show-unit` should show:
```
- relation-id: 74
    endpoint: receive-remote-write
    related-endpoint: send-remote-write
    application-data:
      alert_rules: '{"groups": [{"name": "prometheus_alerts_rules", "rules": [{"alert":
        "PrometheusTargetDown", "annotations": {"description": "At least one scrape
        target is down for {{ $labels.juju_application }}", "summary": "Prometheus
        target is down"}, "expr": "sum by (juju_application) (\n  up{juju_application=\"prometheus-k8s\",
        juju_model=\"observability\"} == 0\n) > 0\n", "for": "15m", "labels": {"juju_application":
        "prometheus-k8s", "juju_model": "observability", "juju_model_uuid": "e9f39fb5-e6ff-4e0c-82a5-712bdd7e1912",
        "severity": "critical", "team": "observability"}}]}]}'
    related-units:
      cos-config/0:
        in-scope: true
        data:
          egress-subnets: 10.152.183.178/32
          ingress-address: 10.152.183.178
          private-address: 10.152.183.178

```

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
