### PR TITLE
fix(prometheus_remote_write): sort peer names for alerts duplication

### DIFF
--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -47,7 +47,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 15
 
 PYDEPS = ["cosl"]
 
@@ -611,7 +611,8 @@ class PrometheusRemoteWriteConsumer(Object):
                 if rule.get("alert", "") not in rule_names_to_duplicate:
                     new_rules.append(rule)
                 else:
-                    for name in peer_unit_names:
+                    # Sort unit names to guarantee a deterministic iteration order.
+                    for name in sorted(peer_unit_names):
                         juju_unit = name
                         modified_rule = copy.deepcopy(rule)
 


### PR DESCRIPTION
Contributes to fixing https://github.com/canonical/opentelemetry-collector-operator/issues/330

## Issue

When opentelemetry-collector (or any charm using `PrometheusRemoteWriteConsumer`) is scaled to multiple units, the send-remote-write relation databag churns continuously, causing an infinite cascade of `relation-changed` events on the remote-write receiver (e.g. Mimir).

`_duplicate_rules_per_unit` iterates over peers (a `set`). On every charm invocation the HostMetricsMissing rules are appended in a different order for each peer unit. 

## Solution
Sort `peer_unit_names` before iterating