### PR TITLE
feat: add charms blueprint (backport #836)

### DIFF
--- a/.tfdocs.yaml
+++ b/.tfdocs.yaml
@@ -1,0 +1,41 @@
+# https://terraform-docs.io/user-guide/configuration/
+
+formatter: markdown table
+
+sections:
+  show:
+    - requirements
+    - modules
+    - providers
+    - inputs
+    - outputs
+
+# This allows us to customize the injected docs
+content: ""
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  # anchor: true
+  color: true
+  default: true
+  description: true
+  # escape: true
+  # hide-empty: false
+  # html: true
+  # indent: 2
+  lockfile: false
+  # read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/charms.just
+++ b/charms.just
@@ -190,10 +190,11 @@ release charm_file channel:
     charmcraft release "{{ charm_name }}" --revision="$charm_revision" --channel="{{ channel }}" $resource_args
     echo "✓ Released {{ charm_name }} revision $charm_revision to {{ channel }}"
 
-# Print all commits between the current branch and the merge-base with `ref`
+# Print all commits between two refs (defaults to current branch for target_ref)
 [group("release")]
-[arg("ref", help="Branch (or generic ref) from to get the changelog from")]
-changelog ref:
+[arg("ref", help="Branch (or generic ref) to get the changelog from")]
+[arg("target_ref", help="Branch (or generic ref) to compare to (defaults to current branch)")]
+changelog ref target_ref="":
     #!/usr/bin/env python3
     import re
     import subprocess
@@ -206,16 +207,22 @@ changelog ref:
     match = re.search(r"github\.com[:/]([^/]+/[^/.]+)", remote_url)
     repo_path = match.group(1) if match else ""
 
-    # Resolve ref
+    # Resolve refs
     ref = "{{ ref }}"
     try:
         git("rev-parse", "--verify", ref)
     except subprocess.CalledProcessError:
         ref = f"origin/{ref}"
 
+    target_ref = "{{ target_ref }}" or git("rev-parse", "--abbrev-ref", "HEAD")
+    try:
+        git("rev-parse", "--verify", target_ref)
+    except subprocess.CalledProcessError:
+        target_ref = f"origin/{target_ref}"
+
     # Get merge-base and commits
-    base = git("merge-base", "HEAD", ref)
-    log_output = git("log", f"--format=%H\t%s", f"{base}..HEAD")
+    base = git("merge-base", target_ref, ref)
+    log_output = git("log", f"--format=%H\t%s", f"{base}..{target_ref}")
 
     # Categorize commits
     categories = {"breaking": [], "features": [], "fixes": [], "others": []}
@@ -251,7 +258,9 @@ changelog ref:
             categories["others"].append(formatted)
 
     # Print changelog
+    short_base = base[:7]
     print("# Changelog\n")
+    print(f"Changes on `{target_ref}` since diverging from `{ref}` (merge-base: `{short_base}`).\n")
     sections = [("Breaking Changes", "breaking"), ("Features", "features"), ("Fixes", "fixes"), ("Others", "others")]
     for title, key in sections:
         if categories[key]:

--- a/charms.just
+++ b/charms.just
@@ -1,0 +1,263 @@
+# Centralized justfile for the Canonical Observability charms
+set shell := ["bash", "-uc"]
+
+charm_name := `echo ${PWD##*/} | sed 's/-operator$//'`  # Get the charm name from the folder name
+
+export UV_FROZEN := "true"  # Prevent `uv run` from updating the lockfile
+export PYTHONPATH := ".:./lib:./src"
+
+
+[private]
+@default:
+    just --list
+
+# Print the charm name
+[group("info")]
+@name:
+  echo "{{charm_name}}"
+
+
+# Update uv.lock dependencies
+[group("maintenance")]
+lock:
+    unset UV_FROZEN; uv lock --upgrade --no-cache
+
+# Scan for security vulnerabilities
+[group("maintenance")]
+scan:
+    @echo "Scanning for security vulnerabilities..."
+    uvx uv-secure
+
+# Fetch centralized files from canonical/observability
+[group("maintenance")]
+refresh:
+    #!/usr/bin/env bash
+    which -s gh || { echo "gh not found"; exit 1; }
+    refresh_folder="blueprints/charms"
+    api_path="repos/canonical/observability/contents/$refresh_folder"
+    for file in charms.just .tfdocs.yaml; do
+      echo "Fetching latest '$file' from canonical/observability ..."
+      gh api "$api_path/$file" --jq '.content' | base64 --decode > "$file"
+      echo "✓ $file updated"
+    done
+
+
+# Format the codebase
+[group("dev")]
+format: sync
+    # Fix generic linting issues
+    uv run ruff check --fix-only
+    # Fix import-related issues (including ordering)
+    uv run ruff check --select=I --fix-only
+    # Format the code
+    uv run ruff format
+
+alias fmt := format
+
+# Lint the codebase
+[group("dev")]
+lint: sync
+    # Lint the code
+    uv run ruff check
+    # Run static checks
+    uv run ty check src
+    # Check for misspellings
+    uv run codespell src
+    # Check for dead code (heuristic, so failures are ignored)
+    uv run vulture src --min-confidence=80 || true
+    # Run actionlint on GitHub Actions workflows
+    test -d .github/workflows && uvx --from=actionlint-py actionlint
+    @echo "✓ Linting passed!"
+
+
+# Run all quality checks: formatting, linting and unit tests
+[group("dev")]
+check: sync format lint unit
+    @echo; echo "✓ All checks passed!"
+
+# Sync the virtual environment (.venv)
+[group("dev")]
+sync:
+    uv sync --all-groups --all-extras
+
+# Sync and activate the virtual environment (.venv)
+[group("dev")]
+venv:
+    @echo "Activating virtual environment..."
+    @uv sync --all-groups --all-extras
+    @. .venv/bin/activate; exec "$SHELL" -i
+
+
+# Run unit tests
+[group("test")]
+unit *args: sync
+    uv run coverage run --source=src -m pytest tests/unit {{ args }}
+
+# Run integration tests
+[group("test")]
+integration *args: sync
+    uv run pytest --exitfirst tests/integration {{ args }}
+
+# Pretty print all feature files
+[group("info")]
+features:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    features_dir="tests/integration/features"
+    if [ ! -d "$features_dir" ]; then
+        echo "No features directory found at $features_dir"
+        exit 1
+    fi
+    # Calculate totals first
+    total_features=$(find "$features_dir" -name "*.feature" -type f | wc -l)
+    total_scenarios=$(grep -rh "^[[:space:]]*Scenario:" "$features_dir" 2>/dev/null | wc -l || echo "0")
+    printf "Total: \033[1m%d features\033[0m with \033[1m%d scenarios\033[0m\n" "$total_features" "$total_scenarios"
+    echo ""
+    for feature_file in "$features_dir"/*.feature; do
+        [ -f "$feature_file" ] || continue
+        filename=$(basename "$feature_file")
+        feature_name="${filename%.feature}"
+        # Extract the Feature: line
+        feature_title=$(grep -m1 "^Feature:" "$feature_file" | sed 's/Feature: //')
+        # Extract feature description (lines after Feature: until first Scenario, skipping blank lines)
+        description=$(awk '/^Feature:/{found=1; next} found && /^[[:space:]]*Scenario/{exit} found && /^[[:space:]]*$/{next} found{gsub(/^[[:space:]]+/, ""); print}' "$feature_file" | head -3)
+        # Count scenarios
+        scenario_count=$(grep -c "^[[:space:]]*Scenario:" "$feature_file" || echo "0")
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        printf "\033[1m%s\033[0m (%d scenarios)\n" "$feature_title" "$scenario_count"
+        echo "   $feature_file"
+        echo ""
+        if [ -n "$description" ]; then
+            echo "$description" | while IFS= read -r line; do
+                echo "   $line"
+            done
+            echo ""
+        fi
+        # List scenarios
+        grep "^[[:space:]]*Scenario:" "$feature_file" | sed 's/^[[:space:]]*Scenario:[[:space:]]*//' | while IFS= read -r scenario; do
+            echo "   - $scenario"
+        done
+        echo ""
+    done
+
+
+# Update the Terraform README with auto-generated content
+[group("terraform")]
+terraform-docs:
+    which terraform-docs > /dev/null 2>&1 || { echo "× terraform-docs not found"; exit 1; }
+    terraform-docs --config .tfdocs.yaml .
+    @echo "✓ Terraform docs updated"
+
+# Lint and validate the Terraform module
+[group("terraform")]
+terraform-lint:
+    which terraform > /dev/null 2>&1 || { echo "× terraform not found"; exit 1; }
+    cd terraform && terraform init -backend=false && terraform validate
+    terraform fmt -recursive -check
+    @echo "✓ Terraform lint passed"
+
+
+# Release a .charm file to Charmhub
+[group("release")]
+release charm_file channel:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Upload the charm and get the revision
+    echo "Uploading charm {{ charm_file }}..."
+    upload_output=$(charmcraft upload "{{ charm_file }}" --format=json)
+    charm_revision=$(echo "$upload_output" | jq -r '.revision')
+    echo "✓ Uploaded charm revision: $charm_revision"
+    # Get resources from charmcraft.yaml
+    resource_args=""
+    if [ -f charmcraft.yaml ]; then
+        while IFS= read -r resource_name; do
+            upstream=$(yq -r ".resources.\"$resource_name\".\"upstream-source\" // empty" charmcraft.yaml)
+            if [ -n "$upstream" ]; then
+                echo "Uploading resource '$resource_name' from $upstream..."
+                res_output=$(charmcraft upload-resource "{{ charm_name }}" "$resource_name" --image="docker://$upstream" --format=json)
+                res_revision=$(echo "$res_output" | jq -r '.revision')
+            else
+                echo "Fetching latest revision for resource '$resource_name'..."
+                res_revision=$(charmcraft resource-revisions "{{ charm_name }}" "$resource_name" --format=json | jq -r '.[0].revision')
+            fi
+            echo "✓ Resource '$resource_name' revision: $res_revision"
+            resource_args="$resource_args --resource=$resource_name:$res_revision"
+        done < <(yq -r '.resources | keys | .[]' charmcraft.yaml 2>/dev/null || true)
+    fi
+    # Release the charm
+    echo "Releasing {{ charm_name }} to {{ channel }}..."
+    # shellcheck disable=SC2086
+    charmcraft release "{{ charm_name }}" --revision="$charm_revision" --channel="{{ channel }}" $resource_args
+    echo "✓ Released {{ charm_name }} revision $charm_revision to {{ channel }}"
+
+# Print all commits between the current branch and the merge-base with `ref`
+[group("release")]
+[arg("ref", help="Branch (or generic ref) from to get the changelog from")]
+changelog ref:
+    #!/usr/bin/env python3
+    import re
+    import subprocess
+
+    def git(*args):
+        return subprocess.run(["git", *args], capture_output=True, text=True, check=True).stdout.strip()
+
+    # Get repo path from remote URL
+    remote_url = git("remote", "get-url", "origin")
+    match = re.search(r"github\.com[:/]([^/]+/[^/.]+)", remote_url)
+    repo_path = match.group(1) if match else ""
+
+    # Resolve ref
+    ref = "{{ ref }}"
+    try:
+        git("rev-parse", "--verify", ref)
+    except subprocess.CalledProcessError:
+        ref = f"origin/{ref}"
+
+    # Get merge-base and commits
+    base = git("merge-base", "HEAD", ref)
+    log_output = git("log", f"--format=%H\t%s", f"{base}..HEAD")
+
+    # Categorize commits
+    categories = {"breaking": [], "features": [], "fixes": [], "others": []}
+
+    for line in log_output.splitlines():
+        if not line:
+            continue
+        hash, msg = line.split("\t", 1)
+
+        # Skip changelog update commits
+        if msg.startswith("chore(changelog)"):
+            continue
+        short_hash = hash[:7]
+
+        # Format line with links
+        pr_match = re.search(r"\(#(\d+)\)", msg)
+        if pr_match and repo_path:
+            pr_num = pr_match.group(1)
+            formatted = f"- {msg.replace(f'(#{pr_num})', f'([#{pr_num}](https://github.com/{repo_path}/pull/{pr_num}))')}"
+        elif repo_path:
+            formatted = f"- {msg} ([{short_hash}](https://github.com/{repo_path}/commit/{hash}))"
+        else:
+            formatted = f"- {msg} ({short_hash})"
+
+        # Categorize
+        if re.match(r"^[a-z]+(\(.+\))?!:", msg):
+            categories["breaking"].append(formatted)
+        elif re.match(r"^feat(\(.+\))?:", msg):
+            categories["features"].append(formatted)
+        elif re.match(r"^fix(\(.+\))?:", msg):
+            categories["fixes"].append(formatted)
+        else:
+            categories["others"].append(formatted)
+
+    # Print changelog
+    print("# Changelog\n")
+    sections = [("Breaking Changes", "breaking"), ("Features", "features"), ("Fixes", "fixes"), ("Others", "others")]
+    for title, key in sections:
+        if categories[key]:
+            print(f"## {title}\n")
+            print("\n".join(categories[key]))
+            print()
+
+
+

--- a/charms.just
+++ b/charms.just
@@ -16,6 +16,67 @@ export PYTHONPATH := ".:./lib:./src"
 @name:
   echo "{{charm_name}}"
 
+# List all track branches in chronological order (oldest first)
+[group("info")]
+tracks:
+    #!/usr/bin/env python3
+    import subprocess
+
+    def git(*args):
+        r = subprocess.run(["git", *args], capture_output=True, text=True)
+        return r.stdout.strip() if r.returncode == 0 else None
+
+    branches = git("branch", "-r", "--list", "origin/track/*")
+    if not branches:
+        exit(0)
+
+    dated = []
+    for line in branches.splitlines():
+        branch = line.strip().removeprefix("origin/")
+        merge_base = git("merge-base", f"origin/{branch}", "origin/main")
+        if not merge_base:
+            continue
+        first = git("rev-list", "--ancestry-path", f"{merge_base}..origin/{branch}", "--reverse")
+        commit = first.splitlines()[0] if first else merge_base
+        date = git("log", "-1", "--format=%at", commit)
+        dated.append((int(date), branch))
+
+    for _, branch in sorted(dated):
+        print(branch)
+
+# Get the previous track branch relative to the current branch
+[group("info")]
+previous-track:
+    #!/usr/bin/env python3
+    import subprocess
+    import sys
+
+    def git(*args):
+        return subprocess.run(["git", *args], capture_output=True, text=True, check=True).stdout.strip()
+
+    def just(*args):
+        r = subprocess.run(["just", *args], capture_output=True, text=True)
+        if r.returncode != 0:
+            sys.exit(r.returncode)
+        return r.stdout.strip()
+
+    current = git("rev-parse", "--abbrev-ref", "HEAD")
+    tracks = just("tracks").splitlines() if just("tracks") else []
+
+    if not tracks:
+        print("No track branches found", file=sys.stderr)
+        sys.exit(1)
+
+    if current == "main":
+        print(tracks[-1])
+    elif current in tracks:
+        idx = tracks.index(current)
+        if idx > 0:
+            print(tracks[idx - 1])
+    else:
+        print(f"Cannot determine previous track from branch '{current}'", file=sys.stderr)
+        print("Specify ref explicitly: just changelog <ref>", file=sys.stderr)
+        sys.exit(1)
 
 # Update uv.lock dependencies
 [group("maintenance")]
@@ -190,39 +251,53 @@ release charm_file channel:
     charmcraft release "{{ charm_name }}" --revision="$charm_revision" --channel="{{ channel }}" $resource_args
     echo "✓ Released {{ charm_name }} revision $charm_revision to {{ channel }}"
 
-# Print all commits between two refs (defaults to current branch for target_ref)
+# Print all commits between two refs (auto-deduces refs when on main or track branches)
 [group("release")]
-[arg("ref", help="Branch (or generic ref) to get the changelog from")]
-[arg("target_ref", help="Branch (or generic ref) to compare to (defaults to current branch)")]
-changelog ref target_ref="":
+[arg("from_ref", help="Branch (or generic ref) to compare from (defaults to previous track)")]
+[arg("to_ref", help="Branch (or generic ref) to compare to (defaults to current branch)")]
+changelog from_ref="" to_ref="":
     #!/usr/bin/env python3
     import re
     import subprocess
+    import sys
 
     def git(*args):
         return subprocess.run(["git", *args], capture_output=True, text=True, check=True).stdout.strip()
+
+    def just(*args):
+        result = subprocess.run(["just", *args], capture_output=True, text=True)
+        if result.returncode != 0:
+            print(result.stderr, file=sys.stderr, end="")
+            sys.exit(result.returncode)
+        return result.stdout.strip()
 
     # Get repo path from remote URL
     remote_url = git("remote", "get-url", "origin")
     match = re.search(r"github\.com[:/]([^/]+/[^/.]+)", remote_url)
     repo_path = match.group(1) if match else ""
 
-    # Resolve refs
-    ref = "{{ ref }}"
+    # Resolve from_ref (auto-deduce if empty)
+    from_ref = "{{ from_ref }}"
+    if not from_ref:
+        from_ref = just("previous-track")
+        if not from_ref:
+            print("No previous track to compare against", file=sys.stderr)
+            sys.exit(1)
     try:
-        git("rev-parse", "--verify", ref)
+        git("rev-parse", "--verify", from_ref)
     except subprocess.CalledProcessError:
-        ref = f"origin/{ref}"
+        from_ref = f"origin/{from_ref}"
 
-    target_ref = "{{ target_ref }}" or git("rev-parse", "--abbrev-ref", "HEAD")
+    # Resolve to_ref (default to current branch)
+    to_ref = "{{ to_ref }}" or git("rev-parse", "--abbrev-ref", "HEAD")
     try:
-        git("rev-parse", "--verify", target_ref)
+        git("rev-parse", "--verify", to_ref)
     except subprocess.CalledProcessError:
-        target_ref = f"origin/{target_ref}"
+        to_ref = f"origin/{to_ref}"
 
     # Get merge-base and commits
-    base = git("merge-base", target_ref, ref)
-    log_output = git("log", f"--format=%H\t%s", f"{base}..{target_ref}")
+    base = git("merge-base", to_ref, from_ref)
+    log_output = git("log", f"--format=%H\t%s", f"{base}..{to_ref}")
 
     # Categorize commits
     categories = {"breaking": [], "features": [], "fixes": [], "others": []}
@@ -260,7 +335,7 @@ changelog ref target_ref="":
     # Print changelog
     short_base = base[:7]
     print("# Changelog\n")
-    print(f"Changes on `{target_ref}` since diverging from `{ref}` (merge-base: `{short_base}`).\n")
+    print(f"Changes on `{to_ref}` since the common ancestor with `{from_ref}` (`{short_base}`).\n")
     sections = [("Breaking Changes", "breaking"), ("Features", "features"), ("Fixes", "fixes"), ("Others", "others")]
     for title, key in sections:
         if categories[key]:

--- a/justfile
+++ b/justfile
@@ -1,0 +1,9 @@
+set allow-duplicate-recipes
+set allow-duplicate-variables
+import? 'charms.just'
+
+[private]
+@default:
+  just --list
+  echo ""
+  echo "For help with a specific recipe, run: just --usage <recipe>"


### PR DESCRIPTION
Add the [charms blueprint](https://github.com/canonical/observability/tree/main/blueprints/charms) to Prometheus; for the time being, this will live next to `tox` instead of replacing it, until we have widespread adoption across all of our charms and we can adapt CI to it.

Backport of #836.