### PR TITLE
feat: source `cosTool` from cosl

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - track/**
+      - feat/**
 
 permissions:
   # Required for all workflows

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - track/**
-      - feat/**
 
 permissions:
   # Required for all workflows

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -335,12 +335,13 @@ import subprocess
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union, cast
 from urllib.parse import urlparse
 
 import yaml
-from cosl import JujuTopology
+from cosl import CosTool, JujuTopology
 from cosl.rules import AlertRules, generic_alert_groups
+from cosl.types import OfficialRuleFileFormat
 from ops.charm import CharmBase, RelationRole
 from ops.framework import (
     BoundEvent,
@@ -361,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 61
+LIBPATCH = 62
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -993,7 +994,7 @@ class MetricsEndpointConsumer(Object):
         self._charm = charm
         self._relation_name = relation_name
         self._fallback_scrape_protocol = fallback_scrape_protocol
-        self._tool = CosTool(self._charm)
+        self._tool = CosTool("promql")
         events = self._charm.on[relation_name]
         self.framework.observe(events.relation_changed, self._on_metrics_provider_relation_changed)
         self.framework.observe(
@@ -1052,7 +1053,7 @@ class MetricsEndpointConsumer(Object):
                 # Therefore we need to dedupe here and after all jobs are collected.
                 static_scrape_jobs = _dedupe_job_names(static_scrape_jobs)
                 try:
-                    self._tool.validate_scrape_jobs(static_scrape_jobs)
+                    _validate_scrape_jobs(static_scrape_jobs)
                 except subprocess.CalledProcessError as e:
                     if self._charm.unit.is_leader():
                         data = json.loads(relation.data[self._charm.app].get("event", "{}"))
@@ -1143,7 +1144,7 @@ class MetricsEndpointConsumer(Object):
 
             alerts[identifier] = alert_rules
 
-            _, errmsg = self._tool.validate_alert_rules(alert_rules)
+            _, errmsg = self._tool.validate_alert_rules(cast(OfficialRuleFileFormat, alert_rules))
             if errmsg:
                 logger.error(f"Invalid alert rule file: {errmsg}")
                 if alerts[identifier]:
@@ -1354,6 +1355,43 @@ class MetricsEndpointConsumer(Object):
             parts = [target, "80"]
 
         return parts
+
+
+def _validate_scrape_jobs(jobs: list) -> bool:
+    """Validate scrape jobs using cos-tool.
+
+    Args:
+        jobs: A list of Prometheus scrape job dicts to validate.
+
+    Returns:
+        True if validation passed or cos-tool is unavailable.
+
+    Raises:
+        subprocess.CalledProcessError: if cos-tool rejects the scrape jobs.
+    """
+    arch = platform.machine()
+    arch = "amd64" if arch == "x86_64" else arch
+    cos_tool_path = Path("cos-tool-{}".format(arch))
+    try:
+        cos_tool_path = cos_tool_path.resolve(strict=True)
+    except (FileNotFoundError, OSError):
+        logger.debug("cos-tool unavailable. Not validating scrape jobs.")
+        return True
+
+    conf = {"scrape_configs": jobs}
+    with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as tmpfile:
+        tmpfile.write(yaml.safe_dump(conf))
+        tmpfile_name = tmpfile.name
+    try:
+        subprocess.run(
+            [str(cos_tool_path), "validate-config", tmpfile_name],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+    finally:
+        Path(tmpfile_name).unlink(missing_ok=True)
+    return True
 
 
 def _dedupe_job_names(jobs: List[dict]):
@@ -1847,123 +1885,3 @@ class PrometheusRulesProvider(Object):
                 alert_rules_as_dict,
                 sort_keys=True,  # sort, to prevent unnecessary relation_changed events
             )
-
-class CosTool:
-    """Uses cos-tool to inject label matchers into alert rule expressions and validate rules."""
-
-    _path = None
-    _disabled = False
-
-    def __init__(self, charm):
-        self._charm = charm
-
-    @property
-    def path(self):
-        """Lazy lookup of the path of cos-tool."""
-        if self._disabled:
-            return None
-        if not self._path:
-            self._path = self._get_tool_path()
-            if not self._path:
-                logger.debug("Skipping injection of juju topology as label matchers")
-                self._disabled = True
-        return self._path
-
-    def apply_label_matchers(self, rules) -> dict:
-        """Will apply label matchers to the expression of all alerts in all supplied groups."""
-        if not self.path:
-            return rules
-        for group in rules["groups"]:
-            rules_in_group = group.get("rules", [])
-            for rule in rules_in_group:
-                topology = {}
-                # if the user for some reason has provided juju_unit, we'll need to honor it
-                # in most cases, however, this will be empty
-                for label in [
-                    "juju_model",
-                    "juju_model_uuid",
-                    "juju_application",
-                    "juju_charm",
-                    "juju_unit",
-                ]:
-                    if label in rule["labels"]:
-                        topology[label] = rule["labels"][label]
-
-                rule["expr"] = self.inject_label_matchers(rule["expr"], topology)
-        return rules
-
-    def validate_alert_rules(self, rules: dict) -> Tuple[bool, str]:
-        """Will validate correctness of alert rules, returning a boolean and any errors."""
-        if not self.path:
-            logger.debug("`cos-tool` unavailable. Not validating alert correctness.")
-            return True, ""
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            rule_path = Path(tmpdir + "/validate_rule.yaml")
-            rule_path.write_text(yaml.dump(rules))
-
-            args = [str(self.path), "validate", str(rule_path)]
-            # noinspection PyBroadException
-            try:
-                self._exec(args)
-                return True, ""
-            except subprocess.CalledProcessError as e:
-                logger.debug("Validating the rules failed: %s", e.output.decode("utf8"))
-                return False, ", ".join(
-                    [
-                        line
-                        for line in e.output.decode("utf8").splitlines()
-                        if "error validating" in line
-                    ]
-                )
-
-    def validate_scrape_jobs(self, jobs: list) -> bool:
-        """Validate scrape jobs using cos-tool."""
-        if not self.path:
-            logger.debug("`cos-tool` unavailable. Not validating scrape jobs.")
-            return True
-        conf = {"scrape_configs": jobs}
-        with tempfile.NamedTemporaryFile() as tmpfile:
-            with open(tmpfile.name, "w") as f:
-                f.write(yaml.safe_dump(conf))
-            try:
-                self._exec([str(self.path), "validate-config", tmpfile.name])
-            except subprocess.CalledProcessError as e:
-                logger.error("Validating scrape jobs failed: {}".format(e.output))
-                raise
-        return True
-
-    def inject_label_matchers(self, expression, topology) -> str:
-        """Add label matchers to an expression."""
-        if not topology:
-            return expression
-        if not self.path:
-            logger.debug("`cos-tool` unavailable. Leaving expression unchanged: %s", expression)
-            return expression
-        args = [str(self.path), "transform"]
-        args.extend(
-            ["--label-matcher={}={}".format(key, value) for key, value in topology.items()]
-        )
-
-        args.extend(["{}".format(expression)])
-        # noinspection PyBroadException
-        try:
-            return self._exec(args)
-        except subprocess.CalledProcessError as e:
-            logger.debug('Applying the expression failed: "%s", falling back to the original', e)
-            return expression
-
-    def _get_tool_path(self) -> Optional[Path]:
-        arch = platform.machine()
-        arch = "amd64" if arch == "x86_64" else arch
-        res = "cos-tool-{}".format(arch)
-        try:
-            path = Path(res).resolve(strict=True)
-            return path
-        except (FileNotFoundError, OSError):
-            logger.debug('Could not locate cos-tool at: "{}"'.format(res))
-        return None
-
-    def _exec(self, cmd) -> str:
-        result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        return result.stdout.decode("utf-8").strip()

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -335,7 +335,7 @@ import subprocess
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import yaml
@@ -844,7 +844,7 @@ def _type_convert_stored(obj):
     if isinstance(obj, StoredList):
         return list(map(_type_convert_stored, obj))
     if isinstance(obj, StoredDict):
-        rdict = {}  # type: Dict[Any, Any]
+        rdict = {}
         for k in obj.keys():
             rdict[k] = _type_convert_stored(obj[k])
         return rdict
@@ -1108,7 +1108,7 @@ class MetricsEndpointConsumer(Object):
             A dictionary mapping the Juju topology identifier of the source charm to
             its list of alert rule groups.
         """
-        alerts = {}  # type: Dict[str, dict] # mapping b/w juju identifiers and alert rule files
+        alerts: Dict[str, OfficialRuleFileFormat] = {}
         for relation in self._charm.model.relations[self._relation_name]:
             if not relation.units or not relation.app:
                 continue
@@ -1144,7 +1144,7 @@ class MetricsEndpointConsumer(Object):
 
             alerts[identifier] = alert_rules
 
-            _, errmsg = self._tool.validate_alert_rules(cast(OfficialRuleFileFormat, alert_rules))
+            _, errmsg = self._tool.validate_alert_rules(alert_rules)
             if errmsg:
                 logger.error(f"Invalid alert rule file: {errmsg}")
                 if alerts[identifier]:
@@ -1162,7 +1162,7 @@ class MetricsEndpointConsumer(Object):
         return alerts
 
     def _get_identifier_by_alert_rules(
-        self, rules: dict
+        self, rules: OfficialRuleFileFormat
     ) -> Tuple[Union[str, None], Union[JujuTopology, None]]:
         """Determine an appropriate dict key for alert rules.
 
@@ -1182,7 +1182,9 @@ class MetricsEndpointConsumer(Object):
         # Construct an ID based on what's in the alert rules if they have labels
         for group in rules["groups"]:
             try:
-                labels = group["rules"][0]["labels"]
+                labels = group["rules"][0].get("labels")
+                if not labels:
+                    continue
                 topology = JujuTopology(
                     # Don't try to safely get required constructor fields. There's already
                     # a handler for KeyErrors
@@ -1209,7 +1211,7 @@ class MetricsEndpointConsumer(Object):
 
         return None, None
 
-    def _inject_alert_expr_labels(self, rules: Dict[str, Any]) -> Dict[str, Any]:
+    def _inject_alert_expr_labels(self, rules: OfficialRuleFileFormat) -> OfficialRuleFileFormat:
         """Iterate through alert rules and inject topology into expressions.
 
         Args:

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -20,7 +20,7 @@ import os
 import re
 import socket
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Union
 
 from cosl import CosTool, JujuTopology
 from cosl.rules import HOST_METRICS_MISSING_RULE_NAME, AlertRules, generic_alert_groups
@@ -830,7 +830,7 @@ class PrometheusRemoteWriteProvider(Object):
         Returns:
             a dictionary mapping the name of an alert rule group to the group.
         """
-        alerts = {}  # type: Dict[str, dict] # mapping b/w juju identifiers and alert rule files
+        alerts: Dict[str, OfficialRuleFileFormat] = {}
         for relation in self._charm.model.relations[self._relation_name]:
             if not relation.units or not relation.app:
                 continue
@@ -846,9 +846,7 @@ class PrometheusRemoteWriteProvider(Object):
                 try:
                     scrape_metadata = json.loads(relation.data[relation.app]["scrape_metadata"])
                     identifier = JujuTopology.from_dict(scrape_metadata).identifier
-                    alerts[identifier] = cast(
-                        dict, self._tool.apply_label_matchers(cast(OfficialRuleFileFormat, alert_rules))
-                    )
+                    alerts[identifier] = self._tool.apply_label_matchers(alert_rules)
 
                 except KeyError as e:
                     logger.debug(
@@ -864,7 +862,7 @@ class PrometheusRemoteWriteProvider(Object):
                 continue
 
             alerts[identifier] = alert_rules
-            _, errmsg = self._tool.validate_alert_rules(cast(OfficialRuleFileFormat, alert_rules))
+            _, errmsg = self._tool.validate_alert_rules(alert_rules)
             if errmsg:
                 logger.error(f"Invalid alert rule file: {errmsg}")
                 if alerts[identifier]:
@@ -882,7 +880,7 @@ class PrometheusRemoteWriteProvider(Object):
         return alerts
 
     def _get_identifier_by_alert_rules(
-        self, rules: Dict[str, Any]
+        self, rules: OfficialRuleFileFormat
     ) -> Tuple[Union[str, None], Union[JujuTopology, None]]:
         """Determine an appropriate dict key for alert rules.
 
@@ -902,7 +900,9 @@ class PrometheusRemoteWriteProvider(Object):
         # Construct an ID based on what's in the alert rules if they have labels
         for group in rules["groups"]:
             try:
-                labels = group["rules"][0]["labels"]
+                labels = group["rules"][0].get("labels")
+                if not labels:
+                    continue
                 topology = JujuTopology(
                     # Don't try to safely get required constructor fields. There's already
                     # a handler for KeyErrors
@@ -929,7 +929,7 @@ class PrometheusRemoteWriteProvider(Object):
 
         return None, None
 
-    def _inject_alert_expr_labels(self, rules: Dict[str, Any]) -> Dict[str, Any]:
+    def _inject_alert_expr_labels(self, rules: OfficialRuleFileFormat) -> OfficialRuleFileFormat:
         """Iterate through alert rules and inject topology into expressions.
 
         Args:

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -17,17 +17,14 @@ import copy
 import json
 import logging
 import os
-import platform
 import re
 import socket
-import subprocess
-import tempfile
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Union, cast
 
-import yaml
-from cosl import JujuTopology
+from cosl import CosTool, JujuTopology
 from cosl.rules import HOST_METRICS_MISSING_RULE_NAME, AlertRules, generic_alert_groups
+from cosl.types import OfficialRuleFileFormat
 from ops.charm import (
     CharmBase,
     HookEvent,
@@ -47,7 +44,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 16
 
 PYDEPS = ["cosl"]
 
@@ -455,7 +452,7 @@ class PrometheusRemoteWriteConsumer(Object):
         self._extra_alert_labels = extra_alert_labels
         self._peer_relation_name = peer_relation_name
         self.topology = JujuTopology.from_charm(charm)
-        self._tool = CosTool(self._charm)
+        self._tool = CosTool("promql")
         on_relation = self._charm.on[self._relation_name]
 
         self.framework.observe(on_relation.relation_joined, self._handle_endpoints_changed)
@@ -737,7 +734,7 @@ class PrometheusRemoteWriteProvider(Object):
 
         super().__init__(charm, relation_name)
         self._charm = charm
-        self._tool = CosTool(self._charm)
+        self._tool = CosTool("promql")
         self._relation_name = relation_name
         self._get_server_url = server_url_func
         self._endpoint_path = endpoint_path
@@ -849,7 +846,9 @@ class PrometheusRemoteWriteProvider(Object):
                 try:
                     scrape_metadata = json.loads(relation.data[relation.app]["scrape_metadata"])
                     identifier = JujuTopology.from_dict(scrape_metadata).identifier
-                    alerts[identifier] = self._tool.apply_label_matchers(alert_rules)
+                    alerts[identifier] = cast(
+                        dict, self._tool.apply_label_matchers(cast(OfficialRuleFileFormat, alert_rules))
+                    )
 
                 except KeyError as e:
                     logger.debug(
@@ -865,7 +864,7 @@ class PrometheusRemoteWriteProvider(Object):
                 continue
 
             alerts[identifier] = alert_rules
-            _, errmsg = self._tool.validate_alert_rules(alert_rules)
+            _, errmsg = self._tool.validate_alert_rules(cast(OfficialRuleFileFormat, alert_rules))
             if errmsg:
                 logger.error(f"Invalid alert rule file: {errmsg}")
                 if alerts[identifier]:
@@ -974,108 +973,3 @@ class PrometheusRemoteWriteProvider(Object):
         rules["groups"] = modified_groups
         return rules
 
-
-# Copy/pasted from prometheus_scrape.py
-class CosTool:
-    """Uses cos-tool to inject label matchers into alert rule expressions and validate rules."""
-
-    _path = None
-    _disabled = False
-
-    def __init__(self, charm):
-        self._charm = charm
-
-    @property
-    def path(self):
-        """Lazy lookup of the path of cos-tool."""
-        if self._disabled:
-            return None
-        if not self._path:
-            self._path = self._get_tool_path()
-            if not self._path:
-                logger.debug("Skipping injection of juju topology as label matchers")
-                self._disabled = True
-        return self._path
-
-    def apply_label_matchers(self, rules) -> dict:
-        """Will apply label matchers to the expression of all alerts in all supplied groups."""
-        if not self.path:
-            return rules
-        for group in rules["groups"]:
-            rules_in_group = group.get("rules", [])
-            for rule in rules_in_group:
-                topology = {}
-                # if the user for some reason has provided juju_unit, we'll need to honor it
-                # in most cases, however, this will be empty
-                for label in [
-                    "juju_model",
-                    "juju_model_uuid",
-                    "juju_application",
-                    "juju_charm",
-                    "juju_unit",
-                ]:
-                    if label in rule["labels"]:
-                        topology[label] = rule["labels"][label]
-
-                rule["expr"] = self.inject_label_matchers(rule["expr"], topology)
-        return rules
-
-    def validate_alert_rules(self, rules: dict) -> Tuple[bool, str]:
-        """Will validate correctness of alert rules, returning a boolean and any errors."""
-        if not self.path:
-            logger.debug("`cos-tool` unavailable. Not validating alert correctness.")
-            return True, ""
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            rule_path = Path(tmpdir + "/validate_rule.yaml")
-            rule_path.write_text(yaml.dump(rules))
-
-            args = [str(self.path), "validate", str(rule_path)]
-            # noinspection PyBroadException
-            try:
-                self._exec(args)
-                return True, ""
-            except subprocess.CalledProcessError as e:
-                logger.debug("Validating the rules failed: %s", e.output)
-                return False, ", ".join(
-                    [
-                        line
-                        for line in e.output.decode("utf8").splitlines()
-                        if "error validating" in line
-                    ]
-                )
-
-    def inject_label_matchers(self, expression, topology) -> str:
-        """Add label matchers to an expression."""
-        if not topology:
-            return expression
-        if not self.path:
-            logger.debug("`cos-tool` unavailable. Leaving expression unchanged: %s", expression)
-            return expression
-        args = [str(self.path), "transform"]
-        args.extend(
-            ["--label-matcher={}={}".format(key, value) for key, value in topology.items()]
-        )
-
-        args.extend(["{}".format(expression)])
-        # noinspection PyBroadException
-        try:
-            return self._exec(args)
-        except subprocess.CalledProcessError as e:
-            logger.debug('Applying the expression failed: "%s", falling back to the original', e)
-            return expression
-
-    def _get_tool_path(self) -> Optional[Path]:
-        arch = platform.machine()
-        arch = "amd64" if arch == "x86_64" else arch
-        res = "cos-tool-{}".format(arch)
-        try:
-            path = Path(res).resolve(strict=True)
-            return path
-        except (FileNotFoundError, OSError):
-            logger.debug('Could not locate cos-tool at: "{}"'.format(res))
-        return None
-
-    def _exec(self, cmd) -> str:
-        result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        return result.stdout.decode("utf-8").strip()

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -929,7 +929,7 @@ class CharmProvidingPromBakedInRules(CharmBase):
         self.provider = MetricsEndpointProvider(
             self, jobs=JOBS, alert_rules_path=str(PROJECT_DIR / "src" / "prometheus_alert_rules")
         )
-        self.tool = CosTool(self)
+        self.tool = CosTool("promql")
 
 
 class TestBakedInAlertRules(unittest.TestCase):

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -4,9 +4,11 @@
 import subprocess
 import unittest
 from pathlib import PosixPath
+from typing import cast
 from unittest import mock
 
 from charms.prometheus_k8s.v0.prometheus_scrape import CosTool
+from cosl.types import OfficialRuleFileFormat
 from ops.charm import CharmBase
 from ops.testing import Harness
 
@@ -18,7 +20,7 @@ class ToolProviderCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.tool = CosTool(self)
+        self.tool = CosTool("promql")
 
 
 class TestTransform(unittest.TestCase):
@@ -63,7 +65,7 @@ class TestTransform(unittest.TestCase):
 
         tool = self.harness.charm.tool
         output = tool.apply_label_matchers(
-            {
+            cast(OfficialRuleFileFormat, {
                 "groups": [
                     {
                         "alert": "CPUOverUse",
@@ -82,15 +84,15 @@ class TestTransform(unittest.TestCase):
                         },
                     }
                 ]
-            }
+            })
         )
-        self.assertEqual(output["groups"][0]["expr"], "process_cpu_seconds_total > 0.12")
+        self.assertEqual(cast(dict, output)["groups"][0]["expr"], "process_cpu_seconds_total > 0.12")
 
     @mock.patch("platform.machine", lambda: "invalid")
     def test_uses_original_expression_when_binary_missing(self):
         tool = self.harness.charm.tool
         output = tool.apply_label_matchers(
-            {
+            cast(OfficialRuleFileFormat, {
                 "groups": [
                     {
                         "alert": "CPUOverUse",
@@ -109,9 +111,9 @@ class TestTransform(unittest.TestCase):
                         },
                     }
                 ]
-            }
+            })
         )
-        self.assertEqual(output["groups"][0]["expr"], "process_cpu_seconds_total > 0.12")
+        self.assertEqual(cast(dict, output)["groups"][0]["expr"], "process_cpu_seconds_total > 0.12")
 
     @mock.patch("platform.machine", lambda: "x86_64")
     def test_fetches_the_correct_expression(self):
@@ -157,14 +159,14 @@ class TestValidateAlerts(unittest.TestCase):
     def test_returns_errors_on_bad_rule_file(self):
         tool = self.harness.charm.tool
         valid, errs = tool.validate_alert_rules(
-            {
+            cast(OfficialRuleFileFormat, {
                 "groups": [
                     {
                         "alert": "BadSyntax",
                         "expr": "process_cpu_seconds_total{) > 0.12",
                     }
                 ]
-            }
+            })
         )
         self.assertEqual(valid, False)
         self.assertIn("error validating", errs)
@@ -173,7 +175,7 @@ class TestValidateAlerts(unittest.TestCase):
     def test_successfully_validates_good_alert_rules(self):
         tool = self.harness.charm.tool
         valid, errs = tool.validate_alert_rules(
-            {
+            cast(OfficialRuleFileFormat, {
                 "groups": [
                     {
                         "name": "group_name",
@@ -197,7 +199,7 @@ class TestValidateAlerts(unittest.TestCase):
                         ],
                     }
                 ]
-            }
+            })
         )
         self.assertEqual(errs, "")
         self.assertEqual(valid, True)

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -4,11 +4,9 @@
 import subprocess
 import unittest
 from pathlib import PosixPath
-from typing import cast
 from unittest import mock
 
 from charms.prometheus_k8s.v0.prometheus_scrape import CosTool
-from cosl.types import OfficialRuleFileFormat
 from ops.charm import CharmBase
 from ops.testing import Harness
 
@@ -65,55 +63,65 @@ class TestTransform(unittest.TestCase):
 
         tool = self.harness.charm.tool
         output = tool.apply_label_matchers(
-            cast(OfficialRuleFileFormat, {
+            {
                 "groups": [
                     {
-                        "alert": "CPUOverUse",
-                        "expr": "process_cpu_seconds_total > 0.12",
-                        "for": "0m",
-                        "labels": {
-                            "severity": "Low",
-                            "juju_model": "None",
-                            "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
-                            "juju_application": "consumer-tester",
-                        },
-                        "annotations": {
-                            "summary": "Instance {{ $labels.instance }} CPU over use",
-                            "description": "{{ $labels.instance }} of job "
-                            "{{ $labels.job }} has used too much CPU.",
-                        },
+                        "name": "test_group",
+                        "rules": [
+                            {
+                                "alert": "CPUOverUse",
+                                "expr": "process_cpu_seconds_total > 0.12",
+                                "for": "0m",
+                                "labels": {
+                                    "severity": "Low",
+                                    "juju_model": "None",
+                                    "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                                    "juju_application": "consumer-tester",
+                                },
+                                "annotations": {
+                                    "summary": "Instance {{ $labels.instance }} CPU over use",
+                                    "description": "{{ $labels.instance }} of job "
+                                    "{{ $labels.job }} has used too much CPU.",
+                                },
+                            }
+                        ],
                     }
                 ]
-            })
+            }
         )
-        self.assertEqual(cast(dict, output)["groups"][0]["expr"], "process_cpu_seconds_total > 0.12")
+        self.assertEqual(output.get("groups", [])[0]["rules"][0]["expr"], "process_cpu_seconds_total > 0.12")
 
     @mock.patch("platform.machine", lambda: "invalid")
     def test_uses_original_expression_when_binary_missing(self):
         tool = self.harness.charm.tool
         output = tool.apply_label_matchers(
-            cast(OfficialRuleFileFormat, {
+            {
                 "groups": [
                     {
-                        "alert": "CPUOverUse",
-                        "expr": "process_cpu_seconds_total > 0.12",
-                        "for": "0m",
-                        "labels": {
-                            "severity": "Low",
-                            "juju_model": "None",
-                            "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
-                            "juju_application": "consumer-tester",
-                        },
-                        "annotations": {
-                            "summary": "Instance {{ $labels.instance }} CPU over use",
-                            "description": "{{ $labels.instance }} of job "
-                            "{{ $labels.job }} has used too much CPU.",
-                        },
+                        "name": "test_group",
+                        "rules": [
+                            {
+                                "alert": "CPUOverUse",
+                                "expr": "process_cpu_seconds_total > 0.12",
+                                "for": "0m",
+                                "labels": {
+                                    "severity": "Low",
+                                    "juju_model": "None",
+                                    "juju_model_uuid": "f2c1b2a6-e006-11eb-ba80-0242ac130004",
+                                    "juju_application": "consumer-tester",
+                                },
+                                "annotations": {
+                                    "summary": "Instance {{ $labels.instance }} CPU over use",
+                                    "description": "{{ $labels.instance }} of job "
+                                    "{{ $labels.job }} has used too much CPU.",
+                                },
+                            }
+                        ],
                     }
                 ]
-            })
+            }
         )
-        self.assertEqual(cast(dict, output)["groups"][0]["expr"], "process_cpu_seconds_total > 0.12")
+        self.assertEqual(output.get("groups", [])[0]["rules"][0]["expr"], "process_cpu_seconds_total > 0.12")
 
     @mock.patch("platform.machine", lambda: "x86_64")
     def test_fetches_the_correct_expression(self):
@@ -159,14 +167,19 @@ class TestValidateAlerts(unittest.TestCase):
     def test_returns_errors_on_bad_rule_file(self):
         tool = self.harness.charm.tool
         valid, errs = tool.validate_alert_rules(
-            cast(OfficialRuleFileFormat, {
+            {
                 "groups": [
                     {
-                        "alert": "BadSyntax",
-                        "expr": "process_cpu_seconds_total{) > 0.12",
+                        "name": "test_group",
+                        "rules": [
+                            {
+                                "alert": "BadSyntax",
+                                "expr": "process_cpu_seconds_total{) > 0.12",
+                            }
+                        ],
                     }
                 ]
-            })
+            }
         )
         self.assertEqual(valid, False)
         self.assertIn("error validating", errs)
@@ -175,7 +188,7 @@ class TestValidateAlerts(unittest.TestCase):
     def test_successfully_validates_good_alert_rules(self):
         tool = self.harness.charm.tool
         valid, errs = tool.validate_alert_rules(
-            cast(OfficialRuleFileFormat, {
+            {
                 "groups": [
                     {
                         "name": "group_name",
@@ -199,7 +212,7 @@ class TestValidateAlerts(unittest.TestCase):
                         ],
                     }
                 ]
-            })
+            }
         )
         self.assertEqual(errs, "")
         self.assertEqual(valid, True)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Similar to https://github.com/canonical/loki-k8s-operator/pull/607/.
Before https://github.com/canonical/cos-lib/pull/202 goes in, we should source CosTool in these two libs from `cosl` to pull all the performance efficiency changes easily.

## Solution
<!-- A summary of the solution addressing the above issue -->
Replaces the local CosTool clone so it can be sourced from `cosl`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Once merged, if we decide we want the perf improvements of https://github.com/canonical/cos-lib/pull/202 in tracks 2 and 3, then we should backport the changes of this PR using `charmcraft fetch-lib` in those two tracks.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
