### PR TITLE
feat: blocked on invalid scrape jobs

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 62
+LIBPATCH = 63
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -1055,11 +1055,16 @@ class MetricsEndpointConsumer(Object):
                 try:
                     _validate_scrape_jobs(static_scrape_jobs)
                 except subprocess.CalledProcessError as e:
+                    logger.error(f"Invalid scrape job file: {e}")
                     if self._charm.unit.is_leader():
                         data = json.loads(relation.data[self._charm.app].get("event", "{}"))
                         data["scrape_job_errors"] = str(e)
                         relation.data[self._charm.app]["event"] = json.dumps(data)
                 else:
+                    if self._charm.unit.is_leader():
+                        data = json.loads(relation.data[self._charm.app].get("event", "{}"))
+                        data.pop("scrape_job_errors", None)
+                        relation.data[self._charm.app]["event"] = json.dumps(data)
                     scrape_jobs.extend(static_scrape_jobs)
 
         scrape_jobs = _dedupe_job_names(scrape_jobs)

--- a/src/charm.py
+++ b/src/charm.py
@@ -132,6 +132,7 @@ class CompositeStatus(TypedDict):
     k8s_patch: Tuple[str, str]
     config: Tuple[str, str]
     alert_rules: Tuple[str, str]
+    scrape_jobs: Tuple[str, str]
 
 
 def to_tuple(status: StatusBase) -> Tuple[str, str]:
@@ -172,6 +173,7 @@ class PrometheusCharm(CharmBase):
                 k8s_patch=to_tuple(ActiveStatus()),
                 config=to_tuple(ActiveStatus()),
                 alert_rules=to_tuple(ActiveStatus()),
+                scrape_jobs=to_tuple(ActiveStatus()),
             )
         )
 
@@ -857,6 +859,29 @@ class PrometheusCharm(CharmBase):
 
         return False
 
+    def _has_scrape_job_errors(self) -> bool:
+        """Check if any metrics-endpoint relation reported scrape job validation errors."""
+        for relation in self.model.relations.get(DEFAULT_METRICS_RELATION_NAME, []):
+            app_data = relation.data.get(self.app)
+            if not app_data:
+                continue
+
+            event_raw = app_data.get("event", "{}")
+            try:
+                event_data = json.loads(event_raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if event_data.get("scrape_job_errors"):
+                logger.error(
+                    "Scrape job validation error on relation %s: %s",
+                    relation.id,
+                    event_data["scrape_job_errors"],
+                )
+                return True
+
+        return False
+
     def _push_alert_rules(self, alerts):
         """Pushes alert rules from a rules file to the prometheus container.
 
@@ -1137,6 +1162,13 @@ class PrometheusCharm(CharmBase):
             processed_job, processed_certs = self._process_tls_config(job)
             certs = {**certs, **processed_certs}
             prometheus_config["scrape_configs"].append(processed_job)  # type: ignore
+
+        if self._has_scrape_job_errors():
+            msg = "Invalid scrape jobs. See debug-log"
+            logger.error(msg)
+            self._stored.status["scrape_jobs"] = to_tuple(BlockedStatus(msg))
+        else:
+            self._stored.status["scrape_jobs"] = to_tuple(ActiveStatus())
 
         web_config = self._web_config()
 

--- a/tests/unit/test_scrape_job_filtering.py
+++ b/tests/unit/test_scrape_job_filtering.py
@@ -4,11 +4,13 @@
 import dataclasses
 import json
 
-import yaml
+import ops
 from ops.model import ActiveStatus, BlockedStatus
 from scenario import Relation, State
 
 from charm import to_status
+
+ops.testing.SIMULATE_CAN_CONNECT = True  # pyright: ignore
 
 
 # To test that invalid scrape jobs are filtered out and the charm goes into blocked
@@ -57,17 +59,6 @@ INVALID_SCRAPE_JOB_RELATION = Relation(
 )
 
 
-def _scrape_job_names(context, state_out):
-    """Read the scrape job names written to the prometheus config on disk."""
-    fs = state_out.get_container("prometheus").get_filesystem(context)
-    prometheus_config = fs.joinpath("etc", "prometheus", "prometheus.yml")
-    if not prometheus_config.exists():
-        return set()
-
-    config = yaml.safe_load(prometheus_config.read_text())
-    return {job.get("job_name") for job in config.get("scrape_configs", [])}
-
-
 def _scrape_jobs_status(state_out):
     """Return only the scrape-jobs status, ignoring unrelated unit statuses."""
     charm_stored_state = next(
@@ -89,8 +80,7 @@ def test_valid_scrape_job_relation_remains_active(context, prometheus_container)
     # WHEN the relation changed event is processed
     state_out = context.run(context.on.relation_changed(VALID_SCRAPE_JOB_RELATION), state_in)
 
-    # THEN the valid job is written and the scrape-jobs status remains active
-    assert any("valid-job" in name for name in _scrape_job_names(context, state_out))
+    # THEN the scrape-jobs status remains active
     assert isinstance(_scrape_jobs_status(state_out), ActiveStatus)
 
 
@@ -105,8 +95,7 @@ def test_invalid_scrape_job_relation_blocks(context, prometheus_container):
     # WHEN the relation changed event is processed
     state_out = context.run(context.on.relation_changed(INVALID_SCRAPE_JOB_RELATION), state_in)
 
-    # THEN the invalid job is filtered out and the scrape-jobs status is blocked
-    assert not any("invalid-job" in name for name in _scrape_job_names(context, state_out))
+    # THEN the scrape-jobs status is blocked
     assert isinstance(_scrape_jobs_status(state_out), BlockedStatus)
 
 
@@ -168,6 +157,6 @@ def test_invalid_scrape_job_relation_becoming_valid_recovers_to_active(
         dataclasses.replace(blocked_state, relations=[now_valid_relation]),
     )
 
-    # THEN the previous invalid status is cleared and valid jobs are written
-    assert any("valid-job" in name for name in _scrape_job_names(context, recovered_state))
+    # THEN the previous invalid status is cleared
     assert isinstance(_scrape_jobs_status(recovered_state), ActiveStatus)
+

--- a/tests/unit/test_scrape_job_filtering.py
+++ b/tests/unit/test_scrape_job_filtering.py
@@ -1,0 +1,173 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import dataclasses
+import json
+
+import yaml
+from ops.model import ActiveStatus, BlockedStatus
+from scenario import Relation, State
+
+from charm import to_status
+
+
+# To test that invalid scrape jobs are filtered out and the charm goes into blocked
+# status, we create two `metrics-endpoint` relations, one with a valid scrape job and
+# one with an invalid scrape job. The invalid scrape job has a `sample_limit` set to
+# a dict instead of a number, which cos-tool rejects.
+def _scrape_jobs(job_name: str, valid: bool) -> str:
+    job = {
+        "job_name": job_name,
+        "metrics_path": "/metrics",
+        "static_configs": [{"targets": ["192.0.2.1:9090"]}],
+    }
+    if not valid:
+        # `sample_limit` must be a number; a dict makes the scrape job invalid.
+        job["sample_limit"] = {"not_a_key": "not_a_value"}
+    return json.dumps([job])
+
+
+def _metadata(app_name: str) -> str:
+    return json.dumps(
+        {
+            "model": "test",
+            "model_uuid": "20ce8299-3634-4bef-8bd8-5ace6c8816b4",
+            "application": app_name,
+            "charm_name": f"{app_name}-charm",
+        }
+    )
+
+
+VALID_SCRAPE_JOB_RELATION = Relation(
+    "metrics-endpoint",
+    remote_app_name="scrape-job-valid",
+    remote_app_data={
+        "scrape_jobs": _scrape_jobs("valid-job", valid=True),
+        "scrape_metadata": _metadata("scrape-job-valid"),
+    },
+)
+
+INVALID_SCRAPE_JOB_RELATION = Relation(
+    "metrics-endpoint",
+    remote_app_name="scrape-job-invalid",
+    remote_app_data={
+        "scrape_jobs": _scrape_jobs("invalid-job", valid=False),
+        "scrape_metadata": _metadata("scrape-job-invalid"),
+    },
+)
+
+
+def _scrape_job_names(context, state_out):
+    """Read the scrape job names written to the prometheus config on disk."""
+    fs = state_out.get_container("prometheus").get_filesystem(context)
+    prometheus_config = fs.joinpath("etc", "prometheus", "prometheus.yml")
+    if not prometheus_config.exists():
+        return set()
+
+    config = yaml.safe_load(prometheus_config.read_text())
+    return {job.get("job_name") for job in config.get("scrape_configs", [])}
+
+
+def _scrape_jobs_status(state_out):
+    """Return only the scrape-jobs status, ignoring unrelated unit statuses."""
+    charm_stored_state = next(
+        stored_state
+        for stored_state in state_out.stored_states
+        if stored_state.owner_path == "PrometheusCharm"
+    )
+    return to_status(charm_stored_state.content["status"]["scrape_jobs"])
+
+
+def test_valid_scrape_job_relation_remains_active(context, prometheus_container):
+    # GIVEN a scrape relation with a valid scrape job
+    state_in = State(
+        leader=True,
+        relations=[VALID_SCRAPE_JOB_RELATION],
+        containers=[prometheus_container],
+    )
+
+    # WHEN the relation changed event is processed
+    state_out = context.run(context.on.relation_changed(VALID_SCRAPE_JOB_RELATION), state_in)
+
+    # THEN the valid job is written and the scrape-jobs status remains active
+    assert any("valid-job" in name for name in _scrape_job_names(context, state_out))
+    assert isinstance(_scrape_jobs_status(state_out), ActiveStatus)
+
+
+def test_invalid_scrape_job_relation_blocks(context, prometheus_container):
+    # GIVEN a scrape relation with an invalid scrape job
+    state_in = State(
+        leader=True,
+        relations=[INVALID_SCRAPE_JOB_RELATION],
+        containers=[prometheus_container],
+    )
+
+    # WHEN the relation changed event is processed
+    state_out = context.run(context.on.relation_changed(INVALID_SCRAPE_JOB_RELATION), state_in)
+
+    # THEN the invalid job is filtered out and the scrape-jobs status is blocked
+    assert not any("invalid-job" in name for name in _scrape_job_names(context, state_out))
+    assert isinstance(_scrape_jobs_status(state_out), BlockedStatus)
+
+
+def test_invalid_scrape_job_relation_broken_recovers_to_active(
+    context, prometheus_container
+):
+    # GIVEN an invalid scrape relation has already blocked the charm
+    state_in = State(
+        leader=True,
+        relations=[INVALID_SCRAPE_JOB_RELATION],
+        containers=[prometheus_container],
+    )
+
+    blocked_state = context.run(
+        context.on.relation_changed(INVALID_SCRAPE_JOB_RELATION), state_in
+    )
+
+    assert isinstance(_scrape_jobs_status(blocked_state), BlockedStatus)
+
+    # WHEN the invalid scrape relation is removed
+    invalid_relation_out = blocked_state.get_relation(INVALID_SCRAPE_JOB_RELATION.id)
+    state_out = context.run(
+        context.on.relation_broken(invalid_relation_out),
+        blocked_state,
+    )
+
+    # THEN the charm status must be active again
+    assert isinstance(_scrape_jobs_status(state_out), ActiveStatus)
+
+
+def test_invalid_scrape_job_relation_becoming_valid_recovers_to_active(
+    context, prometheus_container
+):
+    # GIVEN a scrape relation with invalid jobs has already blocked the charm
+    state_in = State(
+        leader=True,
+        relations=[INVALID_SCRAPE_JOB_RELATION],
+        containers=[prometheus_container],
+    )
+
+    blocked_state = context.run(
+        context.on.relation_changed(INVALID_SCRAPE_JOB_RELATION), state_in
+    )
+
+    assert isinstance(_scrape_jobs_status(blocked_state), BlockedStatus)
+
+    # WHEN the same scrape relation updates its jobs to become valid
+    relation_after_invalid = blocked_state.get_relation(INVALID_SCRAPE_JOB_RELATION.id)
+    now_valid_relation = dataclasses.replace(
+        relation_after_invalid,
+        remote_app_data={
+            **relation_after_invalid.remote_app_data,
+            "scrape_jobs": VALID_SCRAPE_JOB_RELATION.remote_app_data["scrape_jobs"],
+        },
+    )
+
+    recovered_state = context.run(
+        context.on.relation_changed(now_valid_relation),
+        dataclasses.replace(blocked_state, relations=[now_valid_relation]),
+    )
+
+    # THEN the previous invalid status is cleared and valid jobs are written
+    assert any("valid-job" in name for name in _scrape_job_names(context, recovered_state))
+    assert isinstance(_scrape_jobs_status(recovered_state), ActiveStatus)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #633.

Based on changes in https://github.com/canonical/prometheus-k8s-operator/pull/817.

## Solution
<!-- A summary of the solution addressing the above issue -->
Similar to https://github.com/canonical/prometheus-k8s-operator/pull/817, we:
1. Write validation errors from Cos Tool to local app data (only the leader can do that). This was already implemented.
2. When `_configure()` runs, we fetch scrape jobs. If there are any scrape jobs with validation errors, we set blocked.
3. If the relation changes and the validation errors go away, we clear local app data.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
The charm and the changes implemented in this PR are available for testing on `dev/edge/pr849`.

### Before
To observe the "before" behaviour, first deploy the bundle below:
```yaml
bundle: kubernetes
applications:
  prom:
    charm: prometheus-k8s
    channel: dev/edge
    revision: 312
    resources:
      prometheus-image: 155
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  scrape:
    charm: prometheus-scrape-target-k8s
    channel: dev/edge
    revision: 42
    scale: 1
    options:
      labels: dns_name:k8s-cluster-ai-1.maas,kubernetes_node:k8s-cluster-ai-1
      metrics_path: /metrics
      params: ""
      scheme: http
      targets: 10.0.0.0:3000
    constraints: arch=amd64
    trust: true
relations:
- - scrape:metrics-endpoint
  - prom:metrics-endpoint

```
The bundle above results in a valid Prometheus scrape job. You can confirm this by curling the Prometheus targets endpoint:
```
curl 10.1.0.15:9090/api/v1/targets | jq 
...
...
...
"activeTargets": [
      {
        "discoveredLabels": {
          "__address__": "10.0.0.0:3000",
          "__metrics_path__": "/metrics",
          "__scheme__": "http",
          "__scrape_interval__": "1m",
          "__scrape_timeout__": "10s",
          "dns_name": "k8s-cluster-ai-1.maas",
          "job": "juju_test2_6081db3_scrape_external_jobs",
          "kubernetes_node": "k8s-cluster-ai-1"
        },
        "labels": {
          "dns_name": "k8s-cluster-ai-1.maas",
          "instance": "10.0.0.0:3000",
          "job": "juju_test2_6081db3_scrape_external_jobs",
          "kubernetes_node": "k8s-cluster-ai-1"
        },
        "scrapePool": "juju_test2_6081db3_scrape_external_jobs",
        "scrapeUrl": "http://10.0.0.0:3000/metrics",
        "globalUrl": "http://10.0.0.0:3000/metrics",
        "lastError": "",
        "lastScrape": "0001-01-01T00:00:00Z",
        "lastScrapeDuration": 0,
        "health": "unknown",
        "scrapeInterval": "1m",
        "scrapeTimeout": "10s"
      },
...
...
...

```
To simulate what an invalid scrape job, follow the steps below.
1. `juju config scrape params='{"auth": "snmp_v3", "module": "if_mib_if_name", "target": "192.168.100.200"}'. This config option provided is invalid because the `params` config option expects the values in the dictionary to be a list of strings, not strings themselves.
4. This results in a validation error that ends up getting written to the databag by Prometheus:
```
juju show-unit scrape/0
...
...
...
relation-id: 5
    endpoint: metrics-endpoint
    related-endpoint: metrics-endpoint
    application-data:
      event: '{"scrape_job_errors": "Command ''[''/var/lib/juju/agents/unit-prom-0/charm/cos-tool-amd64'',
        ''validate-config'', ''/tmp/tmpd24mqjw1.yaml'']'' returned non-zero exit status
        1."}'
    related-units:
      prom/0:
...
...
...
```
5. Because the validation of the scrape job fails, this job should not be returned when curling Prom's targets endpoint.
6. If you now clear the `params` config option, the scrape job succeeds and shows up in the list of scrape targets.
7. However, the previous validation error written to relation data does not get removed.
```
jshu scrape/0
...
...
...
- relation-id: 5
    endpoint: metrics-endpoint
    related-endpoint: metrics-endpoint
    application-data:
      event: '{"scrape_job_errors": "Command ''[''/var/lib/juju/agents/unit-prom-0/charm/cos-tool-amd64'',
        ''validate-config'', ''/tmp/tmpd24mqjw1.yaml'']'' returned non-zero exit status
        1."}'
    related-units:
      prom/0:
...
...
```
### After
To observe the after behaviour, refresh the Prom charm: `juju refresh prom --channel dev/edge/pr849`.
1. `juju config params='{"auth": "snmp_v3", "module": "if_mib_if_name", "target": "192.168.100.200"}'`. This is invalid and should result in Prometheus being blocked.
2. The status message should say "Invalid scrape jobs. See debug-log"
3. There should be a validation error message in the relation data Scrape sees:
```
application-data:
      event: '{"scrape_job_errors": "Command ''[''/var/lib/juju/agents/unit-prom-0/charm/cos-tool-amd64'',
        ''validate-config'', ''/tmp/tmphpzy36ht.yaml'']'' returned non-zero exit status
        1."}'
    related-units:
      prom/0:

```
4. Update the `params` config option to something valid such as: `juju config scrape params='{"auth": ["snmp_v3"], "module": ["if_mib_if_name", "if_mib"]}'`
5. Prometheus should become active.
8. The validation errors should be cleared:
```
- relation-id: 5
    endpoint: metrics-endpoint
    related-endpoint: metrics-endpoint
    application-data:
      event: '{}'
    related-units:
      prom/0:
        in-scope: true

```
9. The scrape job should be visible from the Prometheus POV.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
Once this PR merges, the `prometheus_scrape` lib will have to be bumped across all charms that use it. When this happens in Opentelemetry Collector K8s and Opentelemetry Collector, we will need to ensure those two charms also set blocked status if there are any validaton errors in local app data.

We need the same functionality of writing validation errors to local app data in COS Agent. The issue is that COS Agent does not validate anything using COS Tool.