### PR TITLE
feat: move invalid alert rules/scrape job helpers to Prom libs

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 63
+LIBPATCH = 64
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -1362,6 +1362,62 @@ class MetricsEndpointConsumer(Object):
             parts = [target, "80"]
 
         return parts
+
+    def has_invalid_scrape_jobs(self) -> bool:
+        """Check whether any relation reported invalid scrape jobs.
+
+        Validation errors, written to relation app data by this consumer
+        (see :meth:`jobs`), are read back to determine whether the relationship
+        currently carries an invalid scrape job.
+
+        Returns:
+            True if any related metrics provider reported scrape job validation
+            errors, False otherwise.
+        """
+        return self._has_relation_error("scrape_job_errors", "Scrape job validation error")
+
+    def has_invalid_alert_rules(self) -> bool:
+        """Check whether any relation reported invalid alert rules.
+
+        Validation errors, written to relation app data by this consumer
+        (see :attr:`alerts`), are read back to determine whether the relationship
+        currently carries invalid alert rules.
+
+        Returns:
+            True if any related metrics provider reported alert rule validation
+            errors, False otherwise.
+        """
+        return self._has_relation_error("errors", "Alert rule validation error")
+
+    def _has_relation_error(self, error_key: str, error_label: str) -> bool:
+        """Check whether any relation reported the given validation error.
+
+        Args:
+            error_key: the relation app data key that holds the validation error,
+                i.e. "scrape_job_errors" or "errors".
+            error_label: a human readable description of the validation error
+                type, used for logging, e.g. "Scrape job validation error".
+
+        Returns:
+            True if any related metrics provider reported the validation error,
+            False otherwise.
+        """
+        for relation in self._charm.model.relations.get(self._relation_name, []):
+            app_data = relation.data.get(self._charm.app)
+            if not app_data:
+                continue
+
+            event_raw = app_data.get("event", "{}")
+            try:
+                event_data = json.loads(event_raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if error_msg := event_data.get(error_key):
+                logger.error("%s on relation %s: %s", error_label, relation.id, error_msg)
+                return True
+
+        return False
 
 
 def _validate_scrape_jobs(jobs: list) -> bool:

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -44,7 +44,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 17
 
 PYDEPS = ["cosl"]
 
@@ -972,4 +972,47 @@ class PrometheusRemoteWriteProvider(Object):
 
         rules["groups"] = modified_groups
         return rules
+
+    def has_invalid_alert_rules(self) -> bool:
+        """Check whether any relation reported invalid alert rules.
+
+        Validation errors, written to relation app data by the :attr:`alerts`
+        property, are read back to determine whether the relation currently
+        carries an invalid set of alert rules.
+
+        Returns:
+            True if any related consumer reported alert rule validation errors,
+            False otherwise.
+        """
+        return self._has_relation_error("errors", "Alert rule validation error")
+
+    def _has_relation_error(self, error_key: str, error_label: str) -> bool:
+        """Check whether any relation reported the given validation error.
+
+        Args:
+            error_key: the relation app data key that holds the validation error,
+                i.e. "errors".
+            error_label: a human readable description of the validation error
+                type, used for logging, e.g. "Alert rule validation error".
+
+        Returns:
+            True if any related consumer reported the validation error,
+            False otherwise.
+        """
+        for relation in self._charm.model.relations.get(self._relation_name, []):
+            app_data = relation.data.get(self._charm.app)
+            if not app_data:
+                continue
+
+            event_raw = app_data.get("event", "{}")
+            try:
+                event_data = json.loads(event_raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if error_msg := event_data.get(error_key):
+                logger.error("%s on relation %s: %s", error_label, relation.id, error_msg)
+                return True
+
+        return False
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,7 +6,6 @@
 """A Juju charm for Prometheus on Kubernetes."""
 
 import hashlib
-import json
 import logging
 import re
 import socket
@@ -34,9 +33,6 @@ from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
     K8sResourcePatchFailedEvent,
     KubernetesComputeResourcesPatch,
     adjust_resource_requirements,
-)
-from charms.prometheus_k8s.v0.prometheus_scrape import (
-    DEFAULT_RELATION_NAME as DEFAULT_METRICS_RELATION_NAME,
 )
 from charms.prometheus_k8s.v0.prometheus_scrape import (
     MetricsEndpointConsumer,
@@ -837,50 +833,13 @@ class PrometheusCharm(CharmBase):
 
     def _has_alert_rule_errors(self) -> bool:
         """Check if any alert-rule relation reported validation errors."""
-        for relation_name in (DEFAULT_METRICS_RELATION_NAME, DEFAULT_REMOTE_WRITE_RELATION_NAME):
-            for relation in self.model.relations.get(relation_name, []):
-                app_data = relation.data.get(self.app)
-                if not app_data:
-                    continue
-
-                event_raw = app_data.get("event", "{}")
-                try:
-                    event_data = json.loads(event_raw)
-                except (json.JSONDecodeError, TypeError):
-                    continue
-
-                if event_data.get("errors"):
-                    logger.error(
-                        "Alert rule validation error on relation %s: %s",
-                        relation.id,
-                        event_data["errors"],
-                    )
-                    return True
-
-        return False
+        return self.metrics_consumer.has_invalid_alert_rules() or (
+            self.remote_write_provider.has_invalid_alert_rules()
+        )
 
     def _has_scrape_job_errors(self) -> bool:
         """Check if any metrics-endpoint relation reported scrape job validation errors."""
-        for relation in self.model.relations.get(DEFAULT_METRICS_RELATION_NAME, []):
-            app_data = relation.data.get(self.app)
-            if not app_data:
-                continue
-
-            event_raw = app_data.get("event", "{}")
-            try:
-                event_data = json.loads(event_raw)
-            except (json.JSONDecodeError, TypeError):
-                continue
-
-            if event_data.get("scrape_job_errors"):
-                logger.error(
-                    "Scrape job validation error on relation %s: %s",
-                    relation.id,
-                    event_data["scrape_job_errors"],
-                )
-                return True
-
-        return False
+        return self.metrics_consumer.has_invalid_scrape_jobs()
 
     def _push_alert_rules(self, alerts):
         """Pushes alert rules from a rules file to the prometheus container.


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
https://github.com/canonical/prometheus-k8s-operator/pull/817/changes introduced the mechanism for blocking when there are invalid alert rules over `prometheus_scrape` or `prometheus_remote_write`. This PR adds helpers to this charm so that the library provides the helpers for checking whether any validation errors exist. This way charms avoid needing to implement that, see [here](https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/341/changes#r3735823382).

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
