### PR TITLE
fix: leader guard for _has_relation_error

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 64
+LIBPATCH = 65
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -1402,6 +1402,9 @@ class MetricsEndpointConsumer(Object):
             True if any related metrics provider reported the validation error,
             False otherwise.
         """
+        if not self._charm.unit.is_leader():
+            return False
+
         for relation in self._charm.model.relations.get(self._relation_name, []):
             app_data = relation.data.get(self._charm.app)
             if not app_data:

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -44,7 +44,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 17
+LIBPATCH = 18
 
 PYDEPS = ["cosl"]
 
@@ -999,6 +999,9 @@ class PrometheusRemoteWriteProvider(Object):
             True if any related consumer reported the validation error,
             False otherwise.
         """
+        if not self._charm.unit.is_leader():
+            return False
+
         for relation in self._charm.model.relations.get(self._relation_name, []):
             app_data = relation.data.get(self._charm.app)
             if not app_data:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Small fix on top of #851.

#851 moved two methods to the scrape and remote write libs. In Prometheus, those helpers don't need leader guards since Prometheus is always a single unit. However, since we're moving these methods to the lib, we should still add a leader guard since Mimir will be using the same methods.

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
