### PR TITLE
feat: Alert Knob

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -258,7 +258,59 @@ config:
     alert_rule_customizations:
       type: string
       description: |
-        A YAML object that allows customizing the built-in Prometheus alert rules.
+        A YAML string for customizing the alert rules that Prometheus receives from any
+        connected application via the ``metrics-endpoint`` or ``receive-remote-write``
+        relations. Three top-level operations are supported: ``remove``, ``patch``, and
+        ``add``. All three are optional and can be combined freely.
+
+        **remove** — drop matching alerting rules (or entire groups).
+        Each entry requires a ``where`` selector. When a group is targeted by a
+        group-only selector, the entire group (including any recording rules) is dropped.
+        Otherwise only alerting rules are removed; recording rules are left untouched.
+
+        **patch** — merge a ``set`` block into every matching alerting rule.
+        Each entry requires both a ``where`` selector and a ``set`` block.
+        The ``set`` block may override ``alert``, ``expr``, ``for``, and/or merge into
+        ``labels`` / ``annotations`` (existing keys are overwritten; new keys are added).
+
+        **add** — insert operator-authored rule groups into Prometheus.
+        The ``add`` block must contain a ``groups`` list following the standard Prometheus
+        rule file format. These groups are written under a fixed identifier
+        (``custom_alert_rules``). Juju topology labels are NOT injected automatically;
+        include the relevant matchers in your expressions and labels manually.
+
+        **where selector fields** (AND across fields; multiple list entries are OR'd):
+          - ``alert``: exact match on the alert name
+          - ``group``: exact match on the group name
+          - ``labels``: every key-value pair must be present in the rule's labels
+          - ``annotations``: every key-value pair must be present in the rule's annotations
+
+        Example:
+
+          remove:
+            - where:
+                alert: TargetDown
+            - where:
+                labels:
+                  juju_application: noisy-exporter
+
+          patch:
+            - where:
+                alert: HighLatency
+              set:
+                for: 30m
+                labels:
+                  severity: warning
+
+          add:
+            groups:
+              - name: custom-alerts
+                rules:
+                  - alert: MyCustomAlert
+                    expr: up{juju_model="prod", juju_application="myapp"} == 0
+                    for: 1m
+                    annotations:
+                      summary: "Custom alert triggered"
 
 actions:
   validate-configuration:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -255,6 +255,11 @@ config:
        Ref: https://prometheus.io/docs/prometheus/latest/feature_flags/#exemplars-storage
       type: int
 
+    alert_rule_customizations:
+      type: string
+      description: |
+        A YAML object that allows customizing the built-in Prometheus alert rules.
+
 actions:
   validate-configuration:
     description: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = "~=3.14.0"
 dependencies = [
   "ops[tracing]",
   "pyyaml",
-  "cosl",
+  "cosl@git+https://github.com/canonical/cos-lib.git@feat/rules-customization",
   "lightkube>=0.11",
   "lightkube-models>=1.22.0.4",
   "httpx>=0.27",

--- a/src/charm.py
+++ b/src/charm.py
@@ -55,7 +55,7 @@ from charms.traefik_k8s.v1.ingress_per_unit import (
     IngressPerUnitRequirer,
     IngressPerUnitRevokedForUnitEvent,
 )
-from cosl import JujuTopology
+from cosl import JujuTopology, AlertRulesCustomization, AlertRulesCustomizationError
 from cosl.interfaces.datasource_exchange import DatasourceDict, DatasourceExchange
 from cosl.time_validation import is_valid_timespec
 from lightkube.core.client import Client
@@ -129,6 +129,7 @@ class CompositeStatus(TypedDict):
     config: Tuple[str, str]
     alert_rules: Tuple[str, str]
     scrape_jobs: Tuple[str, str]
+    alert_rules_customizations: Tuple[str, str]
 
 
 def to_tuple(status: StatusBase) -> Tuple[str, str]:
@@ -170,6 +171,7 @@ class PrometheusCharm(CharmBase):
                 config=to_tuple(ActiveStatus()),
                 alert_rules=to_tuple(ActiveStatus()),
                 scrape_jobs=to_tuple(ActiveStatus()),
+                alert_rules_customizations=to_tuple(ActiveStatus()),
             )
         )
 
@@ -813,15 +815,28 @@ class PrometheusCharm(CharmBase):
 
         Returns: A boolean indicating if new or different alert rules were pushed.
         """
+        try:
+            customization = AlertRulesCustomization.from_yaml(self.model.config["alert_rule_customizations"])
+        except Exception as e:
+            logger.error("Failed to parse alert rule customizations: %s", e)
+            self._stored.status["scrape_jobs"] = to_tuple(BlockedStatus("Invalid alert rule customizations. See debug-log"))
+            return False
+
         metrics_consumer_alerts = self.metrics_consumer.alerts
         remote_write_alerts = self.remote_write_provider.alerts
-        alerts_hash = sha256(str(metrics_consumer_alerts) + str(remote_write_alerts))
+
+        # The two rule sets being customized are guaranteed to be valid.
+        # The libs are responsible for returning only valid rules.
+        rendered_metrics_consumer_alerts = customization.apply(metrics_consumer_alerts)
+        rendered_remote_write_alerts = customization.apply(remote_write_alerts)
+    
+        alerts_hash = sha256(str(rendered_metrics_consumer_alerts) + str(rendered_remote_write_alerts))
         alert_rules_changed = alerts_hash != self._pull(ALERTS_HASH_PATH)
 
         if alert_rules_changed:
             self.container.remove_path(RULES_DIR, recursive=True)
-            self._push_alert_rules(metrics_consumer_alerts)
-            self._push_alert_rules(remote_write_alerts)
+            self._push_alert_rules(rendered_metrics_consumer_alerts)
+            self._push_alert_rules(rendered_remote_write_alerts)
             self._push(ALERTS_HASH_PATH, alerts_hash)
 
         if self._has_alert_rule_errors():

--- a/src/charm.py
+++ b/src/charm.py
@@ -55,7 +55,7 @@ from charms.traefik_k8s.v1.ingress_per_unit import (
     IngressPerUnitRequirer,
     IngressPerUnitRevokedForUnitEvent,
 )
-from cosl import AlertRulesCustomization, JujuTopology
+from cosl import AlertRulesCustomization, AlertRulesCustomizationError, JujuTopology
 from cosl.interfaces.datasource_exchange import DatasourceDict, DatasourceExchange
 from cosl.time_validation import is_valid_timespec
 from lightkube.core.client import Client
@@ -819,26 +819,29 @@ class PrometheusCharm(CharmBase):
             customization = AlertRulesCustomization.from_yaml(
                 cast(str, self.model.config.get("alert_rule_customizations") or "")
             )
-        except Exception as e:
-            logger.error("Failed to parse alert rule customizations: %s", e)
-            self._stored.status["alert_rules_customizations"] = to_tuple(BlockedStatus("Invalid alert rule customizations. See debug-log"))
-            return False
+            self._stored.status["alert_rules_customizations"] = to_tuple(ActiveStatus())
+        except AlertRulesCustomizationError as e:
+            logger.error("An error occurred while parsing alert rule customizations: %s", e)
+            self._stored.status["alert_rules_customizations"] = to_tuple(
+                BlockedStatus("Invalid alert rule customizations. See debug-log")
+            )
+            customization = AlertRulesCustomization()  # no-op: write rules unmodified
 
         metrics_consumer_alerts = self.metrics_consumer.alerts
         remote_write_alerts = self.remote_write_provider.alerts
 
         # The two rule sets being customized are guaranteed to be valid.
         # The libs are responsible for returning only valid rules.
-        rendered_metrics_consumer_alerts = customization.apply(metrics_consumer_alerts)
-        rendered_remote_write_alerts = customization.apply(remote_write_alerts)
+        metrics_consumer_alerts = customization.apply(metrics_consumer_alerts)
+        remote_write_alerts = customization.apply(remote_write_alerts)
 
-        alerts_hash = sha256(str(rendered_metrics_consumer_alerts) + str(rendered_remote_write_alerts))
+        alerts_hash = sha256(str(metrics_consumer_alerts) + str(remote_write_alerts))
         alert_rules_changed = alerts_hash != self._pull(ALERTS_HASH_PATH)
 
         if alert_rules_changed:
             self.container.remove_path(RULES_DIR, recursive=True)
-            self._push_alert_rules(rendered_metrics_consumer_alerts)
-            self._push_alert_rules(rendered_remote_write_alerts)
+            self._push_alert_rules(metrics_consumer_alerts)
+            self._push_alert_rules(remote_write_alerts)
             self._push(ALERTS_HASH_PATH, alerts_hash)
 
         if self._has_alert_rule_errors():

--- a/src/charm.py
+++ b/src/charm.py
@@ -55,7 +55,7 @@ from charms.traefik_k8s.v1.ingress_per_unit import (
     IngressPerUnitRequirer,
     IngressPerUnitRevokedForUnitEvent,
 )
-from cosl import JujuTopology, AlertRulesCustomization, AlertRulesCustomizationError
+from cosl import AlertRulesCustomization, JujuTopology
 from cosl.interfaces.datasource_exchange import DatasourceDict, DatasourceExchange
 from cosl.time_validation import is_valid_timespec
 from lightkube.core.client import Client
@@ -816,10 +816,12 @@ class PrometheusCharm(CharmBase):
         Returns: A boolean indicating if new or different alert rules were pushed.
         """
         try:
-            customization = AlertRulesCustomization.from_yaml(self.model.config["alert_rule_customizations"])
+            customization = AlertRulesCustomization.from_yaml(
+                cast(str, self.model.config.get("alert_rule_customizations") or "")
+            )
         except Exception as e:
             logger.error("Failed to parse alert rule customizations: %s", e)
-            self._stored.status["scrape_jobs"] = to_tuple(BlockedStatus("Invalid alert rule customizations. See debug-log"))
+            self._stored.status["alert_rules_customizations"] = to_tuple(BlockedStatus("Invalid alert rule customizations. See debug-log"))
             return False
 
         metrics_consumer_alerts = self.metrics_consumer.alerts
@@ -829,7 +831,7 @@ class PrometheusCharm(CharmBase):
         # The libs are responsible for returning only valid rules.
         rendered_metrics_consumer_alerts = customization.apply(metrics_consumer_alerts)
         rendered_remote_write_alerts = customization.apply(remote_write_alerts)
-    
+
         alerts_hash = sha256(str(rendered_metrics_consumer_alerts) + str(rendered_remote_write_alerts))
         alert_rules_changed = alerts_hash != self._pull(ALERTS_HASH_PATH)
 

--- a/tests/unit/test_alert_rule_customizations.py
+++ b/tests/unit/test_alert_rule_customizations.py
@@ -1,0 +1,857 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for the alert_rule_customizations charm config option.
+
+Each test:
+  1. Provides alert rules to Prometheus via relation data (metrics-endpoint and/or
+     receive-remote-write).
+  2. Sets the ``alert_rule_customizations`` config option.
+  3. Fires ``config_changed``.
+  4. Reads the rules files written to the virtual Prometheus filesystem and asserts
+     that the remove / patch / add operations have been applied correctly.
+"""
+
+import json
+from typing import Any, Dict, List, Set
+
+import yaml
+from ops.model import ActiveStatus, BlockedStatus
+from scenario import Relation, State
+
+from charm import to_status
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _alert_rules_json(groups: List[Dict[str, Any]]) -> str:
+    """Serialise a list of groups into the JSON format expected in relation data."""
+    return json.dumps({"groups": groups})
+
+
+def _metadata_json(app_name: str) -> str:
+    return json.dumps(
+        {
+            "model": "test-model",
+            "model_uuid": "20ce8299-3634-4bef-8bd8-5ace6c881234",
+            "application": app_name,
+            "charm_name": f"{app_name}-charm",
+        }
+    )
+
+
+def _make_scrape_relation(app_name: str, groups: List[Dict[str, Any]]) -> Relation:
+    """Build a metrics-endpoint relation carrying the given rule groups."""
+    return Relation(
+        "metrics-endpoint",
+        remote_app_name=app_name,
+        remote_app_data={
+            "alert_rules": _alert_rules_json(groups),
+            "scrape_metadata": _metadata_json(app_name),
+        },
+    )
+
+
+def _make_remote_write_relation(app_name: str, groups: List[Dict[str, Any]]) -> Relation:
+    """Build a receive-remote-write relation carrying the given rule groups."""
+    return Relation(
+        "receive-remote-write",
+        remote_app_name=app_name,
+        remote_app_data={
+            "alert_rules": _alert_rules_json(groups),
+            "scrape_metadata": _metadata_json(app_name),
+        },
+    )
+
+
+def _read_all_rules(context, state_out) -> Dict[str, List[Dict[str, Any]]]:
+    """Return all alert rules written to /etc/prometheus/rules/.
+
+    Returns a mapping of  group_name -> list[rule_dict].
+    """
+    fs = state_out.get_container("prometheus").get_filesystem(context)
+    rules_dir = fs / "etc" / "prometheus" / "rules"
+    if not rules_dir.exists():
+        return {}
+
+    result: Dict[str, List[Dict[str, Any]]] = {}
+    for rule_file in sorted(path for path in rules_dir.iterdir() if path.is_file()):
+        data = yaml.safe_load(rule_file.read_text())
+        for group in data.get("groups", []):
+            result[group["name"]] = group.get("rules", [])
+    return result
+
+
+def _alert_names_in_group(rules_by_group: Dict[str, List[Dict[str, Any]]], group_name: str) -> Set[str]:
+    return {r["alert"] for r in rules_by_group.get(group_name, []) if "alert" in r}
+
+
+def _customization_status(state_out) -> Any:
+    """Return the charm's ``alert_rules_customizations`` stored-state status."""
+    charm_stored = next(
+        s for s in state_out.stored_states if s.owner_path == "PrometheusCharm"
+    )
+    return to_status(charm_stored.content["status"]["alert_rules_customizations"])
+
+
+# ---------------------------------------------------------------------------
+# Shared rule fixtures
+# ---------------------------------------------------------------------------
+
+RULE_ALPHA = {
+    "alert": "AlphaFiring",
+    "expr": 'up{job="alpha"} == 0',
+    "for": "5m",
+    "labels": {"severity": "critical", "juju_application": "app-alpha"},
+    "annotations": {"summary": "Alpha is down"},
+}
+
+RULE_BETA = {
+    "alert": "BetaFiring",
+    "expr": 'up{job="beta"} == 0',
+    "for": "2m",
+    "labels": {"severity": "warning", "juju_application": "app-beta"},
+    "annotations": {"summary": "Beta is degraded"},
+}
+
+RULE_GAMMA = {
+    "alert": "GammaFiring",
+    "expr": 'rate(errors_total[5m]) > 0',
+    "for": "1m",
+    "labels": {"severity": "warning"},
+    "annotations": {"summary": "Gamma has errors"},
+}
+
+GROUP_MAIN = {"name": "main-group", "rules": [RULE_ALPHA, RULE_BETA]}
+GROUP_SECONDARY = {"name": "secondary-group", "rules": [RULE_GAMMA]}
+
+
+# ---------------------------------------------------------------------------
+# Tests: remove
+# ---------------------------------------------------------------------------
+
+
+def test_remove_by_alert_name(context, prometheus_container):
+    """Removing by alert name deletes that rule; the sibling rule in the same group survives."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": "remove:\n  - where:\n      alert: AlphaFiring\n"
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    assert "AlphaFiring" not in _alert_names_in_group(rules, "main-group")
+    assert "BetaFiring" in _alert_names_in_group(rules, "main-group")
+
+
+def test_remove_by_label(context, prometheus_container):
+    """Removing by label key-value deletes every matching rule."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "remove:\n"
+                "  - where:\n"
+                "      labels:\n"
+                "        juju_application: app-alpha\n"
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    assert "AlphaFiring" not in _alert_names_in_group(rules, "main-group")
+    assert "BetaFiring" in _alert_names_in_group(rules, "main-group")
+
+
+def test_remove_by_alert_and_label_and_semantics(context, prometheus_container):
+    """All fields in a where block are ANDed: only rules matching both conditions are removed."""
+    # Both RULE_ALPHA and RULE_BETA share severity=warning… but RULE_ALPHA has severity=critical.
+    # Selector: alert=BetaFiring AND labels.severity=warning → only BetaFiring should be removed.
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "remove:\n"
+                "  - where:\n"
+                "      alert: BetaFiring\n"
+                "      labels:\n"
+                "        severity: warning\n"
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    assert "AlphaFiring" in _alert_names_in_group(rules, "main-group")
+    assert "BetaFiring" not in _alert_names_in_group(rules, "main-group")
+
+
+def test_remove_entire_group_by_group_selector(context, prometheus_container):
+    """A group-only where selector drops the complete group."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN, GROUP_SECONDARY])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "remove:\n"
+                "  - where:\n"
+                "      group: main-group\n"
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    assert "main-group" not in rules
+    assert "secondary-group" in rules
+
+
+def test_remove_last_rule_in_group_prunes_empty_group(context, prometheus_container):
+    """When the only rule in a group is removed, the group itself is pruned from the output."""
+    relation = _make_scrape_relation("myapp", [GROUP_SECONDARY])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "remove:\n"
+                "  - where:\n"
+                "      alert: GammaFiring\n"
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    assert "secondary-group" not in rules
+
+
+def test_remove_nonexistent_rule_is_noop(context, prometheus_container):
+    """A where selector that matches nothing leaves all rules unchanged."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "remove:\n"
+                "  - where:\n"
+                "      alert: TotallyMadeUpAlert\n"
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    assert _alert_names_in_group(rules, "main-group") == {"AlphaFiring", "BetaFiring"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: patch
+# ---------------------------------------------------------------------------
+
+
+def test_patch_for_field(context, prometheus_container):
+    """Patching the 'for' field on a matched rule updates the duration on disk."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "patch:\n"
+                "  - where:\n"
+                "      alert: AlphaFiring\n"
+                "    set:\n"
+                "      for: 30m\n"
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    alpha_rule = next(r for r in rules["main-group"] if r.get("alert") == "AlphaFiring")
+    assert alpha_rule["for"] == "30m"
+    # Other rules are not affected.
+    beta_rule = next(r for r in rules["main-group"] if r.get("alert") == "BetaFiring")
+    assert beta_rule["for"] == "2m"
+
+
+def test_patch_expr_field(context, prometheus_container):
+    """Patching the 'expr' field replaces the full PromQL expression on disk."""
+    new_expr = 'up{job="alpha", env="prod"} == 0'
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "patch:\n"
+                "  - where:\n"
+                "      alert: AlphaFiring\n"
+                "    set:\n"
+                '      expr: \'up{job="alpha", env="prod"} == 0\'\n'
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    alpha_rule = next(r for r in rules["main-group"] if r.get("alert") == "AlphaFiring")
+    assert alpha_rule["expr"] == new_expr
+
+
+def test_patch_adds_new_label(context, prometheus_container):
+    """A 'set.labels' entry that contains a new key merges it into the rule's labels."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "patch:\n"
+                "  - where:\n"
+                "      alert: AlphaFiring\n"
+                "    set:\n"
+                "      labels:\n"
+                "        team: platform\n"
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    alpha_rule = next(r for r in rules["main-group"] if r.get("alert") == "AlphaFiring")
+    assert alpha_rule["labels"]["team"] == "platform"
+    # Pre-existing labels are preserved.
+    assert alpha_rule["labels"]["severity"] == "critical"
+
+
+def test_patch_overwrites_existing_label(context, prometheus_container):
+    """A 'set.labels' entry with an existing key overwrites its value."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "patch:\n"
+                "  - where:\n"
+                "      alert: AlphaFiring\n"
+                "    set:\n"
+                "      labels:\n"
+                "        severity: info\n"
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    alpha_rule = next(r for r in rules["main-group"] if r.get("alert") == "AlphaFiring")
+    assert alpha_rule["labels"]["severity"] == "info"
+
+
+def test_patch_by_label_selector(context, prometheus_container):
+    """Matching via where.labels targets only the rule(s) that carry those labels."""
+    # RULE_BETA has severity=warning; RULE_ALPHA has severity=critical.
+    # Patch by severity=warning should only touch RULE_BETA.
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "patch:\n"
+                "  - where:\n"
+                "      labels:\n"
+                "        severity: warning\n"
+                "    set:\n"
+                "      for: 10m\n"
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    beta_rule = next(r for r in rules["main-group"] if r.get("alert") == "BetaFiring")
+    alpha_rule = next(r for r in rules["main-group"] if r.get("alert") == "AlphaFiring")
+    assert beta_rule["for"] == "10m"
+    assert alpha_rule["for"] == "5m"  # Unchanged.
+
+
+def test_patch_multiple_operations_each_applied(context, prometheus_container):
+    """Two patch entries with distinct where selectors are each applied to their target rule."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "patch:\n"
+                "  - where:\n"
+                "      alert: AlphaFiring\n"
+                "    set:\n"
+                "      for: 15m\n"
+                "  - where:\n"
+                "      alert: BetaFiring\n"
+                "    set:\n"
+                "      for: 20m\n"
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    alpha_rule = next(r for r in rules["main-group"] if r.get("alert") == "AlphaFiring")
+    beta_rule = next(r for r in rules["main-group"] if r.get("alert") == "BetaFiring")
+    assert alpha_rule["for"] == "15m"
+    assert beta_rule["for"] == "20m"
+
+
+# ---------------------------------------------------------------------------
+# Tests: add
+# ---------------------------------------------------------------------------
+
+
+def test_add_single_group(context, prometheus_container):
+    """An 'add' block with one group is written to the custom_alert_rules file."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "add:\n"
+                "  groups:\n"
+                "    - name: custom-alerts\n"
+                "      rules:\n"
+                "        - alert: MyCustomAlert\n"
+                '          expr: \'up{juju_model="prod"} == 0\'\n'
+                "          for: 1m\n"
+                "          annotations:\n"
+                '            summary: "Custom alert triggered"\n'
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    assert "custom-alerts" in rules
+    assert _alert_names_in_group(rules, "custom-alerts") == {"MyCustomAlert"}
+    custom_rule = rules["custom-alerts"][0]
+    assert custom_rule["annotations"]["summary"] == "Custom alert triggered"
+
+
+def test_add_multiple_groups(context, prometheus_container):
+    """An 'add' block with multiple groups writes all of them to the custom file."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "add:\n"
+                "  groups:\n"
+                "    - name: custom-group-one\n"
+                "      rules:\n"
+                "        - alert: CustomAlertOne\n"
+                '          expr: up > 0\n'
+                "          annotations:\n"
+                '            summary: "One"\n'
+                "    - name: custom-group-two\n"
+                "      rules:\n"
+                "        - alert: CustomAlertTwo\n"
+                '          expr: up > 1\n'
+                "          annotations:\n"
+                '            summary: "Two"\n'
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    assert "custom-group-one" in rules
+    assert "custom-group-two" in rules
+    assert _alert_names_in_group(rules, "custom-group-one") == {"CustomAlertOne"}
+    assert _alert_names_in_group(rules, "custom-group-two") == {"CustomAlertTwo"}
+
+
+def test_add_without_relation_rules(context, prometheus_container):
+    """The 'add' block works even when no metrics-endpoint or remote-write relations exist."""
+    state_in = State(
+        leader=True,
+        relations=[],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "add:\n"
+                "  groups:\n"
+                "    - name: standalone-custom\n"
+                "      rules:\n"
+                "        - alert: StandaloneAlert\n"
+                '          expr: up == 0\n'
+                "          annotations:\n"
+                '            summary: "No relations needed"\n'
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    assert "standalone-custom" in rules
+    assert _alert_names_in_group(rules, "standalone-custom") == {"StandaloneAlert"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: combined operations
+# ---------------------------------------------------------------------------
+
+
+def test_remove_and_add_combined(context, prometheus_container):
+    """Remove drops a relation rule while add injects a new custom group; both take effect."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "remove:\n"
+                "  - where:\n"
+                "      alert: AlphaFiring\n"
+                "add:\n"
+                "  groups:\n"
+                "    - name: injected-group\n"
+                "      rules:\n"
+                "        - alert: InjectedAlert\n"
+                '          expr: up == 0\n'
+                "          annotations:\n"
+                '            summary: "Injected"\n'
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    assert "AlphaFiring" not in _alert_names_in_group(rules, "main-group")
+    assert "BetaFiring" in _alert_names_in_group(rules, "main-group")
+    assert "InjectedAlert" in _alert_names_in_group(rules, "injected-group")
+
+
+def test_remove_and_patch_combined(context, prometheus_container):
+    """Remove one rule and patch a different rule in the same group; both effects are visible."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "remove:\n"
+                "  - where:\n"
+                "      alert: AlphaFiring\n"
+                "patch:\n"
+                "  - where:\n"
+                "      alert: BetaFiring\n"
+                "    set:\n"
+                "      for: 25m\n"
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    assert "AlphaFiring" not in _alert_names_in_group(rules, "main-group")
+    beta_rule = next(r for r in rules["main-group"] if r.get("alert") == "BetaFiring")
+    assert beta_rule["for"] == "25m"
+
+
+def test_patch_and_add_combined(context, prometheus_container):
+    """Patching a rule's expr and adding a custom group are both reflected on disk."""
+    new_expr = 'up{job="alpha", env="staging"} == 0'
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "patch:\n"
+                "  - where:\n"
+                "      alert: AlphaFiring\n"
+                "    set:\n"
+                '      expr: \'up{job="alpha", env="staging"} == 0\'\n'
+                "add:\n"
+                "  groups:\n"
+                "    - name: extra-group\n"
+                "      rules:\n"
+                "        - alert: ExtraAlert\n"
+                '          expr: up > 0\n'
+                "          annotations:\n"
+                '            summary: "Extra"\n'
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    alpha_rule = next(r for r in rules["main-group"] if r.get("alert") == "AlphaFiring")
+    assert alpha_rule["expr"] == new_expr
+    assert "ExtraAlert" in _alert_names_in_group(rules, "extra-group")
+
+
+def test_all_three_operations_combined(context, prometheus_container):
+    """Full scenario: remove one rule, patch another, and add a custom group.
+
+    This mirrors the manual test documented in the PR description.
+    """
+    group_with_three_rules = {
+        "name": "loki-alerts",
+        "rules": [
+            {
+                "alert": "LokiRequestLatency",
+                "expr": 'histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[5m])) by (le)) > 1',
+                "for": "5m",
+                "labels": {"severity": "warning", "juju_application": "loki"},
+                "annotations": {"summary": "Loki request latency is high"},
+            },
+            {
+                "alert": "LokiRequestPanic",
+                "expr": 'sum(increase(loki_panic_total[5m])) > 0',
+                "for": "5m",
+                "labels": {"severity": "critical"},
+                "annotations": {"summary": "Loki panicked"},
+            },
+            {
+                "alert": "LokiRequestErrors",
+                "expr": 'sum(rate(loki_request_duration_seconds_count{status_code=~"5.."}[5m])) > 0',
+                "for": "5m",
+                "labels": {"severity": "warning"},
+                "annotations": {"summary": "Loki request errors"},
+            },
+        ],
+    }
+    app_with_label = {
+        "name": "other-group",
+        "rules": [
+            {
+                "alert": "HighLatency",
+                "expr": 'up == 0',
+                "for": "1m",
+                "labels": {"severity": "critical", "juju_application": "avalanche-k8s"},
+                "annotations": {"summary": "High latency"},
+            }
+        ],
+    }
+
+    relation = _make_scrape_relation("loki", [group_with_three_rules, app_with_label])
+
+    new_expr = (
+        'sum by (namespace, job) '
+        '(increase(loki_panic_total{juju_application="loki",juju_model="test"}[30m])) > 0'
+    )
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "remove:\n"
+                "  - where:\n"
+                "      alert: LokiRequestLatency\n"
+                "  - where:\n"
+                "      labels:\n"
+                "        juju_application: avalanche-k8s\n"
+                "patch:\n"
+                "  - where:\n"
+                "      alert: LokiRequestPanic\n"
+                "    set:\n"
+                "      for: 30m\n"
+                f"      expr: '{new_expr}'\n"
+                "      labels:\n"
+                "        some_label: some_value\n"
+                "add:\n"
+                "  groups:\n"
+                "    - name: custom-alerts\n"
+                "      rules:\n"
+                "        - alert: MyCustomAlert\n"
+                '          expr: \'up{juju_model="prod"} == 0\'\n'
+                "          for: 1m\n"
+                "          annotations:\n"
+                '            summary: "Custom alert triggered"\n'
+                "        - alert: MyOtherCustomAlert\n"
+                '          expr: \'up{juju_model="staging"} < 1\'\n'
+                "          annotations:\n"
+                '            summary: "Some high priority issue"\n'
+                "    - name: my-other-custom-alerts\n"
+                "      rules:\n"
+                "        - alert: MyThirdAlert\n"
+                "          expr: up > 0\n"
+                "          annotations:\n"
+                '            summary: "Something happened"\n'
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+
+    # LokiRequestLatency must be removed.
+    assert "LokiRequestLatency" not in _alert_names_in_group(rules, "loki-alerts")
+
+    # The rule with juju_application=avalanche-k8s must be removed
+    # (entire other-group is pruned since it had only that rule).
+    assert "other-group" not in rules
+
+    # LokiRequestPanic must be patched.
+    panic_rule = next(r for r in rules["loki-alerts"] if r.get("alert") == "LokiRequestPanic")
+    assert panic_rule["for"] == "30m"
+    assert panic_rule["expr"] == new_expr
+    assert panic_rule["labels"]["some_label"] == "some_value"
+
+    # LokiRequestErrors must be untouched.
+    assert "LokiRequestErrors" in _alert_names_in_group(rules, "loki-alerts")
+
+    # Custom groups must be present.
+    assert _alert_names_in_group(rules, "custom-alerts") == {"MyCustomAlert", "MyOtherCustomAlert"}
+    assert _alert_names_in_group(rules, "my-other-custom-alerts") == {"MyThirdAlert"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: error handling and edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_yaml_config_sets_blocked_status(context, prometheus_container):
+    """Malformed YAML in alert_rule_customizations causes a BlockedStatus (not a crash)."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": "remove: [unclosed bracket"
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    assert isinstance(_customization_status(state_out), BlockedStatus)
+
+
+def test_unknown_top_level_key_sets_blocked_status(context, prometheus_container):
+    """A config with an unrecognised top-level key (e.g. 'replace') causes BlockedStatus."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "replace:\n"
+                "  - where:\n"
+                "      alert: AlphaFiring\n"
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    assert isinstance(_customization_status(state_out), BlockedStatus)
+
+
+def test_empty_config_is_noop(context, prometheus_container):
+    """An empty alert_rule_customizations string is a no-op; rules are written as normal."""
+    relation = _make_scrape_relation("myapp", [GROUP_MAIN])
+    state_in = State(
+        leader=True,
+        relations=[relation],
+        containers=[prometheus_container],
+        config={"alert_rule_customizations": ""},
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    assert _alert_names_in_group(rules, "main-group") == {"AlphaFiring", "BetaFiring"}
+    assert isinstance(_customization_status(state_out), ActiveStatus)
+
+
+def test_customizations_apply_to_both_relation_endpoints(context, prometheus_container):
+    """A remove operation affects rules coming from both metrics-endpoint and receive-remote-write."""
+    # Both relations provide a rule named "AlphaFiring" in different groups.
+    scrape_relation = _make_scrape_relation(
+        "scrape-app",
+        [{"name": "scrape-group", "rules": [RULE_ALPHA, RULE_BETA]}],
+    )
+    remote_write_relation = _make_remote_write_relation(
+        "rw-app",
+        [{"name": "rw-group", "rules": [RULE_ALPHA, RULE_GAMMA]}],
+    )
+    state_in = State(
+        leader=True,
+        relations=[scrape_relation, remote_write_relation],
+        containers=[prometheus_container],
+        config={
+            "alert_rule_customizations": (
+                "remove:\n"
+                "  - where:\n"
+                "      alert: AlphaFiring\n"
+            )
+        },
+    )
+
+    state_out = context.run(context.on.config_changed(), state_in)
+
+    rules = _read_all_rules(context, state_out)
+    # AlphaFiring removed from scrape group.
+    assert "AlphaFiring" not in _alert_names_in_group(rules, "scrape-group")
+    assert "BetaFiring" in _alert_names_in_group(rules, "scrape-group")
+    # AlphaFiring removed from remote-write group.
+    assert "AlphaFiring" not in _alert_names_in_group(rules, "rw-group")
+    assert "GammaFiring" in _alert_names_in_group(rules, "rw-group")

--- a/tests/unit/test_alert_rule_customizations.py
+++ b/tests/unit/test_alert_rule_customizations.py
@@ -768,7 +768,7 @@ def test_all_three_operations_combined(context, prometheus_container):
 
 
 def test_invalid_yaml_config_sets_blocked_status(context, prometheus_container):
-    """Malformed YAML in alert_rule_customizations causes a BlockedStatus (not a crash)."""
+    """Malformed YAML in alert_rule_customizations causes BlockedStatus but rules are still written."""
     relation = _make_scrape_relation("myapp", [GROUP_MAIN])
     state_in = State(
         leader=True,
@@ -781,11 +781,15 @@ def test_invalid_yaml_config_sets_blocked_status(context, prometheus_container):
 
     state_out = context.run(context.on.config_changed(), state_in)
 
+    # Status must be blocked to signal the bad config.
     assert isinstance(_customization_status(state_out), BlockedStatus)
+    # Unmodified rules must still be written so alerting keeps working.
+    rules = _read_all_rules(context, state_out)
+    assert _alert_names_in_group(rules, "main-group") == {"AlphaFiring", "BetaFiring"}
 
 
 def test_unknown_top_level_key_sets_blocked_status(context, prometheus_container):
-    """A config with an unrecognised top-level key (e.g. 'replace') causes BlockedStatus."""
+    """A config with an unrecognised top-level key causes BlockedStatus but rules are still written."""
     relation = _make_scrape_relation("myapp", [GROUP_MAIN])
     state_in = State(
         leader=True,
@@ -802,7 +806,11 @@ def test_unknown_top_level_key_sets_blocked_status(context, prometheus_container
 
     state_out = context.run(context.on.config_changed(), state_in)
 
+    # Status must be blocked to signal the bad config.
     assert isinstance(_customization_status(state_out), BlockedStatus)
+    # Unmodified rules must still be written so alerting keeps working.
+    rules = _read_all_rules(context, state_out)
+    assert _alert_names_in_group(rules, "main-group") == {"AlphaFiring", "BetaFiring"}
 
 
 def test_empty_config_is_noop(context, prometheus_container):

--- a/uv.lock
+++ b/uv.lock
@@ -380,18 +380,15 @@ wheels = [
 
 [[package]]
 name = "cosl"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
+version = "1.10.3"
+source = { git = "https://github.com/canonical/cos-lib.git?rev=feat%2Frules-customization#f7d0cbba87c14a7697b104992db632171d0afe01" }
 dependencies = [
+    { name = "diskcache" },
     { name = "ops" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "tenacity" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/f1/6bc646976c499e9bb7a048ef17b6295f23b145f11f1cee4207ce10494342/cosl-1.9.1.tar.gz", hash = "sha256:80d899b5f278bf64252eb94bfb1bbd03dade5073c2cbc0ea43e9abc68be9ee1e", size = 150395, upload-time = "2026-03-31T12:50:20.064Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/1d/558af69f639d6772be034b13417a7bbeb92a56939f891493d1546e724213/cosl-1.9.1-py3-none-any.whl", hash = "sha256:201107a68f398b8a5f5e91f6dcaeb1777e7b2816a1592c8eea4a491d1750e1a6", size = 38217, upload-time = "2026-03-31T12:50:18.87Z" },
 ]
 
 [[package]]
@@ -521,6 +518,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f9/6b/6a4a5aaf38535eb332c2856aa08e73ed7c549d0851b1215401af0a2db1a7/deepdiff-9.1.0.tar.gz", hash = "sha256:07e9e366fab4297755153c4eab795ad4ef3cbd0d51660e847f5751c6bd727687", size = 382149, upload-time = "2026-05-15T20:18:05.751Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/26/4a2bad8eb430d8d805a4642c4bff25103a37548d74ab346f8b1e024abcc5/deepdiff-9.1.0-py3-none-any.whl", hash = "sha256:80c0460e1993b04f6f0ca79abf25548b129fd218478c4ebb08f80560f5d10610", size = 184662, upload-time = "2026-05-15T20:18:03.956Z" },
+]
+
+[[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
 ]
 
 [[package]]
@@ -1292,7 +1298,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'dev'" },
     { name = "codespell", marker = "extra == 'dev'" },
-    { name = "cosl" },
+    { name = "cosl", git = "https://github.com/canonical/cos-lib.git?rev=feat%2Frules-customization" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "cryptography" },
     { name = "deepdiff", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Based on changes in https://github.com/canonical/cos-lib/pull/205.

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
To test, first deploy the following bundle:
```yaml
bundle: kubernetes
applications:
  aval:
    charm: avalanche-k8s
    channel: dev/edge
    revision: 79
    base: ubuntu@26.04/stable
    resources:
      avalanche-image: 21
    scale: 1
    constraints: arch=amd64
  cos-config:
    charm: cos-configuration-k8s
    channel: dev/edge
    revision: 124
    base: ubuntu@26.04/stable
    resources:
      git-sync-image: 38
    scale: 1
    options:
      git_branch: main
      git_repo: https://github.com/sinapah/cos-config
      prometheus_alert_rules_path: prometheus_alert_rules
    constraints: arch=amd64
    storage:
      content-from-git: kubernetes,1,1024M
    trust: true
  loki:
    charm: loki-k8s
    channel: dev/edge
    revision: 250
    base: ubuntu@26.04/stable
    resources:
      loki-image: 105
      node-exporter-image: 4
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
  otelcol:
    charm: opentelemetry-collector-k8s
    channel: dev/edge
    revision: 238
    base: ubuntu@26.04/stable
    resources:
      opentelemetry-collector-image: 11
    scale: 1
    constraints: arch=amd64
    storage:
      persisted: kubernetes,1,1024M
    trust: true
  prom:
    charm: prometheus-k8s
    channel: dev/edge
    revision: 320
    base: ubuntu@26.04/stable
    resources:
      prometheus-image: 155
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  traefik:
    charm: traefik-k8s
    channel: latest/edge
    revision: 413
    base: ubuntu@20.04/stable
    resources:
      traefik-image: 174
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - otelcol:metrics-endpoint
  - aval:metrics-endpoint
- - otelcol:send-remote-write
  - prom:receive-remote-write
- - otelcol:metrics-endpoint
  - loki:metrics-endpoint
- - prom:ingress
  - traefik:ingress-per-unit
- - cos-config:send-remote-write
  - prom:receive-remote-write

```
You should then expect to see in Prometheus's `prometheus` container at `/etc/prometheus/rules`, the following file: `juju_test_a3ea41d9_otelcol.rules`. The content of the file should be:
```yaml
groups:
- name: test_a3ea41d9_otelcol_AggregatorHostHealth_rules
  rules:
  - alert: HostMetricsMissing
    annotations:
      description: '`Up` missing for unit ''{{ $labels.juju_unit }}'' of application
        {{ $labels.juju_application }} in model {{ $labels.juju_model }}. Please ensure
        the unit or the collector scraping it is up and is able to successfully reach
        the metrics backend.'
      summary: Unit '{{ $labels.juju_unit }}' of application '{{ $labels.juju_application
        }}' is down or failing to remote write.
    expr: absent(up{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3",juju_unit="otelcol/0"})
    for: 5m
    labels:
      juju_application: otelcol
      juju_charm: opentelemetry-collector-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      juju_unit: otelcol/0
      severity: warning
  - alert: AggregatorMetricsMissing
    annotations:
      description: '`Up` missing for ALL units of application {{ $labels.juju_application
        }} in model {{ $labels.juju_model }}. This can also mean the units or the
        collector scraping them are unable to reach the remote write endpoint of the
        metrics backend. Please ensure the correct firewall rules are applied.'
      summary: Metrics not received from application '{{ $labels.juju_application
        }}'. All units are down or failing to remote write.
    expr: absent(up{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"})
    for: 5m
    labels:
      juju_application: otelcol
      juju_charm: opentelemetry-collector-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: critical
- name: test_a3ea41d9_otelcol_prometheus_alerts_rules
  rules:
  - alert: PrometheusTargetDown
    annotations:
      description: At least one scrape target is down for {{ $labels.juju_application
        }}
      summary: Prometheus target is down
    expr: sum by (juju_application) (up{juju_application="prometheus-k8s",juju_model="observability",juju_model_uuid="e9f39fb5-e6ff-4e0c-82a5-712bdd7e1912"}
      == 0) > 0
    for: 15m
    labels:
      juju_application: prometheus-k8s
      juju_charm: opentelemetry-collector-k8s
      juju_model: observability
      juju_model_uuid: e9f39fb5-e6ff-4e0c-82a5-712bdd7e1912
      severity: critical
      team: observability
- name: test_a3ea41d9_aval_AlwaysFiringDueToAbsentMetric_rules
  rules:
  - alert: AlwaysFiringDueToAbsentMetric
    annotations:
      description: '{{ $labels.instance }} of job {{ $labels.job }} is firing the
        dummy alarm.'
      summary: Instance {{ $labels.instance }} dummy alarm (always firing)
    expr: absent(some_metric_name_that_shouldnt_exist{job="non_existing_job",juju_application="aval",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"})
    for: 0m
    labels:
      juju_application: aval
      juju_charm: avalanche-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: High
- name: test_a3ea41d9_aval_AlwaysFiringDueToNumericValue_rules
  rules:
  - alert: AlwaysFiringDueToNumericValue
    annotations:
      description: '{{ $labels.instance }} of job {{ $labels.job }} is firing the
        dummy alarm.'
      summary: Instance {{ $labels.instance }} dummy alarm (always firing)
    expr: avalanche_metric_mmmmm_0_0{juju_application="aval",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3",series_id="0"}
      > -1
    for: 0m
    labels:
      juju_application: aval
      juju_charm: avalanche-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: High
- name: test_a3ea41d9_aval_HostHealth_rules
  rules:
  - alert: HostDown
    annotations:
      description: Juju application '{{ $labels.juju_application }}' in model '{{
        $labels.juju_model }}' is down. Prometheus has been unable to scrape it during
        at least the past five minutes.
      summary: Host '{{ $labels.instance }}' is down.
    expr: up{juju_application="aval",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}
      < 1
    for: 5m
    labels:
      juju_application: aval
      juju_charm: avalanche-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: critical
  - alert: HostMetricsMissing
    annotations:
      description: '`Up` missing for unit ''{{ $labels.juju_unit }}'' of application
        {{ $labels.juju_application }} in model {{ $labels.juju_model }}. Please ensure
        the unit or the collector scraping it is up and is able to successfully reach
        the metrics backend.'
      summary: Unit '{{ $labels.juju_unit }}' of application '{{ $labels.juju_application
        }}' is down or failing to remote write.
    expr: absent(up{juju_application="aval",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"})
    for: 5m
    labels:
      juju_application: aval
      juju_charm: avalanche-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: warning
- name: test_a3ea41d9_loki_LokiDistributorFailures_rules
  rules:
  - alert: LokiDistributorRejectingLogs
    annotations:
      description: "The {{ $labels.job }} distributor is rejecting log entries on\
        \ route {{ $labels.route }} due to {{ $labels.reason }}\n  Rate = {{ printf\
        \ \"%.2f\" $value }}/s\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
      summary: Loki distributor rejecting logs on route {{ $labels.route }} (job {{
        $labels.job }})
    expr: sum by (namespace, job, route, reason) (rate(loki_distributor_rejected_requests_total{juju_application="loki",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
      > 0.1
    for: 5m
    labels:
      juju_application: loki
      juju_charm: loki-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: warning
- name: test_a3ea41d9_loki_LokiProcessTooManyRestarts_rules
  rules:
  - alert: LokiProcessTooManyRestarts
    annotations:
      description: "A loki process had too many restarts (target {{ $labels.instance\
        \ }})\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
      summary: Loki process too many restarts (instance {{ $labels.instance }})
    expr: changes(process_start_time_seconds{juju_application="loki",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[15m])
      > 5
    for: 0m
    labels:
      juju_application: loki
      juju_charm: loki-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: warning
- name: test_a3ea41d9_loki_LokiRequestErrors_rules
  rules:
  - alert: LokiRequestErrors
    annotations:
      description: "The {{ $labels.job }} and {{ $labels.route }} are experiencing\
        \ errors\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
      summary: Loki request errors (instance {{ $labels.instance }})
    expr: 100 * sum by (namespace, job, route) (rate(loki_request_duration_seconds_count{juju_application="loki",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3",status_code=~"5.."}[1m]))
      / sum by (namespace, job, route) (rate(loki_request_duration_seconds_count{juju_application="loki",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[1m]))
      > 10
    for: 15m
    labels:
      juju_application: loki
      juju_charm: loki-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: critical
- name: test_a3ea41d9_loki_LokiRequestLatency_rules
  rules:
  - alert: LokiRequestLatency
    annotations:
      description: "The {{ $labels.job }} on route {{ $labels.route }} is experiencing\
        \ {{ printf \"%.2f\" $value }}s 99th percentile latency\n  VALUE = {{ $value\
        \ }}\n  LABELS = {{ $labels }}"
      summary: Loki request latency for route {{ $labels.route }} (job {{ $labels.job
        }})
    expr: (histogram_quantile(0.99, sum by (namespace, job, route, le) (rate(loki_request_duration_seconds_bucket{juju_application="loki",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3",route!~"(?i).*tail.*"}[5m]))))
      > 1
    for: 5m
    labels:
      juju_application: loki
      juju_charm: loki-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: warning
- name: test_a3ea41d9_loki_LokiRequestPanic_rules
  rules:
  - alert: LokiRequestPanic
    annotations:
      description: "The {{ $labels.job }} is experiencing {{ printf \"%.2f\" $value\
        \ }}% increase of panics\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
      summary: Loki request panic (instance {{ $labels.instance }})
    expr: sum by (namespace, job) (increase(loki_panic_total{juju_application="loki",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[10m]))
      > 0
    for: 5m
    labels:
      juju_application: loki
      juju_charm: loki-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: critical
- name: test_a3ea41d9_loki_HostHealth_rules
  rules:
  - alert: HostDown
    annotations:
      description: Juju application '{{ $labels.juju_application }}' in model '{{
        $labels.juju_model }}' is down. Prometheus has been unable to scrape it during
        at least the past five minutes.
      summary: Host '{{ $labels.instance }}' is down.
    expr: up{juju_application="loki",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}
      < 1
    for: 5m
    labels:
      juju_application: loki
      juju_charm: loki-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: critical
  - alert: HostMetricsMissing
    annotations:
      description: '`Up` missing for unit ''{{ $labels.juju_unit }}'' of application
        {{ $labels.juju_application }} in model {{ $labels.juju_model }}. Please ensure
        the unit or the collector scraping it is up and is able to successfully reach
        the metrics backend.'
      summary: Unit '{{ $labels.juju_unit }}' of application '{{ $labels.juju_application
        }}' is down or failing to remote write.
    expr: absent(up{juju_application="loki",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"})
    for: 5m
    labels:
      juju_application: loki
      juju_charm: loki-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: warning
- name: test_a3ea41d9_otelcol_Exporter_rules
  rules:
  - alert: failed-logs
    annotations:
      description: Destination may have a problem or payload is incorrect
      summary: Some log points failed to send by exporter (Unit {{ $labels.juju_unit
        }} in model {{ $labels.juju_model }})
    expr: sum(rate(otelcol_exporter_send_failed_log_records{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
      > 0
    for: 5m
    labels:
      juju_application: otelcol
      juju_charm: opentelemetry-collector-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: critical
  - alert: failed-metrics
    annotations:
      description: Destination may have a problem or payload is incorrect
      summary: Some metric points failed to send by exporter (Unit {{ $labels.juju_unit
        }} in model {{ $labels.juju_model }})
    expr: sum(rate(otelcol_exporter_send_failed_metric_points{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
      > 0
    for: 5m
    labels:
      juju_application: otelcol
      juju_charm: opentelemetry-collector-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: critical
  - alert: failed-traces
    annotations:
      description: Destination may have a problem or payload is incorrect
      summary: Some spans failed to send by exporter (Unit {{ $labels.juju_unit }}
        in model {{ $labels.juju_model }})
    expr: sum(rate(otelcol_exporter_send_failed_spans{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
      > 0
    for: 5m
    labels:
      juju_application: otelcol
      juju_charm: opentelemetry-collector-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: critical
  - alert: queue-near-capacity
    annotations:
      description: 'The exporter''s sending queue has stayed above 80% capacity, meaning
        the destination can''t keep up with incoming telemetry. If the queue reaches
        capacity, data will be dropped. Check that the exporter''s endpoint is operational,
        or raise the ''queue_size'' config option. Note that data is only retried
        until ''max_elapsed_time_min'' elapses, after which it is dropped.

        '
      summary: Exporter sending queue is over 80% full (Unit {{ $labels.juju_unit
        }} in model {{ $labels.juju_model }})
    expr: otelcol_exporter_queue_size{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}
      / otelcol_exporter_queue_capacity{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}
      > 0.8
    for: 5m
    labels:
      juju_application: otelcol
      juju_charm: opentelemetry-collector-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: warning
  - alert: queue-overflow
    annotations:
      description: 'The exporter''s sending queue is at capacity and rejecting new
        telemetry at enqueue, causing data loss. Check that the exporter''s endpoint
        is operational, reduce the incoming load, or raise the ''queue_size'' config
        option.

        '
      summary: Exporter sending queue is full and dropping telemetry (Unit {{ $labels.juju_unit
        }} in model {{ $labels.juju_model }})
    expr: sum(rate(otelcol_exporter_enqueue_failed_spans{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
      > 0 or sum(rate(otelcol_exporter_enqueue_failed_log_records{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
      > 0 or sum(rate(otelcol_exporter_enqueue_failed_metric_points{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
      > 0
    for: 0m
    labels:
      juju_application: otelcol
      juju_charm: opentelemetry-collector-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: critical
- name: test_a3ea41d9_otelcol_Hardware_rules
  rules:
  - alert: high-cpu-usage
    annotations:
      description: Collector needs to scale up
      summary: High max CPU usage (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model
        }})
    expr: max(rate(otelcol_process_cpu_seconds_total{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m])
      * 100) > 90
    for: 5m
    labels:
      juju_application: otelcol
      juju_charm: opentelemetry-collector-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: critical
- name: test_a3ea41d9_otelcol_Receiver_rules
  rules:
  - alert: receiver-refused-logs
    annotations:
      description: Maybe collector has received non standard log points or it reached
        some limits
      summary: Some log points have been refused by receiver (Unit {{ $labels.juju_unit
        }} in model {{ $labels.juju_model }})
    expr: sum(rate(otelcol_receiver_refused_log_records_total{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
      > 0
    for: 5m
    labels:
      juju_application: otelcol
      juju_charm: opentelemetry-collector-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: critical
  - alert: receiver-refused-metrics
    annotations:
      description: Maybe collector has received non standard metric points or it reached
        some limits
      summary: Some metric points have been refused by receiver (Unit {{ $labels.juju_unit
        }} in model {{ $labels.juju_model }})
    expr: sum(rate(otelcol_receiver_refused_metric_points_total{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
      > 0
    for: 5m
    labels:
      juju_application: otelcol
      juju_charm: opentelemetry-collector-k8s
      juju_model: test
      juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
      severity: critical

```

Now, let's refresh the charm and then perform the following modifcations:
1. Remove all alerts related to Avalanche. That means remove all alerts where `juju_charm` is equal to `avalanche-k8s`.
2. Remove all alerts related to the group `test_a3ea41d9_otelcol_Receiver_rules`.
3. Remove all alerts where the severity is `critical`. This should result in the removal of the `HostMetricsMissing` alert.
4. Patch the alert named "PrometheusTargetDown" and set its `for` to 1h instead of the current `15m`.
5. Patch the alert named `AggregatorMetricsMissing` and change its `annotations.summary` to be "XYZ".
6. Patch the alert named `high-cpu-usage` and change its `expr` from `max(rate(otelcol_process_cpu_seconds_total{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m])` to `max(rate(otelcol_process_cpu_seconds_total{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[45m])`.
7. Add two custom alert groups named "group-a" and "group-b" each with two custom alerts.

To apply the changes above, we need a YAML block that looks like:
```yaml
remove:
  - where:
      labels:
        juju_charm: avalanche-k8s

  - where:
      group: test_a3ea41d9_otelcol_Receiver_rules

  - where:
      labels:
        severity: critical

patch:
  - where:
      alert: PrometheusTargetDown
    set:
      for: 1h

  - where:
      alert: LokiRequestLatency
    set:
      annotations:
        summary: "XYZ"

  - where:
      alert: queue-near-capacity
    set:
      expr: 'max(rate(otelcol_process_cpu_seconds_total{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[45m]))'

add:
  groups:
    - name: group-a
      rules:
        - alert: GroupAAlertOne
          expr: up{juju_model="prod", juju_application="myapp"} == 0
          for: 5m
          labels:
            severity: warning
          annotations:
            summary: "Group A alert one fired"

        - alert: GroupAAlertTwo
          expr: rate(http_requests_total{juju_model="prod"}[5m]) > 100
          for: 10m
          labels:
            severity: warning
          annotations:
            summary: "Group A alert two fired"

    - name: group-b
      rules:
        - alert: GroupBAlertOne
          expr: memory_usage_bytes{juju_model="prod", juju_application="myapp"} > 1e9
          for: 5m
          labels:
            severity: warning
          annotations:
            summary: "Group B alert one fired"

        - alert: GroupBAlertTwo
          expr: disk_io_time_seconds_total{juju_model="prod"} > 0.9
          for: 15m
          labels:
            severity: warning
          annotations:
            summary: "Group B alert two fired"

```

The resulting diff is:
```diff
<   - alert: AggregatorMetricsMissing
<     annotations:
<       description: '`Up` missing for ALL units of application {{ $labels.juju_application
<         }} in model {{ $labels.juju_model }}. This can also mean the units or the
<         collector scraping them are unable to reach the remote write endpoint of the
<         metrics backend. Please ensure the correct firewall rules are applied.'
<       summary: Metrics not received from application '{{ $labels.juju_application
<         }}'. All units are down or failing to remote write.
<     expr: absent(up{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"})
<     for: 5m
<     labels:
<       juju_application: otelcol
<       juju_charm: opentelemetry-collector-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: critical
< - name: test_a3ea41d9_otelcol_prometheus_alerts_rules
<   rules:
<   - alert: PrometheusTargetDown
<     annotations:
<       description: At least one scrape target is down for {{ $labels.juju_application
<         }}
<       summary: Prometheus target is down
<     expr: sum by (juju_application) (up{juju_application="prometheus-k8s",juju_model="observability",juju_model_uuid="e9f39fb5-e6ff-4e0c-82a5-712bdd7e1912"}
<       == 0) > 0
<     for: 15m
<     labels:
<       juju_application: prometheus-k8s
<       juju_charm: opentelemetry-collector-k8s
<       juju_model: observability
<       juju_model_uuid: e9f39fb5-e6ff-4e0c-82a5-712bdd7e1912
<       severity: critical
<       team: observability
< - name: test_a3ea41d9_aval_AlwaysFiringDueToAbsentMetric_rules
<   rules:
<   - alert: AlwaysFiringDueToAbsentMetric
<     annotations:
<       description: '{{ $labels.instance }} of job {{ $labels.job }} is firing the
<         dummy alarm.'
<       summary: Instance {{ $labels.instance }} dummy alarm (always firing)
<     expr: absent(some_metric_name_that_shouldnt_exist{job="non_existing_job",juju_application="aval",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"})
<     for: 0m
<     labels:
<       juju_application: aval
<       juju_charm: avalanche-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: High
< - name: test_a3ea41d9_aval_AlwaysFiringDueToNumericValue_rules
<   rules:
<   - alert: AlwaysFiringDueToNumericValue
<     annotations:
<       description: '{{ $labels.instance }} of job {{ $labels.job }} is firing the
<         dummy alarm.'
<       summary: Instance {{ $labels.instance }} dummy alarm (always firing)
<     expr: avalanche_metric_mmmmm_0_0{juju_application="aval",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3",series_id="0"}
<       > -1
<     for: 0m
<     labels:
<       juju_application: aval
<       juju_charm: avalanche-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: High
< - name: test_a3ea41d9_aval_HostHealth_rules
<   rules:
<   - alert: HostDown
<     annotations:
<       description: Juju application '{{ $labels.juju_application }}' in model '{{
<         $labels.juju_model }}' is down. Prometheus has been unable to scrape it during
<         at least the past five minutes.
<       summary: Host '{{ $labels.instance }}' is down.
<     expr: up{juju_application="aval",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}
<       < 1
<     for: 5m
<     labels:
<       juju_application: aval
<       juju_charm: avalanche-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: critical
<   - alert: HostMetricsMissing
<     annotations:
<       description: '`Up` missing for unit ''{{ $labels.juju_unit }}'' of application
<         {{ $labels.juju_application }} in model {{ $labels.juju_model }}. Please ensure
<         the unit or the collector scraping it is up and is able to successfully reach
<         the metrics backend.'
<       summary: Unit '{{ $labels.juju_unit }}' of application '{{ $labels.juju_application
<         }}' is down or failing to remote write.
<     expr: absent(up{juju_application="aval",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"})
<     for: 5m
<     labels:
<       juju_application: aval
<       juju_charm: avalanche-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: warning
152,168d54
< - name: test_a3ea41d9_loki_LokiRequestErrors_rules
<   rules:
<   - alert: LokiRequestErrors
<     annotations:
<       description: "The {{ $labels.job }} and {{ $labels.route }} are experiencing\
<         \ errors\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
<       summary: Loki request errors (instance {{ $labels.instance }})
<     expr: 100 * sum by (namespace, job, route) (rate(loki_request_duration_seconds_count{juju_application="loki",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3",status_code=~"5.."}[1m]))
<       / sum by (namespace, job, route) (rate(loki_request_duration_seconds_count{juju_application="loki",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[1m]))
<       > 10
<     for: 15m
<     labels:
<       juju_application: loki
<       juju_charm: loki-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: critical
176,177c62
<       summary: Loki request latency for route {{ $labels.route }} (job {{ $labels.job
<         }})
---
>       summary: XYZ
187,202d71
< - name: test_a3ea41d9_loki_LokiRequestPanic_rules
<   rules:
<   - alert: LokiRequestPanic
<     annotations:
<       description: "The {{ $labels.job }} is experiencing {{ printf \"%.2f\" $value\
<         \ }}% increase of panics\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
<       summary: Loki request panic (instance {{ $labels.instance }})
<     expr: sum by (namespace, job) (increase(loki_panic_total{juju_application="loki",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[10m]))
<       > 0
<     for: 5m
<     labels:
<       juju_application: loki
<       juju_charm: loki-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: critical
205,219d73
<   - alert: HostDown
<     annotations:
<       description: Juju application '{{ $labels.juju_application }}' in model '{{
<         $labels.juju_model }}' is down. Prometheus has been unable to scrape it during
<         at least the past five minutes.
<       summary: Host '{{ $labels.instance }}' is down.
<     expr: up{juju_application="loki",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}
<       < 1
<     for: 5m
<     labels:
<       juju_application: loki
<       juju_charm: loki-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: critical
238,279d91
<   - alert: failed-logs
<     annotations:
<       description: Destination may have a problem or payload is incorrect
<       summary: Some log points failed to send by exporter (Unit {{ $labels.juju_unit
<         }} in model {{ $labels.juju_model }})
<     expr: sum(rate(otelcol_exporter_send_failed_log_records{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
<       > 0
<     for: 5m
<     labels:
<       juju_application: otelcol
<       juju_charm: opentelemetry-collector-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: critical
<   - alert: failed-metrics
<     annotations:
<       description: Destination may have a problem or payload is incorrect
<       summary: Some metric points failed to send by exporter (Unit {{ $labels.juju_unit
<         }} in model {{ $labels.juju_model }})
<     expr: sum(rate(otelcol_exporter_send_failed_metric_points{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
<       > 0
<     for: 5m
<     labels:
<       juju_application: otelcol
<       juju_charm: opentelemetry-collector-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: critical
<   - alert: failed-traces
<     annotations:
<       description: Destination may have a problem or payload is incorrect
<       summary: Some spans failed to send by exporter (Unit {{ $labels.juju_unit }}
<         in model {{ $labels.juju_model }})
<     expr: sum(rate(otelcol_exporter_send_failed_spans{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
<       > 0
<     for: 5m
<     labels:
<       juju_application: otelcol
<       juju_charm: opentelemetry-collector-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: critical
291,293c103
<     expr: otelcol_exporter_queue_size{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}
<       / otelcol_exporter_queue_capacity{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}
<       > 0.8
---
>     expr: max(rate(otelcol_process_cpu_seconds_total{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[45m]))
301,306d110
<   - alert: queue-overflow
<     annotations:
<       description: 'The exporter''s sending queue is at capacity and rejecting new
<         telemetry at enqueue, causing data loss. Check that the exporter''s endpoint
<         is operational, reduce the incoming load, or raise the ''queue_size'' config
<         option.
308,322c112,113
<         '
<       summary: Exporter sending queue is full and dropping telemetry (Unit {{ $labels.juju_unit
<         }} in model {{ $labels.juju_model }})
<     expr: sum(rate(otelcol_exporter_enqueue_failed_spans{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
<       > 0 or sum(rate(otelcol_exporter_enqueue_failed_log_records{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
<       > 0 or sum(rate(otelcol_exporter_enqueue_failed_metric_points{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
<       > 0
<     for: 0m
<     labels:
<       juju_application: otelcol
<       juju_charm: opentelemetry-collector-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: critical
< - name: test_a3ea41d9_otelcol_Hardware_rules
---
> groups:
> - name: group-a
324c115
<   - alert: high-cpu-usage
---
>   - alert: GroupAAlertOne
326,330c117,118
<       description: Collector needs to scale up
<       summary: High max CPU usage (Unit {{ $labels.juju_unit }} in model {{ $labels.juju_model
<         }})
<     expr: max(rate(otelcol_process_cpu_seconds_total{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m])
<       * 100) > 90
---
>       summary: Group A alert one fired
>     expr: up{juju_model="prod", juju_application="myapp"} == 0
333,338c121,129
<       juju_application: otelcol
<       juju_charm: opentelemetry-collector-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: critical
< - name: test_a3ea41d9_otelcol_Receiver_rules
---
>       severity: warning
>   - alert: GroupAAlertTwo
>     annotations:
>       summary: Group A alert two fired
>     expr: rate(http_requests_total{juju_model="prod"}[5m]) > 100
>     for: 10m
>     labels:
>       severity: warning
> - name: group-b
340c131
<   - alert: receiver-refused-logs
---
>   - alert: GroupBAlertOne
342,347c133,134
<       description: Maybe collector has received non standard log points or it reached
<         some limits
<       summary: Some log points have been refused by receiver (Unit {{ $labels.juju_unit
<         }} in model {{ $labels.juju_model }})
<     expr: sum(rate(otelcol_receiver_refused_log_records_total{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
<       > 0
---
>       summary: Group B alert one fired
>     expr: memory_usage_bytes{juju_model="prod", juju_application="myapp"} > 1e9
350,355c137,138
<       juju_application: otelcol
<       juju_charm: opentelemetry-collector-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: critical
<   - alert: receiver-refused-metrics
---
>       severity: warning
>   - alert: GroupBAlertTwo
357,363c140,142
<       description: Maybe collector has received non standard metric points or it reached
<         some limits
<       summary: Some metric points have been refused by receiver (Unit {{ $labels.juju_unit
<         }} in model {{ $labels.juju_model }})
<     expr: sum(rate(otelcol_receiver_refused_metric_points_total{juju_application="otelcol",juju_model="test",juju_model_uuid="a3ea41d9-8d54-4897-8098-dde7bc214ea3"}[5m]))
<       > 0
<     for: 5m
---
>       summary: Group B alert two fired
>     expr: disk_io_time_seconds_total{juju_model="prod"} > 0.9
>     for: 15m
365,369c144
<       juju_application: otelcol
<       juju_charm: opentelemetry-collector-k8s
<       juju_model: test
<       juju_model_uuid: a3ea41d9-8d54-4897-8098-dde7bc214ea3
<       severity: critical
---
>       severity: warning

```
## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
