### PR TITLE
feat: ensure the Prom Scrape lib observes leader_elected

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 65
+LIBPATCH = 66
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -1731,6 +1731,8 @@ class MetricsEndpointProvider(Object):
             if not isinstance(refresh_event, list):
                 refresh_event = [refresh_event]
 
+        # If there is no leader during relation_joined we will still need to set alert rules.
+        self.framework.observe(self._charm.on.leader_elected, self._set_scrape_job_spec)
         self.framework.observe(events.relation_joined, self.set_scrape_job_spec)
         for ev in refresh_event:
             self.framework.observe(ev, self.set_scrape_job_spec)

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1732,7 +1732,8 @@ class MetricsEndpointProvider(Object):
                 refresh_event = [refresh_event]
 
         # If there is no leader during relation_joined we will still need to set alert rules.
-        self.framework.observe(self._charm.on.leader_elected, self._set_scrape_job_spec)
+        self.framework.observe(self._charm.on.leader_elected, self.set_scrape_job_spec)
+
         self.framework.observe(events.relation_joined, self.set_scrape_job_spec)
         for ev in refresh_event:
             self.framework.observe(ev, self.set_scrape_job_spec)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Based on this comment: https://github.com/canonical/ceph-charms/pull/235#discussion_r3871489856

## Solution
<!-- A summary of the solution addressing the above issue -->
Run `set_scrape_job_spec` when `leader_elected` happens in `MetricsEndpointProvider`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
