### PR TITLE
fix!: WAL compression config

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -222,11 +222,15 @@ config:
       default: "80%"
     metrics_wal_compression:
       description: |
-        This flag enables compression of the write-ahead log (WAL).
+        Whether to compress the write-ahead log (WAL).
         Depending on your data, you can expect the WAL size to be
         halved with little extra cpu load.
+        Enabled by default, matching the Prometheus workload default. Disabling this roughly
+        doubles the size of the `wal` directory, which counts towards the storage the workload
+        needs but is **not** reclaimed by `maximum_retention_size` (only persistent blocks are).
+        Disabling it therefore increases the risk of exhausting the `database` storage.
       type: boolean
-      default: false
+      default: true
     evaluation_interval:
       description: |
         How frequently rules will be evaluated.

--- a/src/charm.py
+++ b/src/charm.py
@@ -887,6 +887,8 @@ class PrometheusCharm(CharmBase):
 
         if config.get("metrics_wal_compression"):
             args.append("--storage.tsdb.wal-compression")
+        else:
+            args.append("--no-storage.tsdb.wal-compression")
 
         if self._exemplars:
             args.append("--enable-feature=exemplar-storage")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -123,21 +123,40 @@ class TestCharm(unittest.TestCase):
         fqdn = socket.getfqdn()
         self.assertEqual(cli_arg(plan, "--web.external-url"), f"http://{fqdn}:9090")
 
-    def test_metrics_wal_compression_is_not_enabled_by_default(self):
+    def test_metrics_wal_compression_is_enabled_by_default(self):
         plan = self.harness.get_container_pebble_plan("prometheus")
-        self.assertEqual(cli_arg(plan, "--storage.tsdb.wal-compression"), None)
+        self.assertEqual(
+            cli_arg(plan, "--storage.tsdb.wal-compression"),
+            "--storage.tsdb.wal-compression",
+        )
+        self.assertIsNone(cli_arg(plan, "--no-storage.tsdb.wal-compression"))
 
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")
-    def test_metrics_wal_compression_can_be_enabled(self, *unused):
-        compress_config = {"metrics_wal_compression": True}
-        self.harness.update_config(compress_config)
+    def test_metrics_wal_compression_can_be_disabled(self, *unused):
+        self.harness.update_config({"metrics_wal_compression": False})
+
+        # The workload enables WAL compression by default, so disabling it must emit the negated
+        # flag: dropping the flag entirely would leave compression on.
+        plan = self.harness.get_container_pebble_plan("prometheus")
+        self.assertEqual(
+            cli_arg(plan, "--no-storage.tsdb.wal-compression"),
+            "--no-storage.tsdb.wal-compression",
+        )
+        self.assertIsNone(cli_arg(plan, "--storage.tsdb.wal-compression"))
+
+    @k8s_resource_multipatch
+    @patch("lightkube.core.client.GenericSyncClient")
+    def test_metrics_wal_compression_can_be_re_enabled(self, *unused):
+        self.harness.update_config({"metrics_wal_compression": False})
+        self.harness.update_config({"metrics_wal_compression": True})
 
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(
             cli_arg(plan, "--storage.tsdb.wal-compression"),
             "--storage.tsdb.wal-compression",
         )
+        self.assertIsNone(cli_arg(plan, "--no-storage.tsdb.wal-compression"))
 
     @k8s_resource_multipatch
     @patch("lightkube.core.client.GenericSyncClient")


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes https://github.com/canonical/prometheus-k8s-operator/issues/861

## Solution
<!-- A summary of the solution addressing the above issue -->
Flip the default value of the `metrics_wal_compression` Juju config to match the upstream default. Since this is now the opposite, users will need to take care to 

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
- Deploy prom
- `charmcraft pack` from this branch
- check the value of the config

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
The config option was 